### PR TITLE
Create usePollingQuery to handle refetchInterval logistics for polling react queries 

### DIFF
--- a/apps/admin/frontend/eslint.config.mjs
+++ b/apps/admin/frontend/eslint.config.mjs
@@ -6,6 +6,10 @@ export default [
   {
     rules: {
       'vx/gts-jsdoc': 'off',
+      // Polling must go through usePollingQuery so that any number of
+      // components can subscribe to a polled query without multiplying the
+      // request rate.
+      'vx/no-refetch-interval': 'error',
     },
   },
 ];

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -4,6 +4,7 @@ import type { Api } from '@votingworks/admin-backend';
 import {
   AUTH_STATUS_POLLING_INTERVAL_MS,
   QUERY_CLIENT_DEFAULT_OPTIONS,
+  usePollingQuery,
 } from '@votingworks/ui';
 import {
   QueryClient,
@@ -78,11 +79,13 @@ export const getScannerImportCounts = {
   queryKey(): QueryKey {
     return ['getScannerImportCounts'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getScannerImportCounts(), {
-      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
-    });
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getScannerImportCounts(),
+      DEFAULT_QUERY_REFETCH_INTERVAL
+    );
   },
 } as const;
 
@@ -90,12 +93,14 @@ export const getNetworkStatus = {
   queryKey(): QueryKey {
     return ['getNetworkStatus'];
   },
-  useQuery({ enabled }: { enabled: boolean } = { enabled: true }) {
+  usePollingQuery({ enabled }: { enabled: boolean } = { enabled: true }) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getNetworkStatus(), {
-      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
-      enabled,
-    });
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getNetworkStatus(),
+      DEFAULT_QUERY_REFETCH_INTERVAL,
+      { enabled }
+    );
   },
 } as const;
 
@@ -103,12 +108,12 @@ export const getIsClientAdjudicationEnabled = {
   queryKey(): QueryKey {
     return ['getIsClientAdjudicationEnabled'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(),
       () => apiClient.getIsClientAdjudicationEnabled(),
-      { refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL }
+      DEFAULT_QUERY_REFETCH_INTERVAL
     );
   },
 } as const;
@@ -134,20 +139,24 @@ export const getAuthStatus = {
   queryKey(): QueryKey {
     return [this.queryKeyPrefix];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getAuthStatus(), {
-      refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS,
-      structuralSharing(oldData, newData) {
-        if (!oldData) {
-          return newData;
-        }
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getAuthStatus(),
+      AUTH_STATUS_POLLING_INTERVAL_MS,
+      {
+        structuralSharing(oldData, newData) {
+          if (!oldData) {
+            return newData;
+          }
 
-        // Prevent infinite re-renders of the app tree:
-        const isUnchanged = deepEqual(oldData, newData);
-        return isUnchanged ? oldData : newData;
-      },
-    });
+          // Prevent infinite re-renders of the app tree:
+          const isUnchanged = deepEqual(oldData, newData);
+          return isUnchanged ? oldData : newData;
+        },
+      }
+    );
   },
 } as const;
 
@@ -197,11 +206,13 @@ export const getPrinterStatus = {
   queryKey(): QueryKey {
     return ['getPrinterStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getPrinterStatus(), {
-      refetchInterval: PRINTER_STATUS_POLLING_INTERVAL_MS,
-    });
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getPrinterStatus(),
+      PRINTER_STATUS_POLLING_INTERVAL_MS
+    );
   },
 } as const;
 
@@ -323,15 +334,13 @@ export const getBallotAdjudicationQueueMetadata = {
   queryKey(): QueryKey {
     return ['getBallotAdjudicationQueueMetadata'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(),
       () => apiClient.getBallotAdjudicationQueueMetadata(),
-      {
-        staleTime: 0,
-        refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
-      }
+      DEFAULT_QUERY_REFETCH_INTERVAL,
+      { staleTime: 0 }
     );
   },
 } as const;
@@ -340,15 +349,15 @@ export const getNextCvrIdForBallotAdjudication = {
   queryKey(): QueryKey {
     return ['getNextCvrIdForBallotAdjudication'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(),
       () => apiClient.getNextCvrIdForBallotAdjudication(),
+      DEFAULT_QUERY_REFETCH_INTERVAL,
       {
         cacheTime: 0,
         staleTime: 0,
-        refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
       }
     );
   },
@@ -389,17 +398,17 @@ export const getWriteInCandidates = {
   queryKey(input?: GetWriteInCandidatesInput): QueryKey {
     return input ? ['getWriteInCandidates', input] : ['getWriteInCandidates'];
   },
-  useQuery(
+  usePollingQuery(
     input?: GetWriteInCandidatesInput,
     options: { enabled: boolean } = { enabled: true }
   ) {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(input),
       () => apiClient.getWriteInCandidates(input),
+      DEFAULT_QUERY_REFETCH_INTERVAL,
       {
         staleTime: 0,
-        refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
         ...options,
       }
     );

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -20,7 +20,7 @@ import type {
 } from '@votingworks/usb-drive';
 import { DEFAULT_QUERY_REFETCH_INTERVAL } from './utils/globals.js';
 
-const PRINTER_STATUS_POLLING_INTERVAL_MS = 100;
+export const PRINTER_STATUS_POLLING_INTERVAL_MS = 100;
 
 export type ApiClient = grout.Client<Api>;
 

--- a/apps/admin/frontend/src/app_polling_rate.test.tsx
+++ b/apps/admin/frontend/src/app_polling_rate.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, expect, test, vi, Mock } from 'vitest';
+import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
+import { act, screen } from '../test/react_testing_library.js';
+import { buildApp } from '../test/helpers/build_app.js';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client.js';
+import { PRINTER_STATUS_POLLING_INTERVAL_MS } from './api.js';
+
+// `usePollingQuery` consolidates polling: no matter how many components
+// subscribe to a polled query, exactly one refetch timer runs per query.
+// This test pins the request rate of the app's polled queries with the real
+// component tree mounted, so a regression that multiplies polling (e.g. a
+// second observer passing a `refetchInterval`) fails loudly.
+
+const MEASUREMENT_WINDOW_MS = 5_000;
+
+// `shouldAdvanceTime` lets a little real time creep in alongside the fake
+// clock, so allow some headroom. A duplicated timer would roughly double the
+// count, far past this bound.
+const RATE_HEADROOM = 1.3;
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  apiMock.assertComplete();
+});
+
+test('polled queries issue one request per interval regardless of subscriber count', async () => {
+  // Replace the polled endpoints with plain vitest mocks so calls can be
+  // counted (the strict grout mock does not expose call counts).
+  const getAuthStatus = vi.fn(() =>
+    Promise.resolve({ status: 'logged_out', reason: 'machine_locked' })
+  );
+  (apiMock.apiClient.getAuthStatus as unknown as Mock) = getAuthStatus;
+  const getPrinterStatus = vi.fn(() => Promise.resolve({ connected: false }));
+  (apiMock.apiClient.getPrinterStatus as unknown as Mock) = getPrinterStatus;
+  const getNetworkStatus = vi.fn();
+  (apiMock.apiClient.getNetworkStatus as unknown as Mock) = getNetworkStatus;
+
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetCurrentElectionMetadata();
+  apiMock.expectGetUsbDriveStatus('no_drive');
+  apiMock.expectGetSystemSettings();
+
+  const { renderApp } = buildApp(apiMock);
+  renderApp();
+  await screen.findByText('VxAdmin Locked');
+
+  // At the locked screen, three always-mounted components subscribe to the
+  // auth status query (AppRoot, SessionTimeLimitTracker, and
+  // PrinterAlertWrapper) and one to the printer status query
+  // (PrinterAlertWrapper).
+  const authCallsBefore = getAuthStatus.mock.calls.length;
+  const printerCallsBefore = getPrinterStatus.mock.calls.length;
+  await act(() => vi.advanceTimersByTimeAsync(MEASUREMENT_WINDOW_MS));
+  const authCalls = getAuthStatus.mock.calls.length - authCallsBefore;
+  const printerCalls = getPrinterStatus.mock.calls.length - printerCallsBefore;
+
+  const expectedAuthCalls =
+    MEASUREMENT_WINDOW_MS / AUTH_STATUS_POLLING_INTERVAL_MS;
+  expect(authCalls).toBeGreaterThanOrEqual(expectedAuthCalls);
+  expect(authCalls).toBeLessThanOrEqual(expectedAuthCalls * RATE_HEADROOM);
+
+  const expectedPrinterCalls =
+    MEASUREMENT_WINDOW_MS / PRINTER_STATUS_POLLING_INTERVAL_MS;
+  expect(printerCalls).toBeGreaterThanOrEqual(expectedPrinterCalls);
+  expect(printerCalls).toBeLessThanOrEqual(
+    expectedPrinterCalls * RATE_HEADROOM
+  );
+
+  // Polled queries with no mounted subscriber are not requested at all
+  expect(getNetworkStatus).not.toHaveBeenCalled();
+});

--- a/apps/admin/frontend/src/app_root.tsx
+++ b/apps/admin/frontend/src/app_root.tsx
@@ -9,7 +9,7 @@ import {
 import { useWatchUsbDriveStatus } from './hooks/use_watch_usb_drive_status.js';
 
 export function AppRoot(): JSX.Element | null {
-  const authStatusQuery = getAuthStatus.useQuery();
+  const authStatusQuery = getAuthStatus.usePollingQuery();
   const usbDriveStatusQuery = useWatchUsbDriveStatus();
   const getMachineConfigQuery = getMachineConfig.useQuery();
   const currentElectionMetadataQuery = getCurrentElectionMetadata.useQuery();

--- a/apps/admin/frontend/src/client/api.ts
+++ b/apps/admin/frontend/src/client/api.ts
@@ -6,6 +6,7 @@ import {
   NETWORKED_QUERY_CLIENT_DEFAULT_OPTIONS,
   USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
   createSystemCallApi,
+  usePollingQuery,
 } from '@votingworks/ui';
 import {
   QueryClient,
@@ -59,12 +60,12 @@ export const getNetworkConnectionStatus = {
   queryKey(): QueryKey {
     return ['getNetworkConnectionStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(),
       () => apiClient.getNetworkConnectionStatus(),
-      { refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL }
+      DEFAULT_QUERY_REFETCH_INTERVAL
     );
   },
 } as const;
@@ -73,12 +74,12 @@ export const getAdjudicationSessionStatus = {
   queryKey(): QueryKey {
     return ['getAdjudicationSessionStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(),
       () => apiClient.getAdjudicationSessionStatus(),
-      { refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL }
+      DEFAULT_QUERY_REFETCH_INTERVAL
     );
   },
 } as const;
@@ -87,12 +88,14 @@ export const getSystemSettings = {
   queryKey(): QueryKey {
     return ['getSystemSettings'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getSystemSettings(), {
-      staleTime: 0,
-      refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL,
-    });
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getSystemSettings(),
+      DEFAULT_QUERY_REFETCH_INTERVAL,
+      { staleTime: 0 }
+    );
   },
 } as const;
 
@@ -109,20 +112,24 @@ export const getAuthStatus = {
   queryKey(): QueryKey {
     return ['getAuthStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getAuthStatus(), {
-      refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS,
-      structuralSharing(oldData, newData) {
-        if (!oldData) {
-          return newData;
-        }
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getAuthStatus(),
+      AUTH_STATUS_POLLING_INTERVAL_MS,
+      {
+        structuralSharing(oldData, newData) {
+          if (!oldData) {
+            return newData;
+          }
 
-        // Prevent infinite re-renders of the app tree:
-        const isUnchanged = deepEqual(oldData, newData);
-        return isUnchanged ? oldData : newData;
-      },
-    });
+          // Prevent infinite re-renders of the app tree:
+          const isUnchanged = deepEqual(oldData, newData);
+          return isUnchanged ? oldData : newData;
+        },
+      }
+    );
   },
 } as const;
 
@@ -169,12 +176,12 @@ export const getCurrentElectionMetadata = {
   queryKey(): QueryKey {
     return ['getCurrentElectionMetadata'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(),
       () => apiClient.getCurrentElectionMetadata(),
-      { refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL }
+      DEFAULT_QUERY_REFETCH_INTERVAL
     );
   },
 } as const;
@@ -185,18 +192,22 @@ export const getUsbDriveStatus = {
   queryKey(): QueryKey {
     return ['getUsbDriveStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getUsbDriveStatus(), {
-      refetchInterval: USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
-      structuralSharing(oldData, newData) {
-        if (!oldData) {
-          return newData;
-        }
-        const isUnchanged = deepEqual(oldData, newData);
-        return isUnchanged ? oldData : newData;
-      },
-    });
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getUsbDriveStatus(),
+      USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
+      {
+        structuralSharing(oldData, newData) {
+          if (!oldData) {
+            return newData;
+          }
+          const isUnchanged = deepEqual(oldData, newData);
+          return isUnchanged ? oldData : newData;
+        },
+      }
+    );
   },
 } as const;
 
@@ -265,12 +276,13 @@ export const getWriteInCandidates = {
   queryKey(contestIds: string[]): QueryKey {
     return ['getWriteInCandidates', contestIds];
   },
-  useQuery(contestIds: string[]) {
+  usePollingQuery(contestIds: string[]) {
     const apiClient = useApiClient();
-    return useQuery(
+    return usePollingQuery(
       this.queryKey(contestIds),
       () => apiClient.getWriteInCandidates({ contestIds }),
-      { staleTime: 0, refetchInterval: DEFAULT_QUERY_REFETCH_INTERVAL }
+      DEFAULT_QUERY_REFETCH_INTERVAL,
+      { staleTime: 0 }
     );
   },
 } as const;

--- a/apps/admin/frontend/src/client/client_app_root.tsx
+++ b/apps/admin/frontend/src/client/client_app_root.tsx
@@ -32,11 +32,11 @@ import { ClientAdjudicationScreen } from './screens/client_adjudication_screen.j
 import { ClientBallotAdjudicationScreen } from './screens/client_ballot_adjudication_screen.js';
 
 export function ClientAppRoot(): JSX.Element | null {
-  const authStatusQuery = getAuthStatus.useQuery();
+  const authStatusQuery = getAuthStatus.usePollingQuery();
   const getMachineConfigQuery = getMachineConfig.useQuery();
   const checkPinMutation = checkPin.useMutation();
-  const electionMetadataQuery = getCurrentElectionMetadata.useQuery();
-  const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
+  const electionMetadataQuery = getCurrentElectionMetadata.usePollingQuery();
+  const usbDriveStatusQuery = getUsbDriveStatus.usePollingQuery();
   const apiClient = useApiClient();
   const logOutMutation = logOut.useMutation();
   const history = useHistory();

--- a/apps/admin/frontend/src/client/components/network_status_indicator.tsx
+++ b/apps/admin/frontend/src/client/components/network_status_indicator.tsx
@@ -31,7 +31,7 @@ function indicatorStatus(
  * status buckets as VxCentralScan's indicator.
  */
 export function ClientNetworkStatusIndicator(): JSX.Element | null {
-  const networkStatusQuery = getNetworkConnectionStatus.useQuery();
+  const networkStatusQuery = getNetworkConnectionStatus.usePollingQuery();
   if (!networkStatusQuery.isSuccess) return null;
 
   return (

--- a/apps/admin/frontend/src/client/components/session_time_limit_tracker.tsx
+++ b/apps/admin/frontend/src/client/components/session_time_limit_tracker.tsx
@@ -8,9 +8,9 @@ import {
 } from '../api.js';
 
 export function SessionTimeLimitTracker(): JSX.Element {
-  const authStatusQuery = getAuthStatus.useQuery();
+  const authStatusQuery = getAuthStatus.usePollingQuery();
   const logOutMutation = logOut.useMutation();
-  const systemSettingsQuery = getSystemSettings.useQuery();
+  const systemSettingsQuery = getSystemSettings.usePollingQuery();
   const updateSessionExpiryMutation = updateSessionExpiry.useMutation();
 
   return (

--- a/apps/admin/frontend/src/client/screens/client_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_adjudication_screen.tsx
@@ -6,7 +6,8 @@ import { routerPaths } from '../../router_paths.js';
 
 export function ClientAdjudicationScreen(): JSX.Element {
   const history = useHistory();
-  const adjudicationStatusQuery = getAdjudicationSessionStatus.useQuery();
+  const adjudicationStatusQuery =
+    getAdjudicationSessionStatus.usePollingQuery();
 
   const isAdjudicationEnabled =
     adjudicationStatusQuery.isSuccess &&

--- a/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_ballot_adjudication_screen.tsx
@@ -46,7 +46,8 @@ type FlowState =
 
 export function ClientBallotAdjudicationScreen(): JSX.Element {
   const history = useHistory();
-  const adjudicationStatusQuery = getAdjudicationSessionStatus.useQuery();
+  const adjudicationStatusQuery =
+    getAdjudicationSessionStatus.usePollingQuery();
   const { mutateAsync: claimAndLoadAsync } = claimAndLoadBallot.useMutation();
   const { mutateAsync: releaseBallotAsync } = releaseBallot.useMutation();
 
@@ -181,10 +182,10 @@ function ClientBallotAdjudicationDataLoader({
 }): JSX.Element {
   const history = useHistory();
   const ballotImagesQuery = getBallotImages.useQuery(cvrId);
-  const writeInCandidatesQuery = getWriteInCandidates.useQuery(
+  const writeInCandidatesQuery = getWriteInCandidates.usePollingQuery(
     ballotData.contests.map((c) => c.contestId)
   );
-  const systemSettingsQuery = getSystemSettings.useQuery();
+  const systemSettingsQuery = getSystemSettings.usePollingQuery();
   const { mutateAsync: adjudicateCvrAsync } = adjudicateCvr.useMutation();
   const [mutationError, setMutationError] = useState<AdjudicationError>();
 

--- a/apps/admin/frontend/src/client/screens/client_diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_diagnostics_screen.tsx
@@ -12,7 +12,7 @@ import { AppContext } from '../../contexts/app_context.js';
 import { getNetworkConnectionStatus } from '../api.js';
 
 function NetworkSection(): JSX.Element {
-  const networkStatusQuery = getNetworkConnectionStatus.useQuery();
+  const networkStatusQuery = getNetworkConnectionStatus.usePollingQuery();
 
   return (
     <section>

--- a/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
+++ b/apps/admin/frontend/src/client/screens/client_machine_locked_screen.tsx
@@ -23,7 +23,7 @@ const LockedImage = styled.img`
 function LockScreenFooter(): JSX.Element | null {
   const { electionDefinition, electionPackageHash, machineConfig } =
     useContext(AppContext);
-  const networkStatusQuery = getNetworkConnectionStatus.useQuery();
+  const networkStatusQuery = getNetworkConnectionStatus.usePollingQuery();
   if (!networkStatusQuery.isSuccess) return null;
 
   const status = networkStatusQuery.data;

--- a/apps/admin/frontend/src/components/navigation_screen.tsx
+++ b/apps/admin/frontend/src/components/navigation_screen.tsx
@@ -42,7 +42,7 @@ import { ClientNetworkStatusIndicator } from '../client/components/network_statu
 import { NavItem, Sidebar } from './sidebar.js';
 
 function NetworkStatusIndicator(): JSX.Element | null {
-  const networkStatusQuery = getNetworkStatus.useQuery();
+  const networkStatusQuery = getNetworkStatus.usePollingQuery();
   if (!networkStatusQuery.isSuccess) return null;
 
   const { isOnline, multipleHostsDetected } = networkStatusQuery.data;

--- a/apps/admin/frontend/src/components/network_section.tsx
+++ b/apps/admin/frontend/src/components/network_section.tsx
@@ -5,7 +5,7 @@ import { isMultiStationAdjudicationEnabled } from '../shared_api.js';
 export function NetworkSection(): JSX.Element | null {
   const isMultiStationEnabled =
     isMultiStationAdjudicationEnabled.useQuery().data ?? false;
-  const networkStatusQuery = getNetworkStatus.useQuery({
+  const networkStatusQuery = getNetworkStatus.usePollingQuery({
     enabled: isMultiStationEnabled,
   });
 

--- a/apps/admin/frontend/src/components/print_button.tsx
+++ b/apps/admin/frontend/src/components/print_button.tsx
@@ -58,7 +58,7 @@ export function PrintButton({
   children,
   ...rest
 }: React.PropsWithChildren<PrintButtonProps>): JSX.Element {
-  const printerStatusQuery = getPrinterStatus.useQuery();
+  const printerStatusQuery = getPrinterStatus.usePollingQuery();
 
   const [isShowingConnectPrinterModal, setIsShowingConnectPrinterModal] =
     useState(false);

--- a/apps/admin/frontend/src/components/print_test_page_button.tsx
+++ b/apps/admin/frontend/src/components/print_test_page_button.tsx
@@ -1,11 +1,15 @@
 import { PrintTestPageButton as SharedPrintTestPageButton } from '@votingworks/ui';
-import { addDiagnosticRecord, getPrinterStatus, printTestPage } from '../api.js';
+import {
+  addDiagnosticRecord,
+  getPrinterStatus,
+  printTestPage,
+} from '../api.js';
 
 export { TEST_PAGE_PRINT_DELAY_SECONDS } from '@votingworks/ui';
 
 export function PrintTestPageButton(): JSX.Element {
   const isPrinterConnected =
-    getPrinterStatus.useQuery().data?.connected ?? false;
+    getPrinterStatus.usePollingQuery().data?.connected ?? false;
   const printTestPageMutation = printTestPage.useMutation();
   const addDiagnosticRecordMutation = addDiagnosticRecord.useMutation();
 

--- a/apps/admin/frontend/src/components/printer_alert_wrapper.tsx
+++ b/apps/admin/frontend/src/components/printer_alert_wrapper.tsx
@@ -3,8 +3,8 @@ import { isElectionManagerAuth } from '@votingworks/utils';
 import { getAuthStatus, getPrinterStatus } from '../api.js';
 
 export function PrinterAlertWrapper(): JSX.Element | null {
-  const printerStatusQuery = getPrinterStatus.useQuery();
-  const authStatusQuery = getAuthStatus.useQuery();
+  const printerStatusQuery = getPrinterStatus.usePollingQuery();
+  const authStatusQuery = getAuthStatus.usePollingQuery();
 
   const printerStatus = printerStatusQuery.data;
 

--- a/apps/admin/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/admin/frontend/src/components/session_time_limit_tracker.tsx
@@ -8,7 +8,7 @@ import {
 } from '../api.js';
 
 export function SessionTimeLimitTracker(): JSX.Element {
-  const authStatusQuery = getAuthStatus.useQuery();
+  const authStatusQuery = getAuthStatus.usePollingQuery();
   const logOutMutation = logOut.useMutation();
   const systemSettingsQuery = getSystemSettings.useQuery();
   const updateSessionExpiryMutation = updateSessionExpiry.useMutation();

--- a/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
+++ b/apps/admin/frontend/src/screens/adjudication_start_screen.tsx
@@ -227,7 +227,8 @@ function BallotAdjudicationCard({
   showHeader: boolean;
 }): JSX.Element {
   const { isOfficialResults } = useContext(AppContext);
-  const queueMetadataQuery = getBallotAdjudicationQueueMetadata.useQuery();
+  const queueMetadataQuery =
+    getBallotAdjudicationQueueMetadata.usePollingQuery();
   const cvrFilesQuery = getCastVoteRecordFiles.useQuery();
   const systemSettingsQuery = getSystemSettings.useQuery();
   const candidatesQuery = getQualifiedWriteInCandidates.useQuery();
@@ -393,8 +394,9 @@ function MultiStationClientsTable({
 }
 
 function MultiStationCard(): JSX.Element {
-  const networkStatusQuery = getNetworkStatus.useQuery();
-  const adjudicationEnabledQuery = getIsClientAdjudicationEnabled.useQuery();
+  const networkStatusQuery = getNetworkStatus.usePollingQuery();
+  const adjudicationEnabledQuery =
+    getIsClientAdjudicationEnabled.usePollingQuery();
   const setAdjudicationEnabledMutation =
     setIsClientAdjudicationEnabled.useMutation();
 

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.tsx
@@ -169,7 +169,7 @@ function contestListItems(
 
 export function BallotAdjudicationScreenWrapper(): JSX.Element {
   const ballotQueueQuery = getBallotAdjudicationQueue.useQuery();
-  const nextCvrIdQuery = getNextCvrIdForBallotAdjudication.useQuery();
+  const nextCvrIdQuery = getNextCvrIdForBallotAdjudication.usePollingQuery();
 
   if (!ballotQueueQuery.isSuccess || !nextCvrIdQuery.isSuccess) {
     return (
@@ -402,7 +402,7 @@ function HostBallotAdjudicationScreenDataLoader({
   onExit: () => void;
 }): JSX.Element {
   const ballotImagesQuery = getBallotImages.useQuery({ cvrId });
-  const writeInCandidatesQuery = getWriteInCandidates.useQuery(
+  const writeInCandidatesQuery = getWriteInCandidates.usePollingQuery(
     ballotData
       ? { contestIds: ballotData.contests.map((c) => c.contestId) }
       : undefined,

--- a/apps/admin/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/admin/frontend/src/screens/diagnostics_screen.tsx
@@ -29,7 +29,7 @@ const PageLayout = styled.div`
 export function DiagnosticsScreen(): JSX.Element {
   const { electionDefinition, electionPackageHash } = useContext(AppContext);
   const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
-  const printerStatusQuery = getPrinterStatus.useQuery();
+  const printerStatusQuery = getPrinterStatus.usePollingQuery();
   const diskSpaceQuery = getDiskSpaceSummary.useQuery();
   const diagnosticRecordQuery = getMostRecentPrinterDiagnostic.useQuery();
   const saveReadinessReportMutation = saveReadinessReport.useMutation();

--- a/apps/admin/frontend/src/screens/smart_cards_screen.tsx
+++ b/apps/admin/frontend/src/screens/smart_cards_screen.tsx
@@ -8,7 +8,7 @@ import { getSystemSettings, getAuthStatus, useApiClient } from '../api.js';
 import { AppContext } from '../contexts/app_context.js';
 
 export function SmartCardsScreen(): JSX.Element | null {
-  const authQuery = getAuthStatus.useQuery();
+  const authQuery = getAuthStatus.usePollingQuery();
   const systemSettingsQuery = getSystemSettings.useQuery();
   const apiClient = useApiClient();
   const { electionDefinition } = useContext(AppContext);

--- a/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
+++ b/apps/admin/frontend/src/screens/tally/manual_tallies_form_screen.tsx
@@ -1021,7 +1021,7 @@ function ContestFormWrapper({
 export function ManualTalliesFormScreen(): JSX.Element | null {
   const { precinctId, ballotStyleGroupId, votingMethod } =
     useParams<ManualTallyFormParams>();
-  const getWriteInCandidatesQuery = getWriteInCandidates.useQuery();
+  const getWriteInCandidatesQuery = getWriteInCandidates.usePollingQuery();
   const getManualResultsQuery = getManualResults.useQuery({
     precinctId,
     ballotStyleGroupId,

--- a/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
@@ -93,8 +93,8 @@ function ScannerStatus({ scanner }: { scanner: MachineRecord }): JSX.Element {
 export function ScannersTab(): JSX.Element {
   const { electionDefinition } = useContext(AppContext);
   const { election } = assertDefined(electionDefinition);
-  const networkStatusQuery = getNetworkStatus.useQuery();
-  const importCountsQuery = getScannerImportCounts.useQuery();
+  const networkStatusQuery = getNetworkStatus.usePollingQuery();
+  const importCountsQuery = getScannerImportCounts.usePollingQuery();
 
   if (!networkStatusQuery.isSuccess || !importCountsQuery.isSuccess) {
     return <Loading isFullscreen />;

--- a/apps/central-scan/frontend/eslint.config.mjs
+++ b/apps/central-scan/frontend/eslint.config.mjs
@@ -17,6 +17,10 @@ export default [
         },
       ],
       'vx/gts-jsdoc': 'off',
+      // Polling must go through usePollingQuery so that any number of
+      // components can subscribe to a polled query without multiplying the
+      // request rate.
+      'vx/no-refetch-interval': 'error',
     },
   },
 ];

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -162,7 +162,7 @@ export const getElectionRecord = {
   },
 } as const;
 
-const STATUS_POLLING_INTERVAL_MS = 100;
+export const STATUS_POLLING_INTERVAL_MS = 100;
 
 export const getStatus = {
   queryKey(): QueryKey {

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -6,6 +6,7 @@ import {
   QUERY_CLIENT_DEFAULT_OPTIONS,
   USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
   createSystemCallApi,
+  usePollingQuery,
 } from '@votingworks/ui';
 import {
   QueryClient,
@@ -44,20 +45,24 @@ export const getUsbDriveStatus = {
   queryKey(): QueryKey {
     return ['getUsbDriveStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getUsbDriveStatus(), {
-      refetchInterval: USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
-      structuralSharing(oldData, newData) {
-        if (!oldData) {
-          return newData;
-        }
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getUsbDriveStatus(),
+      USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
+      {
+        structuralSharing(oldData, newData) {
+          if (!oldData) {
+            return newData;
+          }
 
-        // Prevent unnecessary re-renders of dependent components
-        const isUnchanged = deepEqual(oldData, newData);
-        return isUnchanged ? oldData : newData;
-      },
-    });
+          // Prevent unnecessary re-renders of dependent components
+          const isUnchanged = deepEqual(oldData, newData);
+          return isUnchanged ? oldData : newData;
+        },
+      }
+    );
   },
 } as const;
 
@@ -79,11 +84,13 @@ export const getAuthStatus = {
   queryKey(): QueryKey {
     return ['getAuthStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getAuthStatus(), {
-      refetchInterval: AUTH_STATUS_POLLING_INTERVAL_MS,
-    });
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getAuthStatus(),
+      AUTH_STATUS_POLLING_INTERVAL_MS
+    );
   },
 } as const;
 
@@ -133,14 +140,15 @@ export const getNetworkStatus = {
   queryKey(): QueryKey {
     return ['getNetworkStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getNetworkStatus(), {
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getNetworkStatus(),
       // Poll only while networking is enabled. When disabled, the status
       // can't change without a restart, so a single fetch suffices.
-      refetchInterval: (data) =>
-        data?.isEnabled ? NETWORK_STATUS_POLLING_INTERVAL_MS : false,
-    });
+      (data) => (data?.isEnabled ? NETWORK_STATUS_POLLING_INTERVAL_MS : false)
+    );
   },
 } as const;
 
@@ -154,15 +162,19 @@ export const getElectionRecord = {
   },
 } as const;
 
+const STATUS_POLLING_INTERVAL_MS = 100;
+
 export const getStatus = {
   queryKey(): QueryKey {
     return ['getStatus'];
   },
-  useQuery() {
+  usePollingQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getStatus(), {
-      refetchInterval: 100,
-    });
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getStatus(),
+      STATUS_POLLING_INTERVAL_MS
+    );
   },
 } as const;
 

--- a/apps/central-scan/frontend/src/app_polling_rate.test.tsx
+++ b/apps/central-scan/frontend/src/app_polling_rate.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, expect, test, vi, Mock } from 'vitest';
+import { AUTH_STATUS_POLLING_INTERVAL_MS } from '@votingworks/ui';
+import { act, render, screen } from '../test/react_testing_library.js';
+import { App } from './app.js';
+import { ApiMock, createApiMock } from '../test/api.js';
+import { mockStatus } from '../test/fixtures.js';
+import { STATUS_POLLING_INTERVAL_MS } from './api.js';
+
+// `usePollingQuery` consolidates polling: no matter how many components
+// subscribe to a polled query, exactly one refetch timer runs per query.
+// This test pins the request rate of the app's polled queries with the real
+// component tree mounted, so a regression that multiplies polling (e.g. a
+// second observer passing a `refetchInterval`) fails loudly.
+
+const MEASUREMENT_WINDOW_MS = 5_000;
+
+// `shouldAdvanceTime` lets a little real time creep in alongside the fake
+// clock, so allow some headroom. A duplicated timer would roughly double the
+// count, far past this bound.
+const RATE_HEADROOM = 1.3;
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  apiMock.assertComplete();
+});
+
+test('polled queries issue one request per interval regardless of subscriber count', async () => {
+  // Replace the polled endpoints with plain vitest mocks so calls can be
+  // counted (the strict grout mock does not expose call counts).
+  const getAuthStatus = vi.fn(() =>
+    Promise.resolve({ status: 'logged_out', reason: 'machine_locked' })
+  );
+  (apiMock.apiClient.getAuthStatus as unknown as Mock) = getAuthStatus;
+  const getStatus = vi.fn(() => Promise.resolve(mockStatus()));
+  (apiMock.apiClient.getStatus as unknown as Mock) = getStatus;
+  const getUsbDriveStatus = vi.fn(() =>
+    Promise.resolve({ status: 'no_drive' })
+  );
+  (apiMock.apiClient.getUsbDriveStatus as unknown as Mock) = getUsbDriveStatus;
+
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionRecord(null);
+  apiMock.expectGetTestMode(false);
+  apiMock.expectGetPollingPlaceId();
+
+  render(<App apiClient={apiMock.apiClient} />);
+  await screen.findByText(
+    'Insert an election manager card to configure VxCentralScan'
+  );
+
+  // At the locked screen, two always-mounted components subscribe to the
+  // auth status query (AppRoot and SessionTimeLimitTracker), and AppRoot
+  // subscribes to the scanner and USB drive status queries.
+  const authCallsBefore = getAuthStatus.mock.calls.length;
+  const statusCallsBefore = getStatus.mock.calls.length;
+  const usbCallsBefore = getUsbDriveStatus.mock.calls.length;
+  await act(() => vi.advanceTimersByTimeAsync(MEASUREMENT_WINDOW_MS));
+  const authCalls = getAuthStatus.mock.calls.length - authCallsBefore;
+  const statusCalls = getStatus.mock.calls.length - statusCallsBefore;
+  const usbCalls = getUsbDriveStatus.mock.calls.length - usbCallsBefore;
+
+  const expectedAuthCalls =
+    MEASUREMENT_WINDOW_MS / AUTH_STATUS_POLLING_INTERVAL_MS;
+  expect(authCalls).toBeGreaterThanOrEqual(expectedAuthCalls);
+  expect(authCalls).toBeLessThanOrEqual(expectedAuthCalls * RATE_HEADROOM);
+
+  const expectedStatusCalls =
+    MEASUREMENT_WINDOW_MS / STATUS_POLLING_INTERVAL_MS;
+  expect(statusCalls).toBeGreaterThanOrEqual(expectedStatusCalls);
+  expect(statusCalls).toBeLessThanOrEqual(expectedStatusCalls * RATE_HEADROOM);
+
+  expect(usbCalls).toBeGreaterThanOrEqual(expectedStatusCalls);
+  expect(usbCalls).toBeLessThanOrEqual(expectedStatusCalls * RATE_HEADROOM);
+
+  // Polled queries with no mounted subscriber are not requested at all
+  expect(apiMock.apiClient.getNetworkStatus.mock.calls).toHaveLength(0);
+});

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -48,10 +48,10 @@ export interface AppRootProps {
 export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
   const apiClient = useApiClient();
   const machineConfigQuery = getMachineConfig.useQuery();
-  const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
-  const authStatusQuery = getAuthStatus.useQuery();
+  const usbDriveStatusQuery = getUsbDriveStatus.usePollingQuery();
+  const authStatusQuery = getAuthStatus.usePollingQuery();
   const checkPinMutation = checkPin.useMutation();
-  const statusQuery = getStatus.useQuery();
+  const statusQuery = getStatus.usePollingQuery();
   const logOutMutation = logOut.useMutation();
   const unconfigureMutation = unconfigure.useMutation();
 

--- a/apps/central-scan/frontend/src/components/export_results_modal.tsx
+++ b/apps/central-scan/frontend/src/components/export_results_modal.tsx
@@ -36,7 +36,7 @@ export function ExportResultsModal({ onClose }: Props): JSX.Element | null {
 
   const { auth } = useContext(AppContext);
   assert(isElectionManagerAuth(auth));
-  const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
+  const usbDriveStatusQuery = getUsbDriveStatus.usePollingQuery();
   const ejectUsbDriveMutation = ejectUsbDrive.useMutation();
   const exportCastVoteRecordsToUsbDriveMutation =
     exportCastVoteRecordsToUsbDrive.useMutation();

--- a/apps/central-scan/frontend/src/components/network_status_indicator.tsx
+++ b/apps/central-scan/frontend/src/components/network_status_indicator.tsx
@@ -30,7 +30,7 @@ function indicatorStatus(
 }
 
 export function NetworkStatusIndicator(): JSX.Element | null {
-  const networkStatusQuery = getNetworkStatus.useQuery();
+  const networkStatusQuery = getNetworkStatus.usePollingQuery();
   if (!networkStatusQuery.isSuccess || !networkStatusQuery.data.isEnabled) {
     return null;
   }

--- a/apps/central-scan/frontend/src/components/session_time_limit_tracker.tsx
+++ b/apps/central-scan/frontend/src/components/session_time_limit_tracker.tsx
@@ -8,7 +8,7 @@ import {
 } from '../api.js';
 
 export function SessionTimeLimitTracker(): JSX.Element {
-  const authStatusQuery = getAuthStatus.useQuery();
+  const authStatusQuery = getAuthStatus.usePollingQuery();
   const logOutMutation = logOut.useMutation();
   const systemSettingsQuery = getSystemSettings.useQuery();
   const updateSessionExpiryMutation = updateSessionExpiry.useMutation();

--- a/apps/central-scan/frontend/src/components/test_scan_button.tsx
+++ b/apps/central-scan/frontend/src/components/test_scan_button.tsx
@@ -125,7 +125,7 @@ function TestScanModal({
 }
 
 export function TestScanButton(): JSX.Element {
-  const statusQuery = getStatus.useQuery();
+  const statusQuery = getStatus.usePollingQuery();
   const isScannerAttached = statusQuery.data?.isScannerAttached ?? false;
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   return (

--- a/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
+++ b/apps/central-scan/frontend/src/components/toggle_test_mode_button.tsx
@@ -7,7 +7,7 @@ import { getStatus, getTestMode, setTestMode } from '../api.js';
  * Presents a button to toggle between test & live modes with a confirmation.
  */
 export function ToggleTestModeButton(): JSX.Element | null {
-  const statusQuery = getStatus.useQuery();
+  const statusQuery = getStatus.usePollingQuery();
 
   const testModeQuery = getTestMode.useQuery();
   const isTestMode = testModeQuery.data ?? false;

--- a/apps/central-scan/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/diagnostics_screen.tsx
@@ -29,7 +29,7 @@ const PageLayout = styled.div`
 `;
 
 export function DiagnosticsScreen(): JSX.Element {
-  const statusQuery = getStatus.useQuery();
+  const statusQuery = getStatus.usePollingQuery();
   const electionRecordQuery = getElectionRecord.useQuery();
   const batteryInfoQuery = systemCallApi.getBatteryInfo.useQuery();
   const diskSpaceQuery = getDiskSpaceSummary.useQuery();
@@ -38,10 +38,10 @@ export function DiagnosticsScreen(): JSX.Element {
   const upsDiagnosticRecordQuery = getMostRecentUpsDiagnostic.useQuery();
   const logUpsDiagnosticOutcomeMutation =
     logMostRecentUpsDiagnosticOutcome.useMutation();
-  const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
+  const usbDriveStatusQuery = getUsbDriveStatus.usePollingQuery();
   const saveReadinessReportMutation = saveReadinessReport.useMutation();
   const systemSettings = getSystemSettings.useQuery();
-  const networkStatusQuery = getNetworkStatus.useQuery();
+  const networkStatusQuery = getNetworkStatus.usePollingQuery();
 
   if (
     !statusQuery.isSuccess ||

--- a/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
+++ b/apps/central-scan/frontend/src/screens/unconfigured_election_screen_wrapper.tsx
@@ -16,7 +16,7 @@ interface Props {
 export function UnconfiguredElectionScreenWrapper({
   isElectionManagerAuth,
 }: Props): JSX.Element {
-  const usbDriveStatusQuery = getUsbDriveStatus.useQuery();
+  const usbDriveStatusQuery = getUsbDriveStatus.usePollingQuery();
   // USB drive status is guaranteed to exist because app root will not render
   // this component until the USB drive query succeeds.
   assert(usbDriveStatusQuery.isSuccess);

--- a/libs/eslint-plugin-vx/docs/rules/no-refetch-interval.md
+++ b/libs/eslint-plugin-vx/docs/rules/no-refetch-interval.md
@@ -1,0 +1,42 @@
+# Disallow react-query's `refetchInterval` option (`vx/no-refetch-interval`)
+
+react-query runs a separate refetch timer for every observer that sets a
+`refetchInterval` — whether in a `useQuery` call or in a query client's default
+options — and the resulting requests only coalesce if they literally overlap. So
+N components subscribing to one polled query multiply the request rate to the
+backend N-fold (e.g. 4 components × `refetchInterval: 1000` = 4 requests per
+second).
+
+Use `usePollingQuery` from `@votingworks/ui` instead. It drives all instances of
+a query (per query client) with a single shared timer, so the request rate stays
+the same no matter how many components subscribe.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+useQuery(queryKey, queryFn, { refetchInterval: 1000 });
+
+new QueryClient({
+  defaultOptions: { queries: { refetchInterval: 1000 } },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { usePollingQuery } from '@votingworks/ui';
+
+usePollingQuery(queryKey, queryFn, 1000);
+
+// Function intervals are supported too; return `false` to pause polling
+// until the query's data next changes
+usePollingQuery(queryKey, queryFn, (data) => (data?.isEnabled ? 1000 : false));
+```
+
+## When Not To Use It
+
+This rule is currently opt-in per package: apps that have not yet migrated their
+polled queries to `usePollingQuery` (e.g. VxScan, VxPollBook) should enable it
+as part of that migration.

--- a/libs/eslint-plugin-vx/src/rules/index.ts
+++ b/libs/eslint-plugin-vx/src/rules/index.ts
@@ -32,6 +32,7 @@ import noImportSubfolders from './no_import_workspace_subfolders';
 import noExpectToBe from './no_expect_to_be';
 import noManualSleep from './no_manual_sleep';
 import noReactHookMutationDependency from './no_react_hook_mutation_dependency';
+import noRefetchInterval from './no_refetch_interval';
 
 const rules: Record<string, Rule.RuleModule> = {
   'gts-array-type-style': gtsArrayTypeStyle,
@@ -68,6 +69,7 @@ const rules: Record<string, Rule.RuleModule> = {
   'no-expect-to-be': noExpectToBe,
   'no-manual-sleep': noManualSleep,
   'no-react-hook-mutation-dependency': noReactHookMutationDependency,
+  'no-refetch-interval': noRefetchInterval,
 } as unknown as Record<string, Rule.RuleModule>;
 
 export default rules;

--- a/libs/eslint-plugin-vx/src/rules/no_refetch_interval.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_refetch_interval.ts
@@ -1,0 +1,55 @@
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../util';
+
+/**
+ * Disallows setting react-query's `refetchInterval` option, whether in a
+ * `useQuery` call or in a query client's default options. react-query runs a
+ * separate refetch timer for every observer that sets a `refetchInterval`,
+ * and the resulting requests only coalesce if they literally overlap, so N
+ * components subscribing to one polled query multiply the request rate
+ * N-fold. `usePollingQuery` from `@votingworks/ui` drives all instances of a
+ * query with a single shared timer instead.
+ */
+const rule: TSESLint.RuleModule<'noRefetchInterval', readonly unknown[]> =
+  createRule({
+    name: 'no-refetch-interval',
+    meta: {
+      docs: {
+        description:
+          "Disallows react-query's `refetchInterval` option in favor of `usePollingQuery`.",
+      },
+      messages: {
+        noRefetchInterval:
+          'react-query runs a separate refetch timer for every observer that sets `refetchInterval`, so multiple components subscribing to one polled query multiply the request rate. Use `usePollingQuery` from `@votingworks/ui` instead, which drives all instances of a query with a single shared timer.',
+      },
+      schema: [],
+      type: 'problem',
+    },
+    defaultOptions: [],
+
+    create(context) {
+      return {
+        Property(node: TSESTree.Property) {
+          if (node.parent.type !== AST_NODE_TYPES.ObjectExpression) {
+            return;
+          }
+
+          const isRefetchIntervalKey =
+            (node.key.type === AST_NODE_TYPES.Identifier &&
+              !node.computed &&
+              node.key.name === 'refetchInterval') ||
+            (node.key.type === AST_NODE_TYPES.Literal &&
+              node.key.value === 'refetchInterval');
+
+          if (isRefetchIntervalKey) {
+            context.report({
+              node,
+              messageId: 'noRefetchInterval',
+            });
+          }
+        },
+      };
+    },
+  });
+
+export default rule;

--- a/libs/eslint-plugin-vx/tests/rules/no_refetch_interval.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_refetch_interval.test.ts
@@ -1,0 +1,53 @@
+import { join } from 'node:path';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import rule from '../../src/rules/no_refetch_interval';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2018,
+      tsconfigRootDir: join(__dirname, '../fixtures'),
+      project: './tsconfig.json',
+    },
+  },
+});
+
+ruleTester.run('no-refetch-interval', rule, {
+  valid: [
+    // The consolidated polling hook takes the interval positionally
+    `usePollingQuery(queryKey, queryFn, 1000)`,
+    // Options objects without the key are fine
+    `useQuery(queryKey, queryFn, { staleTime: 0 })`,
+    `useQuery(queryKey, queryFn, { 'staleTime': 0 })`,
+    // Reading the option is fine; only setting it is a problem
+    `const interval = options.refetchInterval;`,
+    // Destructuring is reading, not setting
+    `const { refetchInterval } = options;`,
+    `function poll({ refetchInterval }) { return refetchInterval; }`,
+    // A computed key that happens to be named refetchInterval refers to a
+    // variable's value, not the literal option name
+    `const config = { [refetchInterval]: 1000 };`,
+  ],
+  invalid: [
+    {
+      code: `useQuery(queryKey, queryFn, { refetchInterval: 1000 })`,
+      errors: [{ messageId: 'noRefetchInterval' }],
+    },
+    {
+      code: `useQuery(queryKey, queryFn, { refetchInterval })`,
+      errors: [{ messageId: 'noRefetchInterval' }],
+    },
+    {
+      code: `useQuery(queryKey, queryFn, { 'refetchInterval': 1000 })`,
+      errors: [{ messageId: 'noRefetchInterval' }],
+    },
+    {
+      code: `useQuery(queryKey, queryFn, { refetchInterval: (data) => (data ? 100 : false) })`,
+      errors: [{ messageId: 'noRefetchInterval' }],
+    },
+    {
+      code: `new QueryClient({ defaultOptions: { queries: { refetchInterval: 1000 } } })`,
+      errors: [{ messageId: 'noRefetchInterval' }],
+    },
+  ],
+});

--- a/libs/ui/src/hooks/use_polling_query.test.tsx
+++ b/libs/ui/src/hooks/use_polling_query.test.tsx
@@ -41,28 +41,42 @@ test('shares a single polling timer across all instances of a query', async () =
     return null;
   }
 
-  const { unmount } = render(
+  // Mount the subscribers at staggered times — the worst case for passing
+  // `refetchInterval` to `useQuery` directly, where each observer runs its
+  // own timer: out-of-phase timers never overlap in flight, so nothing
+  // coalesces and each subscriber would add a full extra request per
+  // interval. (Simultaneously mounted subscribers would mask that bug, since
+  // aligned timers fire together and the overlapping fetches deduplicate.)
+  const { rerender, unmount } = render(<Subscriber key="a" />, {
+    wrapper: createWrapper(queryClient),
+  });
+  await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS / 4));
+  rerender(
     <React.Fragment>
-      <Subscriber />
-      <Subscriber />
-      <Subscriber />
-    </React.Fragment>,
-    { wrapper: createWrapper(queryClient) }
+      <Subscriber key="a" />
+      <Subscriber key="b" />
+    </React.Fragment>
+  );
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS / 4));
+  rerender(
+    <React.Fragment>
+      <Subscriber key="a" />
+      <Subscriber key="b" />
+      <Subscriber key="c" />
+    </React.Fragment>
   );
 
-  // The initial fetch on mount is shared by all instances
-  await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
-
   // Each tick issues one request total, not one per instance
-  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
-  expect(queryFn).toHaveBeenCalledTimes(2);
-  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
-  expect(queryFn).toHaveBeenCalledTimes(3);
+  const callsBefore = queryFn.mock.calls.length;
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 3));
+  expect(queryFn.mock.calls.length - callsBefore).toEqual(3);
 
   // Polling stops once every instance has unmounted
+  const callsBeforeUnmount = queryFn.mock.calls.length;
   unmount();
   await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 10));
-  expect(queryFn).toHaveBeenCalledTimes(3);
+  expect(queryFn.mock.calls.length).toEqual(callsBeforeUnmount);
 });
 
 test('keeps polling while at least one instance remains mounted', async () => {
@@ -83,7 +97,9 @@ test('keeps polling while at least one instance remains mounted', async () => {
   );
   await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
 
-  rerender(<Subscriber key="a" />);
+  // Unmounting the instance that carries the interval (the earliest-mounted
+  // one) promotes the remaining instance, so polling continues
+  rerender(<Subscriber key="b" />);
   await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
   expect(queryFn).toHaveBeenCalledTimes(2);
 

--- a/libs/ui/src/hooks/use_polling_query.test.tsx
+++ b/libs/ui/src/hooks/use_polling_query.test.tsx
@@ -1,0 +1,222 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { deferred } from '@votingworks/basics';
+import { PollingInterval, usePollingQuery } from './use_polling_query';
+
+vi.useFakeTimers({
+  shouldAdvanceTime: true,
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+const INTERVAL_MS = 1000;
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function QueryWrapper(props: { children: React.ReactNode }) {
+    const { children } = props;
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+test('shares a single polling timer across all instances of a query', async () => {
+  const queryClient = createTestQueryClient();
+  const queryFn = vi.fn(() => Promise.resolve('data'));
+
+  function Subscriber() {
+    usePollingQuery(['sharedQuery'], queryFn, INTERVAL_MS);
+    return null;
+  }
+
+  const { unmount } = render(
+    <React.Fragment>
+      <Subscriber />
+      <Subscriber />
+      <Subscriber />
+    </React.Fragment>,
+    { wrapper: createWrapper(queryClient) }
+  );
+
+  // The initial fetch on mount is shared by all instances
+  await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+
+  // Each tick issues one request total, not one per instance
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(2);
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(3);
+
+  // Polling stops once every instance has unmounted
+  unmount();
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 10));
+  expect(queryFn).toHaveBeenCalledTimes(3);
+});
+
+test('keeps polling while at least one instance remains mounted', async () => {
+  const queryClient = createTestQueryClient();
+  const queryFn = vi.fn(() => Promise.resolve('data'));
+
+  function Subscriber() {
+    usePollingQuery(['sharedQuery'], queryFn, INTERVAL_MS);
+    return null;
+  }
+
+  const { rerender, unmount } = render(
+    <React.Fragment>
+      <Subscriber key="a" />
+      <Subscriber key="b" />
+    </React.Fragment>,
+    { wrapper: createWrapper(queryClient) }
+  );
+  await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+
+  rerender(<Subscriber key="a" />);
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(2);
+
+  // Polling resumes when a new instance mounts after all unmounted
+  unmount();
+  render(<Subscriber />, { wrapper: createWrapper(queryClient) });
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(3);
+});
+
+test('a function interval can pause polling until the data changes', async () => {
+  const queryClient = createTestQueryClient();
+  interface Status {
+    isEnabled: boolean;
+  }
+  const queryFn = vi.fn(() => Promise.resolve<Status>({ isEnabled: false }));
+  const refetchInterval: PollingInterval<Status> = (data) =>
+    data?.isEnabled ? INTERVAL_MS : false;
+
+  renderHook(
+    () => usePollingQuery(['pausableQuery'], queryFn, refetchInterval),
+    { wrapper: createWrapper(queryClient) }
+  );
+  await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+
+  // At mount, before any data is available, the interval function returns
+  // false, and it still does once the initial fetch reports polling disabled
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 10));
+  expect(queryFn).toHaveBeenCalledTimes(1);
+
+  // When the data changes, the interval is re-evaluated and polling resumes
+  queryFn.mockImplementation(() => Promise.resolve({ isEnabled: true }));
+  act(() => {
+    queryClient.setQueryData(['pausableQuery'], { isEnabled: true });
+  });
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(2);
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(3);
+});
+
+test('while paused, ignores updates to other queries', async () => {
+  const queryClient = createTestQueryClient();
+  const pausedQueryFn = vi.fn(() => Promise.resolve('paused'));
+  const pollingQueryFn = vi.fn(() => Promise.resolve('polling'));
+
+  function Subscribers() {
+    usePollingQuery(['pausedQuery'], pausedQueryFn, () => false);
+    usePollingQuery(['pollingQuery'], pollingQueryFn, INTERVAL_MS);
+    return null;
+  }
+
+  // A second subscriber of the paused query, unmounted below to send the
+  // paused poller a non-update event for its own query
+  function PausedSubscriber() {
+    usePollingQuery(['pausedQuery'], pausedQueryFn, () => false);
+    return null;
+  }
+
+  const { rerender } = render(
+    <React.Fragment>
+      <Subscribers />
+      <PausedSubscriber />
+    </React.Fragment>,
+    { wrapper: createWrapper(queryClient) }
+  );
+  await waitFor(() => expect(pausedQueryFn).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(pollingQueryFn).toHaveBeenCalledTimes(1));
+
+  // The polling query's updates don't resume the paused query, and neither
+  // does an observer of the paused query unmounting
+  rerender(<Subscribers />);
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 10));
+  expect(pausedQueryFn).toHaveBeenCalledTimes(1);
+  expect(pollingQueryFn.mock.calls.length).toBeGreaterThan(1);
+});
+
+test('does not issue requests while every observer is disabled', async () => {
+  const queryClient = createTestQueryClient();
+  const queryFn = vi.fn(() => Promise.resolve('data'));
+
+  const { rerender } = renderHook(
+    ({ enabled }: { enabled: boolean }) =>
+      usePollingQuery(['gatedQuery'], queryFn, INTERVAL_MS, { enabled }),
+    { wrapper: createWrapper(queryClient), initialProps: { enabled: false } }
+  );
+
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 10));
+  expect(queryFn).not.toHaveBeenCalled();
+
+  rerender({ enabled: true });
+  await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(2);
+});
+
+test('stops cleanly when unmounted while a refetch is in flight', async () => {
+  const queryClient = createTestQueryClient();
+  const initialFetch = deferred<string>();
+  const queryFn = vi.fn(() => initialFetch.promise);
+
+  const { unmount } = renderHook(
+    () => usePollingQuery(['slowQuery'], queryFn, INTERVAL_MS),
+    { wrapper: createWrapper(queryClient) }
+  );
+  await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+
+  // The tick fires while the initial fetch is still in flight and reuses it
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS));
+  expect(queryFn).toHaveBeenCalledTimes(1);
+
+  unmount();
+  initialFetch.resolve('data');
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 10));
+  expect(queryFn).toHaveBeenCalledTimes(1);
+});
+
+test('polls queries with different keys independently', async () => {
+  const queryClient = createTestQueryClient();
+  const fastQueryFn = vi.fn(() => Promise.resolve('fast'));
+  const slowQueryFn = vi.fn(() => Promise.resolve('slow'));
+
+  function Subscribers() {
+    usePollingQuery(['fastQuery'], fastQueryFn, INTERVAL_MS);
+    usePollingQuery(['slowQuery'], slowQueryFn, INTERVAL_MS * 10);
+    return null;
+  }
+
+  render(<Subscribers />, { wrapper: createWrapper(queryClient) });
+  await waitFor(() => expect(fastQueryFn).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(slowQueryFn).toHaveBeenCalledTimes(1));
+
+  await act(() => vi.advanceTimersByTimeAsync(INTERVAL_MS * 10));
+  expect(fastQueryFn).toHaveBeenCalledTimes(11);
+  expect(slowQueryFn).toHaveBeenCalledTimes(2);
+});

--- a/libs/ui/src/hooks/use_polling_query.ts
+++ b/libs/ui/src/hooks/use_polling_query.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import {
   QueryClient,
   QueryFunction,
@@ -18,100 +18,52 @@ import {
  */
 export type PollingInterval<T> = number | ((data?: T) => number | false);
 
-interface PollingRegistration {
-  getInterval(): number | false;
+interface Registration {
+  readonly enabled: boolean;
+  setIsLeader(isLeader: boolean): void;
 }
 
-interface Poller {
-  readonly registrations: Set<PollingRegistration>;
-  stop(): void;
+const registrationsByClient = new WeakMap<
+  QueryClient,
+  Map<string, Registration[]>
+>();
+
+/**
+ * The leader — the one instance that passes `refetchInterval` through to
+ * react-query — is the earliest-mounted instance that is enabled. If every
+ * instance is disabled there is no leader, which is fine: react-query would
+ * not poll a disabled observer anyway.
+ */
+function elect(registrations: Registration[]): void {
+  const leader = registrations.find((registration) => registration.enabled);
+  for (const registration of registrations) {
+    registration.setIsLeader(registration === leader);
+  }
 }
 
-function createPoller(
+function registerInstance(
   queryClient: QueryClient,
-  queryKey: QueryKey,
   queryHash: string,
-  registration: PollingRegistration
-): Poller {
-  const registrations = new Set([registration]);
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let pausedUntilUpdate = false;
-
-  function schedule(): void {
-    const [currentRegistration] = registrations;
-    if (!currentRegistration) {
-      // Every instance unmounted while a refetch was in flight.
-      return;
-    }
-    const interval = currentRegistration.getInterval();
-    if (interval === false) {
-      pausedUntilUpdate = true;
-      return;
-    }
-    timer = setTimeout(() => {
-      void queryClient
-        .refetchQueries(
-          // Only issue a request while the query has an enabled observer.
-          { queryKey, exact: true, type: 'active' },
-          // Reuse an in-flight fetch rather than restarting it.
-          { cancelRefetch: false }
-        )
-        .then(schedule);
-    }, interval);
-  }
-
-  const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
-    if (
-      pausedUntilUpdate &&
-      event.query.queryHash === queryHash &&
-      event.type === 'updated'
-    ) {
-      pausedUntilUpdate = false;
-      schedule();
-    }
-  });
-
-  schedule();
-
-  return {
-    registrations,
-    stop() {
-      clearTimeout(timer);
-      unsubscribe();
-    },
-  };
-}
-
-const pollersByClient = new WeakMap<QueryClient, Map<string, Poller>>();
-
-function acquirePoller(
-  queryClient: QueryClient,
-  queryKey: QueryKey,
-  registration: PollingRegistration
+  registration: Registration
 ): () => void {
-  let pollers = pollersByClient.get(queryClient);
-  if (!pollers) {
-    pollers = new Map();
-    pollersByClient.set(queryClient, pollers);
+  let registrationsByQuery = registrationsByClient.get(queryClient);
+  if (!registrationsByQuery) {
+    registrationsByQuery = new Map();
+    registrationsByClient.set(queryClient, registrationsByQuery);
   }
-  const resolvedPollers = pollers;
-  const queryHash = hashQueryKey(queryKey);
-
-  const existingPoller = resolvedPollers.get(queryHash);
-  const poller =
-    existingPoller ??
-    createPoller(queryClient, queryKey, queryHash, registration);
-  if (existingPoller) {
-    existingPoller.registrations.add(registration);
-  } else {
-    resolvedPollers.set(queryHash, poller);
-  }
+  const registrations = registrationsByQuery.get(queryHash) ?? [];
+  registrations.push(registration);
+  registrationsByQuery.set(queryHash, registrations);
+  elect(registrations);
 
   return () => {
-    poller.registrations.delete(registration);
-    if (poller.registrations.size === 0) {
-      poller.stop();
-      resolvedPollers.delete(queryHash);
+    registrations.splice(registrations.indexOf(registration), 1);
+    if (registrations.length === 0) {
+      registrationsByQuery.delete(queryHash);
+    } else {
+      // Promote the next instance so polling continues when the leader
+      // unmounts before its followers.
+      elect(registrations);
     }
   };
 }
@@ -119,16 +71,19 @@ function acquirePoller(
 /**
  * Like `useQuery`, but keeps the query fresh by polling the backend at
  * `refetchInterval`. Any number of components can use the same polling query
- * simultaneously: react-query's own `refetchInterval` option runs a separate
- * refetch timer for every observer that sets it, and the resulting requests
- * only coalesce if they literally overlap, so N components polling one query
- * multiply the request rate N-fold. This hook instead drives all instances of
- * a query (per query client) with a single shared timer, so the request rate
- * is the same no matter how many components subscribe.
+ * simultaneously: react-query runs a separate refetch timer for every
+ * observer that sets `refetchInterval`, and the resulting requests only
+ * coalesce if they literally overlap, so N components passing it to
+ * `useQuery` directly multiply the request rate N-fold. This hook instead
+ * elects a single instance per query (per query client) to pass
+ * `refetchInterval` through to react-query — so react-query's own polling
+ * implementation does all the work, but only one timer ever runs — and the
+ * rest subscribe with no interval, receiving updates through the shared
+ * query cache.
  *
- * When multiple instances are mounted, the interval of the earliest-mounted
- * instance wins, so bake the interval into the query's hook wrapper in
- * `api.ts` rather than accepting it from callers.
+ * When multiple instances are mounted, the interval of the elected instance
+ * (the earliest-mounted one) wins, so bake the interval into the query's hook
+ * wrapper in `api.ts` rather than accepting it from callers.
  */
 export function usePollingQuery<T>(
   queryKey: QueryKey,
@@ -138,26 +93,16 @@ export function usePollingQuery<T>(
 ): UseQueryResult<T> {
   const queryClient = useQueryClient();
   const queryHash = hashQueryKey(queryKey);
-
-  // Give the polling loop access to the latest key and interval without
-  // restarting it on every render (inline interval functions change identity
-  // on each render).
-  const pollingRef = useRef({ queryKey, refetchInterval });
-  pollingRef.current = { queryKey, refetchInterval };
+  const enabled = options.enabled !== false;
+  const [isLeader, setIsLeader] = useState(false);
 
   useEffect(
-    () =>
-      acquirePoller(queryClient, pollingRef.current.queryKey, {
-        getInterval() {
-          const { queryKey: currentQueryKey, refetchInterval: interval } =
-            pollingRef.current;
-          return typeof interval === 'function'
-            ? interval(queryClient.getQueryData(currentQueryKey))
-            : interval;
-        },
-      }),
-    [queryClient, queryHash]
+    () => registerInstance(queryClient, queryHash, { enabled, setIsLeader }),
+    [queryClient, queryHash, enabled]
   );
 
-  return useQuery(queryKey, queryFn, options);
+  return useQuery(queryKey, queryFn, {
+    ...options,
+    refetchInterval: isLeader ? refetchInterval : undefined,
+  });
 }

--- a/libs/ui/src/hooks/use_polling_query.ts
+++ b/libs/ui/src/hooks/use_polling_query.ts
@@ -1,0 +1,163 @@
+import { useEffect, useRef } from 'react';
+import {
+  QueryClient,
+  QueryFunction,
+  QueryKey,
+  UseQueryOptions,
+  UseQueryResult,
+  hashQueryKey,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+/**
+ * The polling interval for {@link usePollingQuery}: a fixed delay in
+ * milliseconds, or a function of the query's latest data returning a delay,
+ * or `false` to pause polling until the query's data next changes (e.g. via
+ * an invalidation or a newly mounted instance's initial fetch).
+ */
+export type PollingInterval<T> = number | ((data?: T) => number | false);
+
+interface PollingRegistration {
+  getInterval(): number | false;
+}
+
+interface Poller {
+  readonly registrations: Set<PollingRegistration>;
+  stop(): void;
+}
+
+function createPoller(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  queryHash: string,
+  registration: PollingRegistration
+): Poller {
+  const registrations = new Set([registration]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pausedUntilUpdate = false;
+
+  function schedule(): void {
+    const [currentRegistration] = registrations;
+    if (!currentRegistration) {
+      // Every instance unmounted while a refetch was in flight.
+      return;
+    }
+    const interval = currentRegistration.getInterval();
+    if (interval === false) {
+      pausedUntilUpdate = true;
+      return;
+    }
+    timer = setTimeout(() => {
+      void queryClient
+        .refetchQueries(
+          // Only issue a request while the query has an enabled observer.
+          { queryKey, exact: true, type: 'active' },
+          // Reuse an in-flight fetch rather than restarting it.
+          { cancelRefetch: false }
+        )
+        .then(schedule);
+    }, interval);
+  }
+
+  const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+    if (
+      pausedUntilUpdate &&
+      event.query.queryHash === queryHash &&
+      event.type === 'updated'
+    ) {
+      pausedUntilUpdate = false;
+      schedule();
+    }
+  });
+
+  schedule();
+
+  return {
+    registrations,
+    stop() {
+      clearTimeout(timer);
+      unsubscribe();
+    },
+  };
+}
+
+const pollersByClient = new WeakMap<QueryClient, Map<string, Poller>>();
+
+function acquirePoller(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+  registration: PollingRegistration
+): () => void {
+  let pollers = pollersByClient.get(queryClient);
+  if (!pollers) {
+    pollers = new Map();
+    pollersByClient.set(queryClient, pollers);
+  }
+  const resolvedPollers = pollers;
+  const queryHash = hashQueryKey(queryKey);
+
+  const existingPoller = resolvedPollers.get(queryHash);
+  const poller =
+    existingPoller ??
+    createPoller(queryClient, queryKey, queryHash, registration);
+  if (existingPoller) {
+    existingPoller.registrations.add(registration);
+  } else {
+    resolvedPollers.set(queryHash, poller);
+  }
+
+  return () => {
+    poller.registrations.delete(registration);
+    if (poller.registrations.size === 0) {
+      poller.stop();
+      resolvedPollers.delete(queryHash);
+    }
+  };
+}
+
+/**
+ * Like `useQuery`, but keeps the query fresh by polling the backend at
+ * `refetchInterval`. Any number of components can use the same polling query
+ * simultaneously: react-query's own `refetchInterval` option runs a separate
+ * refetch timer for every observer that sets it, and the resulting requests
+ * only coalesce if they literally overlap, so N components polling one query
+ * multiply the request rate N-fold. This hook instead drives all instances of
+ * a query (per query client) with a single shared timer, so the request rate
+ * is the same no matter how many components subscribe.
+ *
+ * When multiple instances are mounted, the interval of the earliest-mounted
+ * instance wins, so bake the interval into the query's hook wrapper in
+ * `api.ts` rather than accepting it from callers.
+ */
+export function usePollingQuery<T>(
+  queryKey: QueryKey,
+  queryFn: QueryFunction<T>,
+  refetchInterval: PollingInterval<T>,
+  options: Omit<UseQueryOptions<T>, 'refetchInterval'> = {}
+): UseQueryResult<T> {
+  const queryClient = useQueryClient();
+  const queryHash = hashQueryKey(queryKey);
+
+  // Give the polling loop access to the latest key and interval without
+  // restarting it on every render (inline interval functions change identity
+  // on each render).
+  const pollingRef = useRef({ queryKey, refetchInterval });
+  pollingRef.current = { queryKey, refetchInterval };
+
+  useEffect(
+    () =>
+      acquirePoller(queryClient, pollingRef.current.queryKey, {
+        getInterval() {
+          const { queryKey: currentQueryKey, refetchInterval: interval } =
+            pollingRef.current;
+          return typeof interval === 'function'
+            ? interval(queryClient.getQueryData(currentQueryKey))
+            : interval;
+        },
+      }),
+    [queryClient, queryHash]
+  );
+
+  return useQuery(queryKey, queryFn, options);
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -48,6 +48,7 @@ export * from './hooks/use_language_controls';
 export * from './hooks/use_lock';
 export * from './hooks/use_now';
 export * from './hooks/use_pin_entry';
+export * from './hooks/use_polling_query';
 export * from './hooks/use_screen_info';
 export * from './icons';
 export * from './insert_ballot_image';


### PR DESCRIPTION
## Overview
Following up on the problem discovered in: https://github.com/votingworks/vxsuite/pull/9102

Adds a usePollingQuery shared hook that manages making sure only 1 query observer is running refetchInterval at a time under the hoods. The client apps therefore just need to use this hook to make sure they are polling properly. Adds a lint rule (optional, currently only enabled in admin/central-scan) enforcing that we use this new hook instead of useQuery with refetchInterval directly. 

## Demo Video or Screenshot
N/A

## Testing Plan
Ran tests
Ran adjudication station & host station, took actions that cause network changes under the hood, saw those automatically reflected in frontend as anticipated. Took basic actions that rely on polling intervals for fe updtes - usb changes, network status changes, etc. and saw properly reflected.  

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
