### PR TITLE
[VxAdmin / VxCentralScan] Transfer cvrs by batch from VxCentralScan to VxAdmin

### DIFF
--- a/apps/admin/backend/schema.sql
+++ b/apps/admin/backend/schema.sql
@@ -186,8 +186,35 @@ create table cvr_files (
   scanner_ids text not null,
   polling_place_ids text not null,
   batch_ids text not null,
-  sha256_hash text not null,
+  -- Null for imports received over the network, which have no export
+  -- signature to hash.
+  sha256_hash text,
+  source text not null default 'usb'
+    check (source = 'usb' or source = 'network'),
+  network_scanner_id text,
+  network_batch_id text,
   created_at text not null default current_timestamp,
+  foreign key (election_id) references elections(id)
+    on delete cascade
+) strict;
+
+create unique index idx_cvr_files_network_transfer
+  on cvr_files(election_id, network_scanner_id, network_batch_id)
+  where source = 'network';
+
+-- Cast vote records that have been validated but not yet imported: held
+-- here — invisible to every other consumer — until finalized, when they
+-- move into the real tables in one atomic transaction. Used by network
+-- transfers today; intended to back a chunked USB import as well.
+create table cvrs_staging (
+  election_id text not null,
+  scanner_id text not null,
+  batch_id text not null,
+  ballot_id text not null,
+  -- The validated, ready-to-insert record (votes, adjudication flags,
+  -- write-ins, image metadata) as JSON.
+  cvr_data text not null,
+  primary key (election_id, scanner_id, batch_id, ballot_id),
   foreign key (election_id) references elections(id)
     on delete cascade
 ) strict;

--- a/apps/admin/backend/src/app.test.ts
+++ b/apps/admin/backend/src/app.test.ts
@@ -36,6 +36,7 @@ import {
   mockSystemAdministratorAuth,
   saveTmpFile,
 } from '../test/app.js';
+import { addMockCvrFileToStore } from '../test/mock_cvr_file.js';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
 import { ManualResultsIdentifier, ManualResultsRecord } from './types.js';
 
@@ -111,6 +112,36 @@ test('setMachineMode throws when election is configured', async () => {
     expect(apiClient.setMachineMode({ mode: 'client' })).rejects.toThrow(
       'Cannot change machine mode while an election is configured.'
     )
+  );
+});
+
+test('getCastVoteRecordsDataVersion reflects CVR changes', async () => {
+  const { apiClient, auth, workspace } = buildTestEnvironment();
+  // Unconfigured: no election to version
+  expect(await apiClient.getCastVoteRecordsDataVersion()).toEqual(0);
+
+  await configureMachine(apiClient, auth, readElectionGeneralDefinition());
+  const initialVersion = await apiClient.getCastVoteRecordsDataVersion();
+
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  addMockCvrFileToStore({
+    electionId,
+    store: workspace.store,
+    pollingPlaceId: 'polling-place-1',
+    mockCastVoteRecordFile: [
+      {
+        ballotStyleGroupId: '1M',
+        batchId: 'batch-1',
+        scannerId: 'scanner-1',
+        precinctId: 'precinct-1',
+        votingMethod: 'precinct',
+        votes: {},
+        card: { type: 'bmd' },
+      },
+    ],
+  });
+  expect(await apiClient.getCastVoteRecordsDataVersion()).toBeGreaterThan(
+    initialVersion
   );
 });
 

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -335,6 +335,16 @@ function buildApi({
      * Counts of CVRs and batches imported from each scanner for the current
      * election.
      */
+    /**
+     * A counter that increments whenever cast vote records change (bumped by
+     * database triggers on import and delete). Cheap to poll; lets the
+     * frontend refresh CVR-derived data when network imports land.
+     */
+    getCastVoteRecordsDataVersion(): number {
+      const electionId = store.getCurrentElectionId();
+      return electionId ? store.getCastVoteRecordsDataVersion(electionId) : 0;
+    },
+
     getScannerImportCounts(): Record<
       string,
       { cvrCount: number; batchCount: number }

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -335,6 +335,14 @@ function buildApi({
      * Counts of CVRs and batches imported from each scanner for the current
      * election.
      */
+    getScannerImportCounts(): Record<
+      string,
+      { cvrCount: number; batchCount: number }
+    > {
+      const electionId = store.getCurrentElectionId();
+      return electionId ? store.getScannerImportCounts(electionId) : {};
+    },
+
     /**
      * A counter that increments whenever cast vote records change (bumped by
      * database triggers on import and delete). Cheap to poll; lets the
@@ -343,14 +351,6 @@ function buildApi({
     getCastVoteRecordsDataVersion(): number {
       const electionId = store.getCurrentElectionId();
       return electionId ? store.getCastVoteRecordsDataVersion(electionId) : 0;
-    },
-
-    getScannerImportCounts(): Record<
-      string,
-      { cvrCount: number; batchCount: number }
-    > {
-      const electionId = store.getCurrentElectionId();
-      return electionId ? store.getScannerImportCounts(electionId) : {};
     },
 
     getIsClientAdjudicationEnabled(): boolean {

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -424,7 +424,7 @@ export async function importCastVoteRecords(
       pollingPlaceIds,
       scannerIds,
       batchIds,
-      sha256Hash: exportHash,
+      source: { type: 'usb', sha256Hash: exportHash },
     });
 
     // Create a mark score distribution map with 0.1 increment buckets for logging

--- a/apps/admin/backend/src/cast_vote_records.ts
+++ b/apps/admin/backend/src/cast_vote_records.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { createHash, randomUUID as uuid } from 'node:crypto';
 import {
+  CastVoteRecordAndReferencedFiles,
   isTestReport,
   readCastVoteRecordExport,
   readCastVoteRecordExportMetadata,
@@ -16,12 +17,15 @@ import {
 } from '@votingworks/basics';
 import { FileSystemEntryType, listDirectory } from '@votingworks/fs';
 import {
+  AdjudicationReason,
+  BallotId,
   CVR,
   ElectionDefinition,
   getBallotStyle,
   getContests,
   getGroupIdFromBallotStyleId,
   getPrecinctById,
+  MarkThresholds,
   Tabulation,
 } from '@votingworks/types';
 import {
@@ -203,6 +207,134 @@ export async function listCastVoteRecordExportsInDirectory(
 }
 
 /**
+ * A cast vote record that has been parsed and validated and is ready to be
+ * inserted into the store.
+ */
+export interface PreparedCastVoteRecord {
+  ballotId: BallotId;
+  cvr: Omit<Tabulation.CastVoteRecord, 'scannerId'>;
+  adjudicationFlags: ReturnType<typeof getCastVoteRecordAdjudicationFlags>;
+  needsAdjudication: boolean;
+  writeIns: CastVoteRecordAndReferencedFiles['castVoteRecordWriteIns'];
+  isHmpb: boolean;
+  referencedFiles: CastVoteRecordAndReferencedFiles['referencedFiles'];
+}
+
+/**
+ * Validates a parsed cast vote record against the election definition and
+ * computes everything needed to insert it. Pure — performs no store writes —
+ * so callers can do any async work (e.g. reading ballot images) before
+ * inserting inside a synchronous transaction.
+ */
+export function prepareCastVoteRecord(
+  parsed: CastVoteRecordAndReferencedFiles,
+  electionDefinition: ElectionDefinition,
+  systemSettings: {
+    adminAdjudicationReasons: AdjudicationReason[];
+    markThresholds: MarkThresholds;
+  }
+): Result<
+  PreparedCastVoteRecord,
+  CastVoteRecordElectionDefinitionValidationError
+> {
+  const {
+    castVoteRecord,
+    castVoteRecordBallotSheetId,
+    castVoteRecordCurrentSnapshot,
+    castVoteRecordOriginalSnapshot,
+    castVoteRecordWriteIns,
+    referencedFiles,
+  } = parsed;
+
+  const validationResult = validateCastVoteRecordAgainstElectionDefinition(
+    castVoteRecord,
+    electionDefinition
+  );
+  if (validationResult.isErr()) {
+    return validationResult;
+  }
+
+  const votes = convertCastVoteRecordVotesToTabulationVotes(
+    castVoteRecordCurrentSnapshot
+  );
+  // HMPB ballots have an original snapshot (for mark adjudication), while BMD ballots
+  // (including multi-page BMD) do not. Multi-page BMD also has BallotSheetId, so we
+  // can't use that alone to identify HMPB.
+  const isHmpb = castVoteRecordOriginalSnapshot !== undefined;
+  let markScores: Tabulation.MarkScores | undefined;
+  if (isHmpb) {
+    markScores = convertCastVoteRecordMarkMetricsToMarkScores(
+      castVoteRecordOriginalSnapshot
+    );
+  }
+
+  // Determine the card type:
+  // - HMPB: has original snapshot and sheet number
+  // - Multi-page BMD: has sheet number but no original snapshot
+  // - Single-page BMD: no sheet number
+  let card: Tabulation.Card;
+  if (isHmpb) {
+    assert(castVoteRecordBallotSheetId !== undefined);
+    card = { type: 'hmpb', sheetNumber: castVoteRecordBallotSheetId };
+  } else if (castVoteRecordBallotSheetId !== undefined) {
+    // Multi-page BMD ballot
+    card = { type: 'bmd', sheetNumber: castVoteRecordBallotSheetId };
+  } else {
+    // Single-page BMD ballot
+    card = { type: 'bmd' };
+  }
+
+  // Currently, we only support filtering on initial adjudication status,
+  // rather than post-adjudication status. As a result, we can just calculate
+  // now, during import.
+  const adjudicationFlags = getCastVoteRecordAdjudicationFlags(
+    electionDefinition,
+    votes,
+    castVoteRecordWriteIns.length,
+    isHmpb ? markScores : undefined,
+    systemSettings.markThresholds
+  );
+  const votingMethod = assertDefined(
+    getCastVoteRecordBallotType(castVoteRecord)
+  );
+  return ok({
+    ballotId: castVoteRecord.UniqueId,
+    cvr: {
+      ballotStyleGroupId: getGroupIdFromBallotStyleId({
+        ballotStyleId: castVoteRecord.BallotStyleId,
+        election: electionDefinition.election,
+      }),
+      batchId: castVoteRecord.BatchId,
+      card,
+      precinctId: castVoteRecord.BallotStyleUnitId,
+      markScores,
+      votes,
+      votingMethod,
+    },
+    adjudicationFlags,
+    needsAdjudication: doesCvrNeedAdjudication(
+      adjudicationFlags,
+      systemSettings.adminAdjudicationReasons
+    ),
+    writeIns: castVoteRecordWriteIns,
+    isHmpb,
+    referencedFiles,
+  });
+}
+
+/**
+ * Whether a cast vote record's ballot images should be stored on import.
+ * Today only records that need adjudication keep their images; this is the
+ * single place to change if VxAdmin moves to storing images for every
+ * record. Shared by the USB and network import paths.
+ */
+export function shouldStoreBallotImages(
+  prepared: PreparedCastVoteRecord
+): boolean {
+  return prepared.needsAdjudication;
+}
+
+/**
  * Imports cast vote records given a cast vote record export directory path
  */
 export async function importCastVoteRecords(
@@ -315,80 +447,26 @@ export async function importCastVoteRecords(
           index: castVoteRecordIndex,
         });
       }
+      const parsed = castVoteRecordResult.ok();
+      const prepareResult = prepareCastVoteRecord(parsed, electionDefinition, {
+        adminAdjudicationReasons,
+        markThresholds,
+      });
+      if (prepareResult.isErr()) {
+        return err({ ...prepareResult.err(), index: castVoteRecordIndex });
+      }
+      const prepared = prepareResult.ok();
       const {
-        castVoteRecord,
-        castVoteRecordBallotSheetId,
-        castVoteRecordCurrentSnapshot,
-        castVoteRecordOriginalSnapshot,
-        castVoteRecordWriteIns,
+        adjudicationFlags,
+        isHmpb,
         referencedFiles,
-      } = castVoteRecordResult.ok();
+        writeIns: castVoteRecordWriteIns,
+      } = prepared;
+      const { markScores } = prepared.cvr;
 
-      const validationResult = validateCastVoteRecordAgainstElectionDefinition(
-        castVoteRecord,
-        electionDefinition
-      );
-      if (validationResult.isErr()) {
-        return err({ ...validationResult.err(), index: castVoteRecordIndex });
-      }
-
-      const votes = convertCastVoteRecordVotesToTabulationVotes(
-        castVoteRecordCurrentSnapshot
-      );
-      // HMPB ballots have an original snapshot (for mark adjudication), while BMD ballots
-      // (including multi-page BMD) do not. Multi-page BMD also has BallotSheetId, so we
-      // can't use that alone to identify HMPB.
-      const isHmpb = castVoteRecordOriginalSnapshot !== undefined;
-      let markScores: Tabulation.MarkScores | undefined;
-      if (isHmpb) {
-        markScores = convertCastVoteRecordMarkMetricsToMarkScores(
-          castVoteRecordOriginalSnapshot
-        );
-      }
-
-      // Determine the card type:
-      // - HMPB: has original snapshot and sheet number
-      // - Multi-page BMD: has sheet number but no original snapshot
-      // - Single-page BMD: no sheet number
-      let card: Tabulation.Card;
-      if (isHmpb) {
-        assert(castVoteRecordBallotSheetId !== undefined);
-        card = { type: 'hmpb', sheetNumber: castVoteRecordBallotSheetId };
-      } else if (castVoteRecordBallotSheetId !== undefined) {
-        // Multi-page BMD ballot
-        card = { type: 'bmd', sheetNumber: castVoteRecordBallotSheetId };
-      } else {
-        // Single-page BMD ballot
-        card = { type: 'bmd' };
-      }
-
-      // Currently, we only support filtering on initial adjudication status,
-      // rather than post-adjudication status. As a result, we can just calculate
-      // now, during import.
-      const adjudicationFlags = getCastVoteRecordAdjudicationFlags(
-        electionDefinition,
-        votes,
-        castVoteRecordWriteIns.length,
-        isHmpb ? markScores : undefined,
-        markThresholds
-      );
-      const votingMethod = assertDefined(
-        getCastVoteRecordBallotType(castVoteRecord)
-      );
       const addCastVoteRecordResult = store.addCastVoteRecordFileEntry({
-        ballotId: castVoteRecord.UniqueId,
-        cvr: {
-          ballotStyleGroupId: getGroupIdFromBallotStyleId({
-            ballotStyleId: castVoteRecord.BallotStyleId,
-            election: electionDefinition.election,
-          }),
-          batchId: castVoteRecord.BatchId,
-          card,
-          precinctId: castVoteRecord.BallotStyleUnitId,
-          markScores,
-          votes,
-          votingMethod,
-        },
+        ballotId: prepared.ballotId,
+        cvr: prepared.cvr,
         cvrFileId: importId,
         electionId,
         adjudicationFlags,
@@ -403,12 +481,7 @@ export async function importCastVoteRecords(
         addCastVoteRecordResult.ok();
 
       if (isCastVoteRecordNew) {
-        const needsAdjudication = doesCvrNeedAdjudication(
-          adjudicationFlags,
-          adminAdjudicationReasons
-        );
-
-        if (needsAdjudication) {
+        if (shouldStoreBallotImages(prepared)) {
           // Guaranteed to be defined given validation in readCastVoteRecordExport
           assert(referencedFiles !== undefined);
           for (const i of [0, 1] as const) {
@@ -473,7 +546,7 @@ export async function importCastVoteRecords(
       } else {
         alreadyPresent += 1;
       }
-      precinctIds.add(castVoteRecord.BallotStyleUnitId);
+      precinctIds.add(prepared.cvr.precinctId);
 
       castVoteRecordIndex += 1;
     }

--- a/apps/admin/backend/src/network_cvr_transfer.test.ts
+++ b/apps/admin/backend/src/network_cvr_transfer.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest';
+import { NetworkCvrImportQueue } from './network_cvr_transfer.js';
+
+test('NetworkCvrImportQueue keeps running after a rejected task', async () => {
+  const queue = new NetworkCvrImportQueue();
+  await expect(
+    queue.run(() => Promise.reject(new Error('boom')))
+  ).rejects.toThrow('boom');
+  expect(await queue.run(() => Promise.resolve('next'))).toEqual('next');
+});

--- a/apps/admin/backend/src/network_cvr_transfer.ts
+++ b/apps/admin/backend/src/network_cvr_transfer.ts
@@ -1,0 +1,568 @@
+import { Buffer } from 'node:buffer';
+import { randomUUID as uuid } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import { assert, assertDefined, err, ok, Result } from '@votingworks/basics';
+import {
+  inMemoryFileSource,
+  readCastVoteRecordFromSource,
+} from '@votingworks/backend';
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import type {
+  CvrTransferManifest,
+  FinishCvrTransferError,
+  StartCvrTransferError,
+} from '@votingworks/networking';
+import {
+  BallotId,
+  BallotPageLayout,
+  safeParseJson,
+  Side,
+  Tabulation,
+} from '@votingworks/types';
+import { z } from 'zod/v4';
+import { getEntries, openZip, readEntry } from '@votingworks/utils';
+import {
+  prepareCastVoteRecord,
+  PreparedCastVoteRecord,
+  shouldStoreBallotImages,
+} from './cast_vote_records.js';
+import { getMachineConfig } from './machine_config.js';
+import { Store } from './store.js';
+import { CastVoteRecordAdjudicationFlags, CvrFileMode } from './types.js';
+import { rootDebug } from './util/debug.js';
+import { Workspace } from './util/workspace.js';
+
+const debug = rootDebug.extend('network-cvr-transfer');
+
+const TRANSFER_MANIFEST_FILE_NAME = 'manifest.json';
+
+const CvrTransferManifestSchema: z.ZodType<CvrTransferManifest> = z.object({
+  machineId: z.string(),
+  batchId: z.string(),
+  label: z.string(),
+  pollingPlaceId: z.string(),
+  sheetCount: z.number().int().nonnegative(),
+  startedAt: z.string(),
+  isTestMode: z.boolean(),
+});
+
+/**
+ * A validated, ready-to-insert cast vote record as staged in the
+ * `cvrs_staging` table (serialized as JSON). Ballot image bytes are
+ * staged as files alongside the transfer's manifest; only their metadata is
+ * staged here.
+ */
+interface StagedCvrData {
+  cvr: Omit<Tabulation.CastVoteRecord, 'scannerId'>;
+  adjudicationFlags: CastVoteRecordAdjudicationFlags;
+  writeIns: PreparedCastVoteRecord['writeIns'];
+  images?: Array<{ side: Side; pageLayout?: BallotPageLayout }>;
+}
+
+/**
+ * Path component ids come from other machines, so only accept a conservative
+ * character set that can't traverse directories.
+ */
+const SAFE_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function isSafeId(id: string): boolean {
+  return SAFE_ID_PATTERN.test(id) && id !== '.' && id !== '..';
+}
+
+function getTransferDirectoryPath(
+  workspace: Workspace,
+  scannerId: string,
+  batchId: string
+): string {
+  return path.join(workspace.path, 'cvr-transfers', scannerId, batchId);
+}
+
+function getStagedImagePath(
+  transferDirectoryPath: string,
+  ballotId: string,
+  side: Side
+): string {
+  return path.join(transferDirectoryPath, 'images', `${ballotId}-${side}.png`);
+}
+
+async function readTransferManifest(
+  transferDirectoryPath: string
+): Promise<CvrTransferManifest | undefined> {
+  let contents: string;
+  try {
+    contents = await fs.readFile(
+      path.join(transferDirectoryPath, TRANSFER_MANIFEST_FILE_NAME),
+      'utf-8'
+    );
+  } catch {
+    return undefined;
+  }
+  const parseResult = safeParseJson(contents, CvrTransferManifestSchema);
+  // Manifests are only ever written by startCvrTransfer
+  assert(parseResult.isOk(), 'invalid CVR transfer manifest');
+  return parseResult.ok();
+}
+
+/**
+ * Serializes network CVR transfer finalizations so that concurrent transfers
+ * from multiple scanners cannot interleave their imports.
+ */
+export class NetworkCvrImportQueue {
+  private tail: Promise<unknown> = Promise.resolve();
+
+  run<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(fn, fn);
+    this.tail = result.catch(() => undefined);
+    return result;
+  }
+}
+
+function checkScannerCompatibility(
+  store: Store,
+  input: { codeVersion: string; ballotHash: string }
+): Result<{ electionId: string }, StartCvrTransferError> {
+  const machineConfig = getMachineConfig();
+  if (input.codeVersion !== machineConfig.codeVersion) {
+    return err({ type: 'code-version-mismatch' });
+  }
+  const electionId = store.getCurrentElectionId();
+  if (!electionId) {
+    return err({ type: 'host-unconfigured' });
+  }
+  const { electionDefinition } = assertDefined(store.getElection(electionId));
+  if (input.ballotHash !== electionDefinition.ballotHash) {
+    return err({ type: 'ballot-hash-mismatch' });
+  }
+  return ok({ electionId });
+}
+
+/**
+ * Starts (or resumes) a CVR transfer for one batch. See the contract docs in
+ * libs/networking for the transfer protocol.
+ */
+export async function startCvrTransfer(
+  { workspace, logger }: { workspace: Workspace; logger: BaseLogger },
+  input: CvrTransferManifest & { codeVersion: string; ballotHash: string }
+): Promise<Result<{ alreadyComplete: boolean }, StartCvrTransferError>> {
+  const { store } = workspace;
+
+  function reject(
+    error: StartCvrTransferError
+  ): Result<{ alreadyComplete: boolean }, StartCvrTransferError> {
+    logger.log(LogEventId.AdminNetworkStatus, 'system', {
+      message: `Rejected CVR transfer of batch ${input.batchId} from scanner ${input.machineId}: ${error.type}.`,
+      disposition: 'failure',
+      scannerMachineId: input.machineId,
+      batchId: input.batchId,
+      error: error.type,
+    });
+    return err(error);
+  }
+
+  if (!isSafeId(input.machineId) || !isSafeId(input.batchId)) {
+    return reject({ type: 'scanner-unconfigured' });
+  }
+
+  const compatibility = checkScannerCompatibility(store, input);
+  if (compatibility.isErr()) {
+    return reject(compatibility.err());
+  }
+  const { electionId } = compatibility.ok();
+
+  const transferMode: CvrFileMode = input.isTestMode ? 'test' : 'official';
+  const currentMode = store.getCurrentCvrFileModeForElection(electionId);
+  if (currentMode !== 'unlocked' && transferMode !== currentMode) {
+    return reject({ type: 'invalid-mode', currentMode });
+  }
+
+  if (store.getNetworkCvrImportId(electionId, input.machineId, input.batchId)) {
+    return ok({ alreadyComplete: true });
+  }
+
+  const transferDirectoryPath = getTransferDirectoryPath(
+    workspace,
+    input.machineId,
+    input.batchId
+  );
+  await fs.mkdir(transferDirectoryPath, { recursive: true });
+  const manifest: CvrTransferManifest = {
+    machineId: input.machineId,
+    batchId: input.batchId,
+    label: input.label,
+    pollingPlaceId: input.pollingPlaceId,
+    sheetCount: input.sheetCount,
+    startedAt: input.startedAt,
+    isTestMode: input.isTestMode,
+  };
+  await fs.writeFile(
+    path.join(transferDirectoryPath, TRANSFER_MANIFEST_FILE_NAME),
+    JSON.stringify(manifest)
+  );
+  logger.log(LogEventId.AdminNetworkStatus, 'system', {
+    message: `Started CVR transfer of batch ${input.batchId} (${input.sheetCount} sheets) from scanner ${input.machineId}.`,
+    scannerMachineId: input.machineId,
+    batchId: input.batchId,
+    sheetCount: input.sheetCount,
+  });
+  return ok({ alreadyComplete: false });
+}
+
+/**
+ * Receives one cast vote record's zipped file set, validates it fully (the
+ * same parsing, election checks, and image hash verification as a USB
+ * import), and stages it — invisible to every other consumer — for the
+ * atomic move at finish. Re-sends after an interruption simply replace the
+ * staged record.
+ *
+ * Doing all per-record work here spreads the import cost across the
+ * transfer instead of concentrating it in finish, and means a malformed
+ * cast vote record is rejected — with a reason — the moment it arrives.
+ */
+export async function receiveCvrTransferUpload(
+  { workspace }: { workspace: Workspace },
+  input: {
+    scannerId: string;
+    batchId: string;
+    castVoteRecordId: string;
+    zipData: Buffer;
+  }
+): Promise<Result<void, string>> {
+  const { store } = workspace;
+  const { scannerId, batchId, castVoteRecordId, zipData } = input;
+  if (
+    !isSafeId(scannerId) ||
+    !isSafeId(batchId) ||
+    !isSafeId(castVoteRecordId)
+  ) {
+    return err('invalid id');
+  }
+  const transferDirectoryPath = getTransferDirectoryPath(
+    workspace,
+    scannerId,
+    batchId
+  );
+  if (!(await readTransferManifest(transferDirectoryPath))) {
+    return err('transfer not started');
+  }
+  // A transfer can only have been started while configured
+  const electionId = assertDefined(store.getCurrentElectionId());
+  const { electionDefinition } = assertDefined(store.getElection(electionId));
+  const { adminAdjudicationReasons, markThresholds } =
+    store.getSystemSettings(electionId);
+
+  let entries: Awaited<ReturnType<typeof getEntries>>;
+  try {
+    entries = getEntries(await openZip(zipData)).filter((entry) => !entry.dir);
+  } catch {
+    return err('invalid zip');
+  }
+  if (entries.some((entry) => !isSafeId(entry.name))) {
+    return err('invalid zip entry name');
+  }
+
+  const files: Record<string, Buffer> = {};
+  for (const entry of entries) {
+    files[entry.name] = await readEntry(entry);
+  }
+
+  const readResult = await readCastVoteRecordFromSource(
+    inMemoryFileSource(files),
+    new Set([batchId])
+  );
+  if (readResult.isErr()) {
+    return err(`invalid cast vote record (${readResult.err().subType})`);
+  }
+  const prepareResult = prepareCastVoteRecord(
+    readResult.ok(),
+    electionDefinition,
+    { adminAdjudicationReasons, markThresholds }
+  );
+  if (prepareResult.isErr()) {
+    return err(`invalid cast vote record (${prepareResult.err().subType})`);
+  }
+  const prepared = prepareResult.ok();
+  if (prepared.ballotId !== castVoteRecordId) {
+    return err('cast vote record id mismatch');
+  }
+
+  let images: StagedCvrData['images'];
+  if (shouldStoreBallotImages(prepared) && prepared.referencedFiles) {
+    images = [];
+    const { imageFiles, layoutFiles } = prepared.referencedFiles;
+    await fs.mkdir(path.join(transferDirectoryPath, 'images'), {
+      recursive: true,
+    });
+    for (const i of [0, 1] as const) {
+      const side = (['front', 'back'] as const)[i];
+      // Reading verifies the file against the hash in the report
+      const imageReadResult = await imageFiles[i].read();
+      if (imageReadResult.isErr()) {
+        return err('could not verify a ballot image');
+      }
+      let pageLayout: BallotPageLayout | undefined;
+      if (layoutFiles) {
+        const layoutReadResult = await layoutFiles[i].read();
+        if (layoutReadResult.isErr()) {
+          return err('could not verify a layout file');
+        }
+        pageLayout = layoutReadResult.ok();
+      }
+      await fs.writeFile(
+        getStagedImagePath(transferDirectoryPath, prepared.ballotId, side),
+        imageReadResult.ok()
+      );
+      images.push({ side, pageLayout });
+    }
+  }
+
+  const cvrData: StagedCvrData = {
+    cvr: prepared.cvr,
+    adjudicationFlags: prepared.adjudicationFlags,
+    writeIns: prepared.writeIns,
+    images,
+  };
+  store.upsertStagedCvr({
+    electionId,
+    scannerId,
+    batchId,
+    ballotId: prepared.ballotId,
+    cvrData: JSON.stringify(cvrData),
+  });
+  return ok();
+}
+
+/**
+ * Completes a CVR transfer: verifies the staged cast vote records against
+ * the manifest's sheet count, then moves them into the real tables in one
+ * atomic transaction — the first moment any other consumer can see them.
+ * Idempotent — a transfer that already completed returns its count.
+ */
+export async function finishCvrTransfer(
+  {
+    workspace,
+    logger,
+    importQueue,
+  }: {
+    workspace: Workspace;
+    logger: BaseLogger;
+    importQueue: NetworkCvrImportQueue;
+  },
+  input: { machineId: string; batchId: string }
+): Promise<Result<{ cvrCount: number }, FinishCvrTransferError>> {
+  const { store } = workspace;
+
+  function reject(
+    error: FinishCvrTransferError
+  ): Result<{ cvrCount: number }, FinishCvrTransferError> {
+    logger.log(LogEventId.AdminNetworkStatus, 'system', {
+      message: `Could not finish CVR transfer of batch ${input.batchId} from scanner ${input.machineId}: ${error.type}.`,
+      disposition: 'failure',
+      scannerMachineId: input.machineId,
+      batchId: input.batchId,
+      error: error.type,
+    });
+    return err(error);
+  }
+
+  if (!isSafeId(input.machineId) || !isSafeId(input.batchId)) {
+    return reject({ type: 'transfer-not-found' });
+  }
+  const electionId = store.getCurrentElectionId();
+  if (!electionId) {
+    return reject({ type: 'transfer-not-found' });
+  }
+
+  const existingImportId = store.getNetworkCvrImportId(
+    electionId,
+    input.machineId,
+    input.batchId
+  );
+  if (existingImportId) {
+    return ok({
+      cvrCount: store.getCastVoteRecordCountByFileId(existingImportId),
+    });
+  }
+
+  const transferDirectoryPath = getTransferDirectoryPath(
+    workspace,
+    input.machineId,
+    input.batchId
+  );
+  const manifest = await readTransferManifest(transferDirectoryPath);
+  if (!manifest) {
+    return reject({ type: 'transfer-not-found' });
+  }
+
+  const received = store.getStagedCvrCount(
+    electionId,
+    input.machineId,
+    input.batchId
+  );
+  if (received !== manifest.sheetCount) {
+    return reject({
+      type: 'sheet-count-mismatch',
+      expected: manifest.sheetCount,
+      received,
+    });
+  }
+
+  return await importQueue.run(async () =>
+    moveStagedTransfer({
+      workspace,
+      logger,
+      electionId,
+      manifest,
+      transferDirectoryPath,
+    })
+  );
+}
+
+async function moveStagedTransfer({
+  workspace,
+  logger,
+  electionId,
+  manifest,
+  transferDirectoryPath,
+}: {
+  workspace: Workspace;
+  logger: BaseLogger;
+  electionId: string;
+  manifest: CvrTransferManifest;
+  transferDirectoryPath: string;
+}): Promise<Result<{ cvrCount: number }, FinishCvrTransferError>> {
+  const { store } = workspace;
+  const { electionDefinition } = assertDefined(store.getElection(electionId));
+
+  const stagedRecords = store
+    .getStagedCvrs(electionId, manifest.machineId, manifest.batchId)
+    .map((record) => ({
+      ballotId: record.ballotId,
+      data: JSON.parse(record.cvrData) as StagedCvrData,
+    }));
+
+  const importId = uuid();
+  const precinctIds = new Set<string>();
+
+  // The move is one synchronous transaction: nothing is visible to any other
+  // consumer until it commits, and returning an err rolls the whole move
+  // back. All rows are inserted before any image file moves so a rollback
+  // can't leave moved images behind.
+  const moveResult = store.withTransaction(
+    (): Result<void, { subType: string }> => {
+      store.addScannerBatch({
+        batchId: manifest.batchId,
+        electionId,
+        label: manifest.label,
+        scannerId: manifest.machineId,
+        scannerMachineType: 'central',
+        pollingPlaceId: manifest.pollingPlaceId,
+        startedAt: manifest.startedAt,
+      });
+      store.addCastVoteRecordFileRecord({
+        id: importId,
+        electionId,
+        exportedTimestamp: new Date().toISOString(),
+        filename: manifest.label,
+        isTestMode: manifest.isTestMode,
+        pollingPlaceIds: new Set([manifest.pollingPlaceId]),
+        scannerIds: new Set([manifest.machineId]),
+        batchIds: [manifest.batchId],
+        source: {
+          type: 'network',
+          scannerId: manifest.machineId,
+          batchId: manifest.batchId,
+        },
+      });
+
+      // Pass 1: insert every cast vote record; any error rolls back before
+      // any image file has moved.
+      const inserted: Array<{
+        cvrId: string;
+        isNew: boolean;
+        ballotId: BallotId;
+        data: StagedCvrData;
+      }> = [];
+      for (const { ballotId, data } of stagedRecords) {
+        const addResult = store.addCastVoteRecordFileEntry({
+          ballotId,
+          cvr: data.cvr,
+          cvrFileId: importId,
+          electionId,
+          adjudicationFlags: data.adjudicationFlags,
+        });
+        if (addResult.isErr()) {
+          return err({ subType: addResult.err().type });
+        }
+        const { cvrId, isNew } = addResult.ok();
+        inserted.push({ cvrId, isNew, ballotId, data });
+        precinctIds.add(data.cvr.precinctId);
+      }
+
+      // Pass 2: write-ins and ballot images (image files move into place
+      // by rename, so this is cheap enough to run inside the transaction)
+      for (const { cvrId, isNew, ballotId, data } of inserted) {
+        if (!isNew) continue;
+        if (data.images) {
+          for (const image of data.images) {
+            store.addBallotImageFromFile({
+              cvrId,
+              electionDefinitionId: electionDefinition.election.id,
+              imageFilePath: getStagedImagePath(
+                transferDirectoryPath,
+                ballotId,
+                image.side
+              ),
+              pageLayout: image.pageLayout,
+              side: image.side,
+            });
+          }
+        }
+        for (const writeIn of data.writeIns) {
+          store.addWriteIn({
+            castVoteRecordId: cvrId,
+            contestId: writeIn.contestId,
+            electionId,
+            optionId: writeIn.optionId,
+            isUnmarked: writeIn.isUnmarked,
+            isUndetected: false,
+            machineMarkedText: writeIn.text,
+          });
+        }
+      }
+
+      store.updateCastVoteRecordFileRecord({ id: importId, precinctIds });
+      store.deleteStagedCvrs(electionId, manifest.machineId, manifest.batchId);
+      return ok();
+    }
+  );
+
+  if (moveResult.isErr()) {
+    const { subType } = moveResult.err();
+    logger.log(LogEventId.ImportCastVoteRecordsComplete, 'system', {
+      message: `Failed to import CVR transfer of batch ${manifest.batchId} from scanner ${manifest.machineId}: ${subType}.`,
+      disposition: 'failure',
+      scannerMachineId: manifest.machineId,
+      batchId: manifest.batchId,
+      error: subType,
+    });
+    return err({ type: 'import-failed', subType });
+  }
+
+  await fs.rm(transferDirectoryPath, { recursive: true, force: true });
+  const cvrCount = stagedRecords.length;
+  debug(
+    'Imported %d CVRs from scanner %s batch %s',
+    cvrCount,
+    manifest.machineId,
+    manifest.batchId
+  );
+  logger.log(LogEventId.ImportCastVoteRecordsComplete, 'system', {
+    message: `Imported ${cvrCount} cast vote records from scanner ${manifest.machineId}, batch ${manifest.batchId}, over the network.`,
+    disposition: 'success',
+    scannerMachineId: manifest.machineId,
+    batchId: manifest.batchId,
+    cvrCount,
+  });
+  return ok({ cvrCount });
+}

--- a/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
+++ b/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
@@ -1,0 +1,751 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import * as fs from 'node:fs/promises';
+import { AddressInfo } from 'node:net';
+import path from 'node:path';
+import { assert, assertDefined, err, ok } from '@votingworks/basics';
+import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
+import { readCastVoteRecordExportMetadata } from '@votingworks/backend';
+import {
+  electionPrimaryPrecinctSplitsFixtures,
+  electionTwoPartyPrimaryFixtures,
+} from '@votingworks/fixtures';
+import { LogEventId } from '@votingworks/logging';
+import { getCvrTransferUploadPath } from '@votingworks/networking';
+import {
+  BooleanEnvironmentVariableName,
+  getEntries,
+  getFeatureFlagMock,
+  openZip,
+  readEntry,
+} from '@votingworks/utils';
+import { zipFile } from '@votingworks/test-utils';
+import {
+  buildTestEnvironment,
+  configureMachine,
+  mockElectionManagerAuth,
+} from '../test/app.js';
+
+vi.setConfig({
+  testTimeout: 60_000,
+});
+
+vi.mock(import('@votingworks/auth'), async (importActual) => ({
+  ...(await importActual()),
+  authenticateArtifactUsingSignatureFile: vi.fn(),
+}));
+
+// mock SKIP_CVR_BALLOT_HASH_CHECK to allow us to use old cvr fixtures
+const featureFlagMock = getFeatureFlagMock();
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticateArtifactUsingSignatureFile).mockResolvedValue(ok());
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.SKIP_CVR_BALLOT_HASH_CHECK
+  );
+});
+
+afterEach(() => {
+  featureFlagMock.resetFeatureFlags();
+});
+
+const electionDefinition =
+  electionTwoPartyPrimaryFixtures.readElectionDefinition();
+
+const SCANNER_ID = 'CS-01';
+
+interface FixtureBatch {
+  batchId: string;
+  label: string;
+  pollingPlaceId: string;
+  startedAt: string;
+  sheetCount: number;
+  cvrs: Array<{ id: string; zip: Buffer }>;
+}
+
+/**
+ * Loads the first batch of the two-party-primary CVR export fixture as
+ * upload-ready zips, one per cast vote record.
+ */
+async function loadFixtureBatch(
+  fixtures: {
+    castVoteRecordExport: { asDirectoryPath(): string };
+  } = electionTwoPartyPrimaryFixtures
+): Promise<FixtureBatch> {
+  const exportDirectoryPath = fixtures.castVoteRecordExport.asDirectoryPath();
+  const metadata = (
+    await readCastVoteRecordExportMetadata(exportDirectoryPath)
+  ).unsafeUnwrap();
+  const batch = assertDefined(metadata.batchManifest[0]);
+
+  const cvrs: FixtureBatch['cvrs'] = [];
+  const entries = await fs.readdir(exportDirectoryPath, {
+    withFileTypes: true,
+  });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const castVoteRecordDirectoryPath = path.join(
+      exportDirectoryPath,
+      entry.name
+    );
+    const report = JSON.parse(
+      await fs.readFile(
+        path.join(castVoteRecordDirectoryPath, 'cast-vote-record-report.json'),
+        'utf-8'
+      )
+    ) as { CVR: Array<{ BatchId: string }> };
+    if (assertDefined(report.CVR[0]).BatchId !== batch.id) continue;
+
+    const files: Record<string, Buffer> = {};
+    for (const fileName of await fs.readdir(castVoteRecordDirectoryPath)) {
+      files[fileName] = await fs.readFile(
+        path.join(castVoteRecordDirectoryPath, fileName)
+      );
+    }
+    cvrs.push({ id: entry.name, zip: await zipFile(files) });
+  }
+
+  return {
+    batchId: batch.id,
+    label: batch.label,
+    pollingPlaceId: batch.pollingPlaceId,
+    startedAt: batch.startTime,
+    sheetCount: cvrs.length,
+    cvrs,
+  };
+}
+
+/** Re-packs a fixture zip after letting `mutate` alter its files. */
+type ZipFiles = Record<string, Buffer>;
+
+async function rezip(
+  zip: Buffer,
+  mutate: (files: ZipFiles) => ZipFiles
+): Promise<Buffer> {
+  const files: ZipFiles = {};
+  for (const entry of getEntries(await openZip(zip))) {
+    files[entry.name] = await readEntry(entry);
+  }
+  return await zipFile(mutate(files));
+}
+
+function editReport(
+  files: ZipFiles,
+  edit: (report: { CVR: Array<Record<string, unknown>> }) => void
+): ZipFiles {
+  const report = JSON.parse(
+    assertDefined(files['cast-vote-record-report.json']).toString('utf-8')
+  );
+  edit(report);
+  return {
+    ...files,
+    'cast-vote-record-report.json': Buffer.from(JSON.stringify(report)),
+  };
+}
+
+/** Replaces the contents of every file whose name matches `suffix`. */
+function replaceFiles(
+  files: ZipFiles,
+  suffix: string,
+  contents: string
+): ZipFiles {
+  return Object.fromEntries(
+    Object.entries(files).map(([name, data]) => [
+      name,
+      name.endsWith(suffix) ? Buffer.from(contents) : data,
+    ])
+  );
+}
+
+async function uploadZip(
+  baseUrl: string,
+  batch: FixtureBatch,
+  cvrId: string,
+  zip: Buffer,
+  scannerId = SCANNER_ID
+): Promise<Response> {
+  return await fetch(
+    baseUrl + getCvrTransferUploadPath(scannerId, batch.batchId, cvrId),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(zip),
+    }
+  );
+}
+
+function startInput(
+  batch: FixtureBatch,
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    machineId: SCANNER_ID,
+    batchId: batch.batchId,
+    label: batch.label,
+    pollingPlaceId: batch.pollingPlaceId,
+    sheetCount: batch.sheetCount,
+    startedAt: batch.startedAt,
+    isTestMode: true,
+    codeVersion: 'dev',
+    ballotHash: electionDefinition.ballotHash,
+    ...overrides,
+  };
+}
+
+function peerBaseUrl(peerServer: { address: () => unknown }): string {
+  const { port } = peerServer.address() as AddressInfo;
+  return `http://localhost:${port}`;
+}
+
+async function uploadCvr(
+  baseUrl: string,
+  batch: FixtureBatch,
+  cvr: FixtureBatch['cvrs'][number],
+  scannerId = SCANNER_ID
+): Promise<Response> {
+  return await fetch(
+    baseUrl + getCvrTransferUploadPath(scannerId, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(cvr.zip),
+    }
+  );
+}
+
+test('transfers a batch end to end, idempotently', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  const batch = await loadFixtureBatch();
+  expect(batch.sheetCount).toBeGreaterThan(0);
+  const baseUrl = peerBaseUrl(peerServer);
+
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+
+  for (const cvr of batch.cvrs) {
+    const response = await uploadCvr(baseUrl, batch, cvr);
+    expect(response.status).toEqual(200);
+  }
+
+  // Uploaded records are staged only: nothing is visible to any other
+  // consumer (and no CVR-change triggers have fired) until finish.
+  expect(workspace.store.getCvrFiles(electionId)).toHaveLength(0);
+  expect(workspace.store.getCastVoteRecordsDataVersion(electionId)).toEqual(0);
+
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(ok({ cvrCount: batch.sheetCount }));
+
+  expect(
+    workspace.store.getCastVoteRecordsDataVersion(electionId)
+  ).toBeGreaterThan(0);
+
+  const cvrFiles = workspace.store.getCvrFiles(electionId);
+  expect(cvrFiles).toHaveLength(1);
+  expect(cvrFiles[0]).toMatchObject({
+    filename: batch.label,
+    numCvrsImported: batch.sheetCount,
+  });
+
+  // Finish is idempotent
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(ok({ cvrCount: batch.sheetCount }));
+
+  // Re-starting a completed transfer reports it as already complete
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: true })
+  );
+  expect(workspace.store.getCvrFiles(electionId)).toHaveLength(1);
+});
+
+test('uploads may arrive in any order and be repeated', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+  // Reverse order, with the first few sent twice (e.g. a retried upload
+  // whose acknowledgment was lost)
+  const uploads = [...batch.cvrs].reverse().concat(batch.cvrs.slice(0, 3));
+  for (const cvr of uploads) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+  expect(
+    workspace.store.getStagedCvrCount(electionId, SCANNER_ID, batch.batchId)
+  ).toEqual(batch.sheetCount);
+
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(ok({ cvrCount: batch.sheetCount }));
+  expect(workspace.store.getCvrFiles(electionId)[0]?.numCvrsImported).toEqual(
+    batch.sheetCount
+  );
+});
+
+test('an interrupted transfer resumes and completes', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+  const half = Math.floor(batch.cvrs.length / 2);
+  for (const cvr of batch.cvrs.slice(0, half)) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+
+  // Finishing early reports how many records are missing
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(
+    err({
+      type: 'sheet-count-mismatch',
+      expected: batch.sheetCount,
+      received: half,
+    })
+  );
+  expect(workspace.store.getCvrFiles(electionId)).toHaveLength(0);
+
+  // "Restart": start again, re-send everything (overwrites are fine)
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+  for (const cvr of batch.cvrs) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(ok({ cvrCount: batch.sheetCount }));
+});
+
+test('startCvrTransfer rejects incompatible scanners', async () => {
+  const { apiClient, auth, peerApiClient } = buildTestEnvironment();
+  const batch = await loadFixtureBatch();
+
+  // Host not configured yet
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    err({ type: 'host-unconfigured' })
+  );
+
+  await configureMachine(apiClient, auth, electionDefinition);
+
+  expect(
+    await peerApiClient.startCvrTransfer(
+      startInput(batch, { codeVersion: 'some-other-version' })
+    )
+  ).toEqual(err({ type: 'code-version-mismatch' }));
+
+  expect(
+    await peerApiClient.startCvrTransfer(
+      startInput(batch, { ballotHash: 'some-other-hash' })
+    )
+  ).toEqual(err({ type: 'ballot-hash-mismatch' }));
+
+  expect(
+    await peerApiClient.startCvrTransfer(
+      startInput(batch, { machineId: '../escape' })
+    )
+  ).toEqual(err({ type: 'scanner-unconfigured' }));
+});
+
+test('startCvrTransfer enforces the test/official mode lock', async () => {
+  const { apiClient, auth, peerApiClient, peerServer } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+  for (const cvr of batch.cvrs) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+  (
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).unsafeUnwrap();
+
+  // The election is now locked to test mode; an official transfer is refused
+  expect(
+    await peerApiClient.startCvrTransfer(
+      startInput(batch, { batchId: 'another-batch', isTestMode: false })
+    )
+  ).toEqual(err({ type: 'invalid-mode', currentMode: 'test' }));
+});
+
+test('upload endpoint rejects invalid requests', async () => {
+  const { apiClient, auth, peerApiClient, peerServer } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+  const cvr = assertDefined(batch.cvrs[0]);
+
+  // Upload before the transfer has started
+  expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(400);
+
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+
+  // Not a zip
+  const badBody = await fetch(
+    baseUrl + getCvrTransferUploadPath(SCANNER_ID, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(Buffer.from('not a zip')),
+    }
+  );
+  expect(badBody.status).toEqual(400);
+
+  // Wrong content type
+  const wrongType = await fetch(
+    baseUrl + getCvrTransferUploadPath(SCANNER_ID, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: 'not a zip',
+    }
+  );
+  expect(wrongType.status).toEqual(400);
+
+  // Zip entry with an unsafe (path-traversing) name. Note jszip sanitizes
+  // leading `../` on load, so use a nested path to exercise the guard.
+  const evilResponse = await fetch(
+    baseUrl + getCvrTransferUploadPath(SCANNER_ID, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(await zipFile({ 'sub/evil.json': '{}' })),
+    }
+  );
+  expect(evilResponse.status).toEqual(400);
+});
+
+test('rejects invalid cast vote records at upload time', async () => {
+  const { apiClient, auth, peerApiClient, peerServer } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+  const cvr = assertDefined(batch.cvrs[0]);
+
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+
+  // A corrupted report is rejected immediately, with a reason
+  const corruptResponse = await fetch(
+    baseUrl + getCvrTransferUploadPath(SCANNER_ID, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(
+        await zipFile({ 'cast-vote-record-report.json': 'not json' })
+      ),
+    }
+  );
+  expect(corruptResponse.status).toEqual(400);
+  expect(await corruptResponse.json()).toEqual({
+    error: expect.stringContaining('invalid cast vote record'),
+  });
+
+  // A valid record uploaded under the wrong id is rejected
+  const mismatchResponse = await fetch(
+    baseUrl +
+      getCvrTransferUploadPath(SCANNER_ID, batch.batchId, 'some-other-id'),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(cvr.zip),
+    }
+  );
+  expect(mismatchResponse.status).toEqual(400);
+  expect(await mismatchResponse.json()).toEqual({
+    error: 'cast vote record id mismatch',
+  });
+});
+
+test('finishCvrTransfer without a started transfer is not found', async () => {
+  const { apiClient, auth, peerApiClient } = buildTestEnvironment();
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: 'no-such-batch',
+    })
+  ).toEqual(err({ type: 'transfer-not-found' }));
+
+  await configureMachine(apiClient, auth, electionDefinition);
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: 'no-such-batch',
+    })
+  ).toEqual(err({ type: 'transfer-not-found' }));
+});
+
+test('rejects unsafe ids in the upload path and finish input', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, peerLogger } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+  const cvr = assertDefined(batch.cvrs[0]);
+
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+  const response = await uploadZip(baseUrl, batch, 'a b', cvr.zip);
+  expect(response.status).toEqual(400);
+  expect(await response.json()).toEqual({ error: 'invalid id' });
+  expect(peerLogger.log).toHaveBeenCalledWith(
+    LogEventId.AdminNetworkStatus,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      castVoteRecordId: 'a b',
+      error: 'invalid id',
+    })
+  );
+
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: 'a b',
+      batchId: batch.batchId,
+    })
+  ).toEqual(err({ type: 'transfer-not-found' }));
+  expect(peerLogger.log).toHaveBeenCalledWith(
+    LogEventId.AdminNetworkStatus,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      error: 'transfer-not-found',
+    })
+  );
+});
+
+test('rejects records that fail election validation or image verification', async () => {
+  const { apiClient, auth, peerApiClient, peerServer } = buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+
+  const cvr = assertDefined(batch.cvrs[0]);
+  const badStyle = await rezip(cvr.zip, (files) =>
+    editReport(files, (report) => {
+      assertDefined(report.CVR[0])['BallotStyleId'] = 'no-such-ballot-style';
+    })
+  );
+  const badStyleResponse = await uploadZip(baseUrl, batch, cvr.id, badStyle);
+  expect(badStyleResponse.status).toEqual(400);
+  expect(await badStyleResponse.json()).toEqual({
+    error: 'invalid cast vote record (ballot-style-not-found)',
+  });
+
+  // Ballot images are only read (and so verified against the hashes in the
+  // report) for records that need adjudication, so try each record until one
+  // trips the check. Records that don't need adjudication are accepted.
+  const results = new Set<string>();
+  for (const candidate of batch.cvrs) {
+    const badImage = await rezip(candidate.zip, (files) =>
+      replaceFiles(files, '.jpg', 'not an image')
+    );
+    const response = await uploadZip(baseUrl, batch, candidate.id, badImage);
+    if (response.status === 200) {
+      results.add('accepted');
+      continue;
+    }
+    expect(response.status).toEqual(400);
+    const { error } = (await response.json()) as { error: string };
+    results.add(error);
+    if (error === 'could not verify a ballot image') break;
+  }
+  expect(results).toContain('could not verify a ballot image');
+  expect([...results]).toEqual(
+    expect.arrayContaining([expect.stringMatching(/accepted|could not verify/)])
+  );
+});
+
+test('verifies and stages layout files for hand-marked paper ballots', async () => {
+  const hmpbElectionDefinition =
+    electionPrimaryPrecinctSplitsFixtures.readElectionDefinition();
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, hmpbElectionDefinition);
+  const batch = await loadFixtureBatch(electionPrimaryPrecinctSplitsFixtures);
+  const baseUrl = peerBaseUrl(peerServer);
+  expect(
+    await peerApiClient.startCvrTransfer(
+      startInput(batch, { ballotHash: hmpbElectionDefinition.ballotHash })
+    )
+  ).toEqual(ok({ alreadyComplete: false }));
+
+  // As with images, layouts are only read for records needing adjudication.
+  let verifiedLayout = false;
+  for (const candidate of batch.cvrs) {
+    const badLayout = await rezip(candidate.zip, (files) =>
+      replaceFiles(files, '.layout.json', '{}')
+    );
+    const response = await uploadZip(baseUrl, batch, candidate.id, badLayout);
+    if (response.status === 200) continue;
+    expect(response.status).toEqual(400);
+    expect(await response.json()).toEqual({
+      error: 'could not verify a layout file',
+    });
+    verifiedLayout = true;
+    break;
+  }
+  expect(verifiedLayout).toEqual(true);
+
+  // The pristine records, layouts included, are accepted and imported
+  for (const cvr of batch.cvrs) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(ok({ cvrCount: batch.sheetCount }));
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  expect(workspace.store.getCvrFiles(electionId)[0]?.numCvrsImported).toEqual(
+    batch.sheetCount
+  );
+});
+
+async function importFixtureExportFromUsb(
+  apiClient: Awaited<ReturnType<typeof buildTestEnvironment>>['apiClient'],
+  auth: Awaited<ReturnType<typeof buildTestEnvironment>>['auth']
+): Promise<void> {
+  mockElectionManagerAuth(auth, electionDefinition.election);
+  (
+    await apiClient.addCastVoteRecordFile({
+      path: electionTwoPartyPrimaryFixtures.castVoteRecordExport.asDirectoryPath(),
+    })
+  ).unsafeUnwrap();
+}
+
+test('a network transfer of a batch already imported from USB adds no ballots', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  await importFixtureExportFromUsb(apiClient, auth);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  const ballotCountBefore = await apiClient.getTotalBallotCount();
+
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+  for (const cvr of batch.cvrs) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(ok({ cvrCount: batch.sheetCount }));
+
+  expect(workspace.store.getCvrFiles(electionId)).toHaveLength(2);
+  expect(await apiClient.getTotalBallotCount()).toEqual(ballotCountBefore);
+});
+
+test('finish fails and rolls back when a record conflicts with an imported ballot', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace, peerLogger } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  await importFixtureExportFromUsb(apiClient, auth);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+  const [conflicting, ...rest] = batch.cvrs;
+  assert(conflicting);
+  // Same ballot id as the USB import, different votes
+  const conflictingZip = await rezip(conflicting.zip, (files) =>
+    editReport(files, (report) => {
+      for (const snapshot of assertDefined(report.CVR[0])[
+        'CVRSnapshot'
+      ] as Array<{
+        CVRContest: Array<{ CVRContestSelection?: unknown[] }>;
+      }>) {
+        const contest = snapshot.CVRContest.find(
+          (c) => (c.CVRContestSelection ?? []).length > 0
+        );
+        if (contest) contest.CVRContestSelection = [];
+      }
+    })
+  );
+  expect(
+    (await uploadZip(baseUrl, batch, conflicting.id, conflictingZip)).status
+  ).toEqual(200);
+  for (const cvr of rest) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(
+    err({
+      type: 'import-failed',
+      subType: 'ballot-id-already-exists-with-different-data',
+    })
+  );
+  expect(peerLogger.log).toHaveBeenCalledWith(
+    LogEventId.ImportCastVoteRecordsComplete,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      error: 'ballot-id-already-exists-with-different-data',
+    })
+  );
+  // Nothing from the transfer became visible
+  expect(workspace.store.getCvrFiles(electionId)).toHaveLength(1);
+});

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import express, { Application } from 'express';
 import * as grout from '@votingworks/grout';
 import {
@@ -18,7 +19,10 @@ import {
 } from '@votingworks/types';
 import { BaseLogger, LogEventId } from '@votingworks/logging';
 import type {
+  CvrTransferManifest,
+  FinishCvrTransferError,
   RegisterScannerError,
+  StartCvrTransferError,
   VxAdminHostApi,
 } from '@votingworks/networking';
 import { getMachineConfig } from './machine_config.js';
@@ -39,6 +43,12 @@ import {
   getBallotImageBuffer,
   getBallotImageMetadata,
 } from './util/adjudication.js';
+import {
+  finishCvrTransfer,
+  NetworkCvrImportQueue,
+  receiveCvrTransferUpload,
+  startCvrTransfer,
+} from './network_cvr_transfer.js';
 
 const debug = rootDebug.extend('peer-app');
 
@@ -53,6 +63,7 @@ export interface PeerAppContext {
 
 function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
   const { store } = workspace;
+  const importQueue = new NetworkCvrImportQueue();
 
   // Client adjudication operations are only served while the host has client
   // adjudication enabled and is the sole host on the network. Enforced
@@ -231,6 +242,19 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       });
     },
 
+    startCvrTransfer(
+      input: CvrTransferManifest & { codeVersion: string; ballotHash: string }
+    ): Promise<Result<{ alreadyComplete: boolean }, StartCvrTransferError>> {
+      return startCvrTransfer({ workspace, logger }, input);
+    },
+
+    finishCvrTransfer(input: {
+      machineId: string;
+      batchId: string;
+    }): Promise<Result<{ cvrCount: number }, FinishCvrTransferError>> {
+      return finishCvrTransfer({ workspace, logger, importQueue }, input);
+    },
+
     getElectionPackageHash(): Optional<string> {
       const currentElectionId = store.getCurrentElectionId();
       if (!currentElectionId) return undefined;
@@ -376,6 +400,44 @@ const VALID_SIDES: ReadonlySet<string> = new Set<Side>(['front', 'back']);
 export function buildPeerApp(context: PeerAppContext): Application {
   const app: Application = express();
   const { store } = context.workspace;
+
+  // Per-CVR upload endpoint for network CVR transfers. Raw (non-grout)
+  // because the body is a zip of the cast vote record's file set.
+  app.post(
+    '/api/cvr-transfer/:scannerId/:batchId/:cvrId',
+    express.raw({ type: 'application/zip', limit: '20mb' }),
+    async (req, res) => {
+      const { scannerId, batchId, cvrId } = req.params;
+      if (!Buffer.isBuffer(req.body)) {
+        res
+          .status(400)
+          .json({ error: 'expected an application/zip request body' });
+        return;
+      }
+      const result = await receiveCvrTransferUpload(
+        { workspace: context.workspace },
+        {
+          scannerId,
+          batchId,
+          castVoteRecordId: cvrId,
+          zipData: req.body,
+        }
+      );
+      if (result.isErr()) {
+        context.logger.log(LogEventId.AdminNetworkStatus, 'system', {
+          message: `Rejected cast vote record ${cvrId} of batch ${batchId} from scanner ${scannerId}: ${result.err()}.`,
+          disposition: 'failure',
+          scannerMachineId: scannerId,
+          batchId,
+          castVoteRecordId: cvrId,
+          error: result.err(),
+        });
+        res.status(400).json({ error: result.err() });
+        return;
+      }
+      res.json({ success: true });
+    }
+  );
 
   // Binary ballot image endpoint — serves raw image bytes
   app.get('/api/ballot-image/:cvrId/:side', async (req, res) => {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -59,7 +59,13 @@ import {
   isCombinedBallotPrimary,
   PartyId,
 } from '@votingworks/types';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { copyFile, mkdir, rm } from 'node:fs/promises';
 import { dirname, join, sep } from 'node:path';
 import { Buffer } from 'node:buffer';
@@ -1175,21 +1181,32 @@ export class Store implements BaseStore {
     isTestMode,
     filename,
     exportedTimestamp,
-    sha256Hash,
     scannerIds,
     pollingPlaceIds,
     batchIds,
+    source,
   }: {
     id: Id;
     electionId: Id;
     isTestMode: boolean;
     filename: string;
     exportedTimestamp: Iso8601Timestamp;
-    sha256Hash: string;
     scannerIds: Set<string>;
     pollingPlaceIds: Set<string>;
     batchIds: string[];
+    /**
+     * Where the file came from. A USB export carries the hash of its signed
+     * metadata, which detects re-imports of the same export; a network
+     * transfer has no export signature and is deduplicated by (scanner,
+     * batch) instead.
+     */
+    source:
+      | { type: 'usb'; sha256Hash: string }
+      | { type: 'network'; scannerId: string; batchId: string };
   }): void {
+    if (source.type === 'usb') {
+      assert(source.sha256Hash.length > 0, 'USB imports must record a hash');
+    }
     this.client.run(
       `
         insert into cvr_files (
@@ -1202,9 +1219,12 @@ export class Store implements BaseStore {
           scanner_ids,
           polling_place_ids,
           batch_ids,
-          sha256_hash
+          sha256_hash,
+          source,
+          network_scanner_id,
+          network_batch_id
         ) values (
-          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         )
       `,
       id,
@@ -1216,8 +1236,171 @@ export class Store implements BaseStore {
       JSON.stringify([...scannerIds]),
       JSON.stringify([...pollingPlaceIds]),
       JSON.stringify(batchIds),
-      sha256Hash
+      source.type === 'usb' ? source.sha256Hash : null,
+      source.type,
+      source.type === 'network' ? source.scannerId : null,
+      source.type === 'network' ? source.batchId : null
     );
+  }
+
+  /**
+   * Stages (or replaces) one validated cast vote record for a pending import,
+   * keyed by the scanner and batch it belongs to. Staged records are
+   * invisible to every other consumer until the import is finalized and they
+   * move into the real tables.
+   */
+  upsertStagedCvr({
+    electionId,
+    scannerId,
+    batchId,
+    ballotId,
+    cvrData,
+  }: {
+    electionId: Id;
+    scannerId: string;
+    batchId: string;
+    ballotId: string;
+    cvrData: string;
+  }): void {
+    this.client.run(
+      `
+        insert into cvrs_staging (
+          election_id, scanner_id, batch_id, ballot_id, cvr_data
+        ) values (?, ?, ?, ?, ?)
+        on conflict (election_id, scanner_id, batch_id, ballot_id)
+        do update set cvr_data = excluded.cvr_data
+      `,
+      electionId,
+      scannerId,
+      batchId,
+      ballotId,
+      cvrData
+    );
+  }
+
+  /**
+   * Counts the staged cast vote records for one pending import.
+   */
+  getStagedCvrCount(
+    electionId: Id,
+    scannerId: string,
+    batchId: string
+  ): number {
+    const row = this.client.one(
+      `
+        select count(*) as count from cvrs_staging
+        where election_id = ? and scanner_id = ? and batch_id = ?
+      `,
+      electionId,
+      scannerId,
+      batchId
+    ) as { count: number };
+    return row.count;
+  }
+
+  /**
+   * Returns the staged cast vote records for one pending import.
+   */
+  getStagedCvrs(
+    electionId: Id,
+    scannerId: string,
+    batchId: string
+  ): Array<{ ballotId: string; cvrData: string }> {
+    return this.client.all(
+      `
+        select ballot_id as ballotId, cvr_data as cvrData
+        from cvrs_staging
+        where election_id = ? and scanner_id = ? and batch_id = ?
+        order by ballot_id
+      `,
+      electionId,
+      scannerId,
+      batchId
+    ) as Array<{ ballotId: string; cvrData: string }>;
+  }
+
+  /**
+   * Deletes one pending import's staged cast vote records.
+   */
+  deleteStagedCvrs(electionId: Id, scannerId: string, batchId: string): void {
+    this.client.run(
+      `
+        delete from cvrs_staging
+        where election_id = ? and scanner_id = ? and batch_id = ?
+      `,
+      electionId,
+      scannerId,
+      batchId
+    );
+  }
+
+  /**
+   * Like {@link addBallotImage}, but moves an already-written (and already
+   * hash-verified) image file into place instead of writing a buffer —
+   * cheap enough to run inside the finalize transaction.
+   */
+  addBallotImageFromFile({
+    cvrId,
+    electionDefinitionId,
+    imageFilePath,
+    pageLayout,
+    side,
+  }: {
+    cvrId: Id;
+    electionDefinitionId: string;
+    imageFilePath: string;
+    pageLayout?: BallotPageLayout;
+    side: Side;
+  }): void {
+    const ballotImagePath = this.getBallotImageFilePath(
+      electionDefinitionId,
+      cvrId,
+      side
+    );
+    mkdirSync(dirname(ballotImagePath), { recursive: true });
+    renameSync(imageFilePath, ballotImagePath);
+    this.client.run(
+      `
+      insert into ballot_images (
+        cvr_id,
+        side,
+        layout
+      ) values (
+        ?, ?, ?
+      )
+    `,
+      cvrId,
+      side,
+      pageLayout ? JSON.stringify(pageLayout) : null
+    );
+  }
+
+  /**
+   * Looks up the import record for a network CVR transfer from the given
+   * scanner and batch, if one exists. Because a transfer's import is a
+   * single atomic transaction, an existing record is always a completed
+   * import.
+   */
+  getNetworkCvrImportId(
+    electionId: Id,
+    scannerId: string,
+    batchId: string
+  ): Optional<Id> {
+    const row = this.client.one(
+      `
+        select id
+        from cvr_files
+        where
+          election_id = ?
+          and source = 'network'
+          and network_scanner_id = ?
+          and network_batch_id = ?
+      `,
+      electionId,
+      scannerId,
+      batchId
+    ) as { id: Id } | undefined;
+    return row?.id;
   }
 
   updateCastVoteRecordFileRecord({
@@ -1713,7 +1896,7 @@ export class Store implements BaseStore {
       pollingPlaceIds: string;
       precinctIds: string;
       scannerIds: string;
-      sha256Hash: string;
+      sha256Hash: string | null;
       createdAt: string;
     }>;
     debug('queried database for cvr file list');

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1880,6 +1880,7 @@ export class Store implements BaseStore {
         precinct_ids as precinctIds,
         scanner_ids as scannerIds,
         sha256_hash as sha256Hash,
+        source,
         datetime(cvr_files.created_at, 'localtime') as createdAt
       from cvr_files
       left join cvr_file_entries on cvr_file_entries.cvr_file_id = cvr_files.id
@@ -1897,6 +1898,7 @@ export class Store implements BaseStore {
       precinctIds: string;
       scannerIds: string;
       sha256Hash: string | null;
+      source: 'usb' | 'network';
       createdAt: string;
     }>;
     debug('queried database for cvr file list');
@@ -1907,6 +1909,7 @@ export class Store implements BaseStore {
           id: result.id,
           electionId,
           sha256Hash: result.sha256Hash,
+          source: result.source,
           filename: result.filename,
           exportTimestamp: convertSqliteTimestampToIso8601(
             result.exportTimestamp

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -154,6 +154,8 @@ export interface CastVoteRecordFileRecord {
   readonly scannerIds: string[];
   /** Null for imports received over the network. */
   readonly sha256Hash: string | null;
+  /** How the import arrived: loaded from a USB drive or sent by a scanner. */
+  readonly source: 'usb' | 'network';
   readonly createdAt: Iso8601Timestamp;
 }
 
@@ -171,6 +173,7 @@ export const CastVoteRecordFileRecordSchema: z.ZodSchema<CastVoteRecordFileRecor
     precinctIds: z.array(z.string()),
     scannerIds: z.array(z.string()),
     sha256Hash: z.string().nonempty().nullable(),
+    source: z.union([z.literal('usb'), z.literal('network')]),
     createdAt: Iso8601TimestampSchema,
   });
 

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -152,7 +152,8 @@ export interface CastVoteRecordFileRecord {
   readonly pollingPlaceIds: string[];
   readonly precinctIds: string[];
   readonly scannerIds: string[];
-  readonly sha256Hash: string;
+  /** Null for imports received over the network. */
+  readonly sha256Hash: string | null;
   readonly createdAt: Iso8601Timestamp;
 }
 
@@ -169,7 +170,7 @@ export const CastVoteRecordFileRecordSchema: z.ZodSchema<CastVoteRecordFileRecor
     pollingPlaceIds: z.array(z.string()),
     precinctIds: z.array(z.string()),
     scannerIds: z.array(z.string()),
-    sha256Hash: z.string().nonempty(),
+    sha256Hash: z.string().nonempty().nullable(),
     createdAt: Iso8601TimestampSchema,
   });
 

--- a/apps/admin/backend/test/backup.ts
+++ b/apps/admin/backend/test/backup.ts
@@ -111,10 +111,10 @@ export function addCvrWithBallotImage(
     isTestMode: false,
     filename: 'cvrs.jsonl',
     exportedTimestamp: new Date().toISOString(),
-    sha256Hash: 'hash',
     scannerIds: new Set(['scanner-1']),
     pollingPlaceIds: new Set(),
     batchIds: [batchId],
+    source: { type: 'usb', sha256Hash: 'hash' },
   });
   const result = store.addCastVoteRecordFileEntry({
     electionId,

--- a/apps/admin/backend/test/mock_cvr_file.ts
+++ b/apps/admin/backend/test/mock_cvr_file.ts
@@ -82,10 +82,10 @@ export function addMockCvrFileToStore({
     isTestMode: true,
     filename: 'mock-cvr-file',
     exportedTimestamp: (exportedTimestamp || new Date()).toISOString(),
-    sha256Hash: 'mock-hash',
     scannerIds,
     pollingPlaceIds: new Set(pollingPlaceId),
     batchIds: mockCastVoteRecordFile.map((f) => f.batchId),
+    source: { type: 'usb', sha256Hash: 'mock-hash' },
   });
 
   const { electionDefinition } = assertDefined(store.getElection(electionId));

--- a/apps/admin/frontend/src/api.ts
+++ b/apps/admin/frontend/src/api.ts
@@ -659,7 +659,12 @@ export const getDiskSpaceSummary = {
 
 // Grouped Invalidations
 
-function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
+function invalidateCastVoteRecordQueries(
+  queryClient: QueryClient,
+  {
+    adjudicationQueueRefetchType = 'active',
+  }: { adjudicationQueueRefetchType?: 'active' | 'none' } = {}
+) {
   return Promise.all([
     // cast vote record endpoints
     queryClient.invalidateQueries(getCastVoteRecordFileMode.queryKey()),
@@ -677,7 +682,9 @@ function invalidateCastVoteRecordQueries(queryClient: QueryClient) {
     queryClient.resetQueries(getLiveResultsReportingUrl.queryKey()),
 
     // ballot adjudication queues
-    queryClient.invalidateQueries(getBallotAdjudicationQueue.queryKey()),
+    queryClient.invalidateQueries(getBallotAdjudicationQueue.queryKey(), {
+      refetchType: adjudicationQueueRefetchType,
+    }),
     queryClient.invalidateQueries(
       getBallotAdjudicationQueueMetadata.queryKey()
     ),
@@ -801,6 +808,34 @@ export const deleteCvrFile = {
     });
   },
 } as const;
+
+export const getCastVoteRecordsDataVersion = {
+  queryKey(): QueryKey {
+    return ['getCastVoteRecordsDataVersion'];
+  },
+  usePollingQuery() {
+    const apiClient = useApiClient();
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getCastVoteRecordsDataVersion(),
+      DEFAULT_QUERY_REFETCH_INTERVAL
+    );
+  },
+} as const;
+
+/**
+ * Invalidates everything derived from cast vote records. Exposed for the
+ * refresher that reacts to server-side (network) imports, which have no
+ * frontend mutation to hang invalidation on.
+ */
+export async function invalidateCastVoteRecordDerivedQueries(
+  queryClient: QueryClient
+): Promise<void> {
+  await invalidateCastVoteRecordQueries(queryClient, {
+    adjudicationQueueRefetchType: 'none',
+  });
+  await invalidateWriteInQueries(queryClient);
+}
 
 export const addCastVoteRecordFile = {
   useMutation() {

--- a/apps/admin/frontend/src/components/app_routes.tsx
+++ b/apps/admin/frontend/src/components/app_routes.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import React, { useContext } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import {
   SetupCardReaderPage,
@@ -42,6 +42,7 @@ import { AdjudicationStartScreen } from '../screens/adjudication_start_screen.js
 import { BallotAdjudicationScreenWrapper as BallotAdjudicationScreen } from '../screens/ballot_adjudication_screen.js';
 import { WriteInCandidatesScreen } from '../screens/write_in_candidates_screen.js';
 import { BackupsScreen } from '../screens/backups_screen.js';
+import { CvrDataRefresher } from './cvr_data_refresher.js';
 
 export function AppRoutes(): JSX.Element | null {
   const { electionDefinition, auth } = useContext(AppContext);
@@ -136,74 +137,77 @@ export function AppRoutes(): JSX.Element | null {
   // Election manager UI
   assert(isElectionManagerAuth(auth));
   return (
-    <Switch>
-      <Route exact path={routerPaths.election}>
-        <ElectionScreen />
-      </Route>
-      <Route exact path={routerPaths.ballotAdjudication}>
-        <BallotAdjudicationScreen />
-      </Route>
-      <Route exact path={routerPaths.adjudicationCandidates}>
-        <WriteInCandidatesScreen />
-      </Route>
-      <Route path={routerPaths.adjudication}>
-        <AdjudicationStartScreen />
-      </Route>
-      <Route
-        path={routerPaths.tallyManualForm({
-          precinctId: ':precinctId',
-          ballotStyleGroupId: ':ballotStyleGroupId',
-          votingMethod: ':votingMethod' as ManualResultsVotingMethod,
-        })}
-      >
-        <ManualTalliesFormScreen />
-      </Route>
-      <Route path={routerPaths.tally}>
-        <TallyScreen />
-      </Route>
-      <Route exact path={routerPaths.reports}>
-        <ReportsScreen />
-      </Route>
-      <Route exact path={routerPaths.tallyReportBuilder}>
-        <TallyReportBuilder />
-      </Route>
-      <Route exact path={routerPaths.tallyFullReport}>
-        <FullElectionTallyReportScreen />
-      </Route>
-      <Route exact path={routerPaths.tallySinglePrecinctReport}>
-        <SinglePrecinctTallyReportScreen />
-      </Route>
-      <Route exact path={routerPaths.tallyAllPrecinctsReport}>
-        <AllPrecinctsTallyReportScreen />
-      </Route>
-      <Route exact path={routerPaths.ballotCountReportBuilder}>
-        <BallotCountReportBuilder />
-      </Route>
-      <Route exact path={routerPaths.ballotCountReportPrecinct}>
-        <PrecinctBallotCountReport />
-      </Route>
-      <Route exact path={routerPaths.ballotCountReportVotingMethod}>
-        <VotingMethodBallotCountReport />
-      </Route>
-      <Route exact path={[routerPaths.tallyWriteInReport]}>
-        <TallyWriteInReportScreen />
-      </Route>
-      <Route exact path={routerPaths.writeInImageReport}>
-        <WriteInImageReportScreen />
-      </Route>
-      <Route exact path={routerPaths.voterTurnoutReport}>
-        <VoterTurnoutReportScreen />
-      </Route>
-      <Route exact path={routerPaths.sendTallyReports}>
-        <SendTallyReportsScreen />
-      </Route>
-      <Route exact path={routerPaths.settings}>
-        <SettingsScreen />
-      </Route>
-      <Route exact path={routerPaths.hardwareDiagnostics}>
-        <DiagnosticsScreen />
-      </Route>
-      <Redirect to={routerPaths.election} />
-    </Switch>
+    <React.Fragment>
+      <CvrDataRefresher />
+      <Switch>
+        <Route exact path={routerPaths.election}>
+          <ElectionScreen />
+        </Route>
+        <Route exact path={routerPaths.ballotAdjudication}>
+          <BallotAdjudicationScreen />
+        </Route>
+        <Route exact path={routerPaths.adjudicationCandidates}>
+          <WriteInCandidatesScreen />
+        </Route>
+        <Route path={routerPaths.adjudication}>
+          <AdjudicationStartScreen />
+        </Route>
+        <Route
+          path={routerPaths.tallyManualForm({
+            precinctId: ':precinctId',
+            ballotStyleGroupId: ':ballotStyleGroupId',
+            votingMethod: ':votingMethod' as ManualResultsVotingMethod,
+          })}
+        >
+          <ManualTalliesFormScreen />
+        </Route>
+        <Route path={routerPaths.tally}>
+          <TallyScreen />
+        </Route>
+        <Route exact path={routerPaths.reports}>
+          <ReportsScreen />
+        </Route>
+        <Route exact path={routerPaths.tallyReportBuilder}>
+          <TallyReportBuilder />
+        </Route>
+        <Route exact path={routerPaths.tallyFullReport}>
+          <FullElectionTallyReportScreen />
+        </Route>
+        <Route exact path={routerPaths.tallySinglePrecinctReport}>
+          <SinglePrecinctTallyReportScreen />
+        </Route>
+        <Route exact path={routerPaths.tallyAllPrecinctsReport}>
+          <AllPrecinctsTallyReportScreen />
+        </Route>
+        <Route exact path={routerPaths.ballotCountReportBuilder}>
+          <BallotCountReportBuilder />
+        </Route>
+        <Route exact path={routerPaths.ballotCountReportPrecinct}>
+          <PrecinctBallotCountReport />
+        </Route>
+        <Route exact path={routerPaths.ballotCountReportVotingMethod}>
+          <VotingMethodBallotCountReport />
+        </Route>
+        <Route exact path={[routerPaths.tallyWriteInReport]}>
+          <TallyWriteInReportScreen />
+        </Route>
+        <Route exact path={routerPaths.writeInImageReport}>
+          <WriteInImageReportScreen />
+        </Route>
+        <Route exact path={routerPaths.voterTurnoutReport}>
+          <VoterTurnoutReportScreen />
+        </Route>
+        <Route exact path={routerPaths.sendTallyReports}>
+          <SendTallyReportsScreen />
+        </Route>
+        <Route exact path={routerPaths.settings}>
+          <SettingsScreen />
+        </Route>
+        <Route exact path={routerPaths.hardwareDiagnostics}>
+          <DiagnosticsScreen />
+        </Route>
+        <Redirect to={routerPaths.election} />
+      </Switch>
+    </React.Fragment>
   );
 }

--- a/apps/admin/frontend/src/components/cvr_data_refresher.test.tsx
+++ b/apps/admin/frontend/src/components/cvr_data_refresher.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { ApiMock, createApiMock } from '../../test/helpers/mock_api_client.js';
+import { renderInAppContext } from '../../test/render_in_app_context.js';
+import { createQueryClient } from '../api.js';
+import { CvrDataRefresher } from './cvr_data_refresher.js';
+import { DEFAULT_QUERY_REFETCH_INTERVAL } from '../utils/globals.js';
+
+let apiMock: ApiMock;
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createApiMock();
+  queryClient = createQueryClient();
+});
+
+afterEach(() => {
+  apiMock.assertComplete();
+});
+
+function isInvalidated(queryKey: unknown[]): boolean | undefined {
+  return queryClient.getQueryState(queryKey)?.isInvalidated;
+}
+
+test('marks CVR-derived queries stale when the data version changes', async () => {
+  const versionMock = apiMock.apiClient.getCastVoteRecordsDataVersion;
+  apiMock.setCastVoteRecordsDataVersion(3);
+
+  queryClient.setQueryData(['getCastVoteRecordFiles'], []);
+  queryClient.setQueryData(['getBallotAdjudicationQueue'], ['cvr-1']);
+
+  renderInAppContext(<CvrDataRefresher />, { apiMock, queryClient });
+  await vi.waitFor(() => expect(versionMock).toHaveBeenCalled());
+  vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL);
+  await vi.waitFor(() => expect(versionMock).toHaveBeenCalledTimes(2));
+
+  // Seeing the same version again is not a change
+  expect(isInvalidated(['getCastVoteRecordFiles'])).toEqual(false);
+
+  apiMock.setCastVoteRecordsDataVersion(4);
+  vi.advanceTimersByTime(DEFAULT_QUERY_REFETCH_INTERVAL);
+  await vi.waitFor(() =>
+    expect(isInvalidated(['getCastVoteRecordFiles'])).toEqual(true)
+  );
+  expect(isInvalidated(['getBallotAdjudicationQueue'])).toEqual(true);
+});

--- a/apps/admin/frontend/src/components/cvr_data_refresher.tsx
+++ b/apps/admin/frontend/src/components/cvr_data_refresher.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  getCastVoteRecordsDataVersion,
+  invalidateCastVoteRecordDerivedQueries,
+} from '../api.js';
+
+/**
+ * Refreshes cast-vote-record-derived data when it changes on the server
+ * without a frontend mutation — i.e. when a networked scanner's batch import
+ * lands. Polls the (trivially cheap) CVR data version and invalidates the
+ * derived queries when it moves. Renders nothing.
+ */
+export function CvrDataRefresher(): null {
+  const queryClient = useQueryClient();
+  const versionQuery = getCastVoteRecordsDataVersion.usePollingQuery();
+  const version = versionQuery.data;
+  const seenVersion = useRef<number>();
+
+  useEffect(() => {
+    if (version === undefined) return;
+    if (seenVersion.current !== undefined && version !== seenVersion.current) {
+      void invalidateCastVoteRecordDerivedQueries(queryClient);
+    }
+    seenVersion.current = version;
+  }, [version, queryClient]);
+
+  return null;
+}

--- a/apps/admin/frontend/src/components/cvr_data_refresher.tsx
+++ b/apps/admin/frontend/src/components/cvr_data_refresher.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useQueryChangeListener } from '@votingworks/ui';
 import {
   getCastVoteRecordsDataVersion,
   invalidateCastVoteRecordDerivedQueries,
@@ -7,23 +7,22 @@ import {
 
 /**
  * Refreshes cast-vote-record-derived data when it changes on the server
- * without a frontend mutation — i.e. when a networked scanner's batch import
+ * without a frontend mutation - i.e. when a networked scanner's batch import
  * lands. Polls the (trivially cheap) CVR data version and invalidates the
  * derived queries when it moves. Renders nothing.
  */
 export function CvrDataRefresher(): null {
   const queryClient = useQueryClient();
   const versionQuery = getCastVoteRecordsDataVersion.usePollingQuery();
-  const version = versionQuery.data;
-  const seenVersion = useRef<number>();
 
-  useEffect(() => {
-    if (version === undefined) return;
-    if (seenVersion.current !== undefined && version !== seenVersion.current) {
-      void invalidateCastVoteRecordDerivedQueries(queryClient);
-    }
-    seenVersion.current = version;
-  }, [version, queryClient]);
+  useQueryChangeListener(versionQuery, {
+    onChange: (_newVersion, previousVersion) => {
+      // On the first observed version there is nothing to refresh yet
+      if (previousVersion !== undefined) {
+        void invalidateCastVoteRecordDerivedQueries(queryClient);
+      }
+    },
+  });
 
   return null;
 }

--- a/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/ballot_adjudication_screen.test.tsx
@@ -750,6 +750,7 @@ test('confirmation modal back returns and accept anyway resolves and navigates t
       numCvrsImported: 1,
       pollingPlaceIds: ['precinct-1-polling-place'],
       precinctIds: ['precinct-1'],
+      source: 'usb',
       scannerIds: ['scanner-1'],
       sha256Hash: 'hash',
       createdAt: new Date().toISOString(),

--- a/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/cvrs_screen.test.tsx
@@ -367,6 +367,7 @@ function mockCvrFile(
     numCvrsImported: 1,
     precinctIds: [precinct1.id],
     sha256Hash: 'hash',
+    source: 'usb',
     ...file,
   };
 }

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
@@ -31,12 +31,16 @@ test('renders import details when non-empty', () => {
           id: 'one',
           exportTimestamp: '2020-11-07T08:00:00',
           numCvrsImported: 412,
+          filename: 'export',
+          source: 'usb' as const,
           scannerIds: ['SCAN-01-0001'],
         },
         {
           id: 'two',
           exportTimestamp: '2020-11-07T09:00:00',
           numCvrsImported: 943,
+          filename: 'export',
+          source: 'usb' as const,
           scannerIds: ['SCAN-01-0001', 'SCAN-01-0002'],
         },
       ]}
@@ -50,10 +54,12 @@ test('renders import details when non-empty', () => {
   screen.getByText('Vx City');
 
   expect(screen.getAllByRole('listitem').map((li) => li.textContent)).toEqual([
-    ['11/7/2020, 8:00 AM', 'Scanner SCAN-01-0001', '412'].join(''),
-    ['11/7/2020, 9:00 AM', 'Scanners: SCAN-01-0001, SCAN-01-0002', '943'].join(
-      ''
-    ),
+    ['11/7/2020, 8:00 AM', 'Scanner SCAN-01-0001 •  USB', '412'].join(''),
+    [
+      '11/7/2020, 9:00 AM',
+      'Scanners: SCAN-01-0001, SCAN-01-0002 •  USB',
+      '943',
+    ].join(''),
   ]);
 
   expect(screen.queryByText('No CVRs')).not.toBeInTheDocument();

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
@@ -43,6 +43,14 @@ test('renders import details when non-empty', () => {
           source: 'usb' as const,
           scannerIds: ['SCAN-01-0001', 'SCAN-01-0002'],
         },
+        {
+          id: 'three',
+          exportTimestamp: '2020-11-07T10:00:00',
+          numCvrsImported: 112,
+          filename: 'Batch 3',
+          source: 'network' as const,
+          scannerIds: ['SCAN-01-0003'],
+        },
       ]}
       name="Vx City"
       type="absentee"
@@ -54,12 +62,13 @@ test('renders import details when non-empty', () => {
   screen.getByText('Vx City');
 
   expect(screen.getAllByRole('listitem').map((li) => li.textContent)).toEqual([
-    ['11/7/2020, 8:00 AM', 'Scanner SCAN-01-0001 •  USB', '412'].join(''),
+    ['11/7/2020, 8:00 AM', ' USB • Scanner SCAN-01-0001', '412'].join(''),
     [
       '11/7/2020, 9:00 AM',
-      'Scanners: SCAN-01-0001, SCAN-01-0002 •  USB',
+      ' USB • Scanners: SCAN-01-0001, SCAN-01-0002',
       '943',
     ].join(''),
+    ['Scanner SCAN-01-0003 • Batch 3', ' Network', '112'].join(''),
   ]);
 
   expect(screen.queryByText('No CVRs')).not.toBeInTheDocument();

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled, { css } from 'styled-components';
 
 import {
@@ -23,7 +24,12 @@ export interface LocationCvrsPanelProps {
 
 export type LocationCvrImport = Pick<
   CastVoteRecordFileRecord,
-  'id' | 'exportTimestamp' | 'numCvrsImported' | 'scannerIds'
+  | 'id'
+  | 'exportTimestamp'
+  | 'filename'
+  | 'numCvrsImported'
+  | 'scannerIds'
+  | 'source'
 >;
 
 const CalloutContent = styled(Caption)`
@@ -144,9 +150,21 @@ export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
           {imports.map((i) => (
             <Import key={i.id}>
               <Caption weight="semiBold">
-                {formatExportDate(i)}
+                {i.source === 'network' ? i.filename : formatExportDate(i)}
                 <br />
-                <Caption weight="regular">{scannerDetails(i)}</Caption>
+                <Caption weight="regular">
+                  {scannerDetails(i)}
+                  {' • '}
+                  {i.source === 'network' ? (
+                    <React.Fragment>
+                      <Icons.Network /> Network
+                    </React.Fragment>
+                  ) : (
+                    <React.Fragment>
+                      <Icons.UsbDrive /> USB
+                    </React.Fragment>
+                  )}
+                </Caption>
               </Caption>
 
               <Font weight="bold">{format.count(i.numCvrsImported)}</Font>

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.tsx
@@ -150,11 +150,11 @@ export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
           {imports.map((i) => (
             <Import key={i.id}>
               <Caption weight="semiBold">
-                {i.source === 'network' ? i.filename : formatExportDate(i)}
+                {i.source === 'network'
+                  ? `${scannerDetails(i)} • ${i.filename}`
+                  : formatExportDate(i)}
                 <br />
                 <Caption weight="regular">
-                  {scannerDetails(i)}
-                  {' • '}
                   {i.source === 'network' ? (
                     <React.Fragment>
                       <Icons.Network /> Network
@@ -162,6 +162,8 @@ export function LocationCvrsPanel(props: LocationCvrsPanelProps): JSX.Element {
                   ) : (
                     <React.Fragment>
                       <Icons.UsbDrive /> USB
+                      {' • '}
+                      {scannerDetails(i)}
                     </React.Fragment>
                   )}
                 </Caption>

--- a/apps/admin/frontend/src/screens/tally/location_list.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_list.test.tsx
@@ -19,12 +19,16 @@ const locationCvrs1: LocationCvrs = {
       id: 'one',
       exportTimestamp: '2020-11-07T08:00:00',
       numCvrsImported: 100,
+      filename: 'export',
+      source: 'usb' as const,
       scannerIds: ['SCAN-0001'],
     }),
     mockImport({
       id: 'two',
       exportTimestamp: '2020-11-07T09:00:00',
       numCvrsImported: 400,
+      filename: 'export',
+      source: 'usb' as const,
       scannerIds: ['SCAN-0001', 'SCAN-0002'],
     }),
   ],
@@ -58,8 +62,10 @@ test('toggles location CVR details on click', () => {
 
   userEvent.click(screen.getButton(/place 1/i));
   expect(screen.getAllByRole('listitem').map((li) => li.textContent)).toEqual([
-    ['11/7/2020, 8:00 AM', 'Scanner SCAN-0001', '100'].join(''),
-    ['11/7/2020, 9:00 AM', 'Scanners: SCAN-0001, SCAN-0002', '400'].join(''),
+    ['11/7/2020, 8:00 AM', 'Scanner SCAN-0001 •  USB', '100'].join(''),
+    ['11/7/2020, 9:00 AM', 'Scanners: SCAN-0001, SCAN-0002 •  USB', '400'].join(
+      ''
+    ),
   ]);
 
   userEvent.click(screen.getButton(/Place 1/i));

--- a/apps/admin/frontend/src/screens/tally/location_list.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_list.test.tsx
@@ -62,8 +62,8 @@ test('toggles location CVR details on click', () => {
 
   userEvent.click(screen.getButton(/place 1/i));
   expect(screen.getAllByRole('listitem').map((li) => li.textContent)).toEqual([
-    ['11/7/2020, 8:00 AM', 'Scanner SCAN-0001 •  USB', '100'].join(''),
-    ['11/7/2020, 9:00 AM', 'Scanners: SCAN-0001, SCAN-0002 •  USB', '400'].join(
+    ['11/7/2020, 8:00 AM', ' USB • Scanner SCAN-0001', '100'].join(''),
+    ['11/7/2020, 9:00 AM', ' USB • Scanners: SCAN-0001, SCAN-0002', '400'].join(
       ''
     ),
   ]);

--- a/apps/admin/frontend/src/screens/tally/remove_import_modal.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/remove_import_modal.test.tsx
@@ -78,6 +78,7 @@ function mockCvrImport(partial: Partial<CvrImport>): CvrImport {
     filename: 'import1.json',
     id: fileId,
     numCvrsImported: 1,
+    source: 'usb',
     pollingPlaceIds: ['place1'],
     precinctIds: ['precinct1'],
     scannerIds: ['SCAN-001'],

--- a/apps/admin/frontend/src/screens/tally/tally_screen.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/tally_screen.test.tsx
@@ -5,11 +5,17 @@ import {
 } from '@votingworks/fixtures';
 
 import userEvent from '@testing-library/user-event';
+import { assertDefined } from '@votingworks/basics';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { screen, waitFor } from '../../../test/react_testing_library.js';
 import { TallyScreen } from './tally_screen.js';
+import { AppRoutes } from '../../components/app_routes.js';
 import { renderInAppContext } from '../../../test/render_in_app_context.js';
-import { ApiMock, createApiMock } from '../../../test/helpers/mock_api_client.js';
+import {
+  ApiMock,
+  createApiMock,
+} from '../../../test/helpers/mock_api_client.js';
+import { mockCastVoteRecordFileRecord } from '../../../test/api_mock_data.js';
 
 const electionTwoPartyPrimaryDefinition =
   readElectionTwoPartyPrimaryDefinition();
@@ -30,6 +36,37 @@ afterEach(() => {
 
 const electionDefinition = electionTwoPartyPrimaryDefinition;
 const nLocations = electionDefinition.election.pollingPlaces.length;
+
+test('refreshes CVR data when the server-side data version changes', async () => {
+  apiMock.expectGetCastVoteRecordFileMode('unlocked');
+  apiMock.expectGetCastVoteRecordFiles([]);
+  // The refresher is mounted by the election manager routes, not the screen
+  renderInAppContext(<AppRoutes />, {
+    electionDefinition,
+    apiMock,
+    route: '/tally',
+  });
+  await waitFor(() => apiMock.assertComplete());
+  const locationsCardText = ['Locations', `0 / ${nLocations}`].join('');
+  screen.getByText(hasTextAcrossElements(locationsCardText));
+
+  // A networked scanner's import lands: the data version moves and the
+  // CVR-derived queries refetch without any user action.
+  apiMock.expectGetCastVoteRecordFileMode('official');
+  apiMock.expectGetCastVoteRecordFiles([
+    {
+      ...mockCastVoteRecordFileRecord,
+      pollingPlaceIds: [
+        assertDefined(electionDefinition.election.pollingPlaces[0]).id,
+      ],
+    },
+  ]);
+  apiMock.setCastVoteRecordsDataVersion(1);
+  await vi.advanceTimersByTimeAsync(1000);
+
+  const updatedCardText = ['Locations', `1 / ${nLocations}`].join('');
+  await waitFor(() => screen.getByText(hasTextAcrossElements(updatedCardText)));
+});
 
 test('has tabs for CVRs and Manual Tallies', async () => {
   apiMock.expectGetCastVoteRecordFileMode('unlocked');

--- a/apps/admin/frontend/test/api_mock_data.ts
+++ b/apps/admin/frontend/test/api_mock_data.ts
@@ -16,6 +16,7 @@ export const mockCastVoteRecordFileRecord: CastVoteRecordFileRecord = {
   scannerIds: [],
   sha256Hash: '',
   createdAt: '',
+  source: 'usb',
 };
 
 export const TEST_FILE1 =

--- a/apps/admin/frontend/test/helpers/mock_api_client.ts
+++ b/apps/admin/frontend/test/helpers/mock_api_client.ts
@@ -67,7 +67,10 @@ export const MOCK_PRINTER_CONFIG: PrinterConfig = {
 
 type MockApiClient = Omit<
   MockClient<Api>,
-  'getBatteryInfo' | 'getDiskSpaceSummary' | 'isMultiStationAdjudicationEnabled'
+  | 'getBatteryInfo'
+  | 'getDiskSpaceSummary'
+  | 'isMultiStationAdjudicationEnabled'
+  | 'getCastVoteRecordsDataVersion'
 > & {
   // Because these are polled so frequently, we opt for a standard vitest mock instead of a
   // libs/test-utils mock since the latter requires every call to be explicitly mocked
@@ -76,6 +79,9 @@ type MockApiClient = Omit<
   // Used by NavigationScreen, which is rendered by nearly every screen, so a
   // standard vitest mock avoids forcing every test to set an expectation.
   isMultiStationAdjudicationEnabled: Mock;
+  // Polled continuously by the tally screen's CvrDataRefresher, so a
+  // standard vitest mock avoids forcing every test to set an expectation.
+  getCastVoteRecordsDataVersion: Mock;
 };
 
 export function createMockApiClient(): MockApiClient {
@@ -90,6 +96,9 @@ export function createMockApiClient(): MockApiClient {
   );
   (mockApiClient.isMultiStationAdjudicationEnabled as unknown as Mock) = vi.fn(
     () => Promise.resolve(false)
+  );
+  (mockApiClient.getCastVoteRecordsDataVersion as unknown as Mock) = vi.fn(() =>
+    Promise.resolve(0)
   );
   // The USB drive watcher long-polls this continuously. Default it to a
   // never-resolving promise; `createApiMock` replaces it with a controllable
@@ -846,6 +855,10 @@ export function createApiMock(
         connectedScanners: overrides.connectedScanners ?? [],
         multipleHostsDetected: overrides.multipleHostsDetected ?? false,
       });
+    },
+
+    setCastVoteRecordsDataVersion(version: number): void {
+      apiClient.getCastVoteRecordsDataVersion.mockResolvedValue(version);
     },
 
     expectGetScannerImportCounts(

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -20,8 +20,14 @@ create table batches (
   started_at text default current_timestamp not null,
   ended_at text,
   deleted_at text,
-  error text
+  error text,
+  -- When this batch's cast vote records were successfully sent to a VxAdmin
+  -- host over the network. Null until sent.
+  sent_to_admin_at text
 ) strict;
+
+create index idx_batches_unsent_to_admin on batches (started_at)
+  where sent_to_admin_at is null and deleted_at is null;
 
 create table sheets (
   id text primary key,

--- a/apps/central-scan/backend/src/cvr_sync.test.ts
+++ b/apps/central-scan/backend/src/cvr_sync.test.ts
@@ -1,0 +1,453 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  Mock,
+  test,
+  vi,
+} from 'vitest';
+import { randomUUID as uuid } from 'node:crypto';
+import { err, ok } from '@votingworks/basics';
+import * as grout from '@votingworks/grout';
+import { NETWORK_POLLING_INTERVAL_MS } from '@votingworks/networking';
+import { getEntries, openZip } from '@votingworks/utils';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
+import { vxFamousNamesFixtures } from '@votingworks/hmpb';
+import {
+  BallotMetadata,
+  BallotType,
+  DEFAULT_SYSTEM_SETTINGS,
+  DEV_MACHINE_ID,
+  PageInterpretationWithFiles,
+  SheetOf,
+  TEST_JURISDICTION,
+} from '@votingworks/types';
+import * as fsSync from 'node:fs';
+import path from 'node:path';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { generateHmpbFixture } from '../test/helpers/ballots.js';
+import { startCvrSync } from './cvr_sync.js';
+import { Store } from './store.js';
+import { NetworkConnectionInfo } from './types.js';
+
+vi.setConfig({
+  testTimeout: 60_000,
+});
+
+vi.mock('@votingworks/grout');
+
+const buildOverride = vi.hoisted((): { result: unknown } => ({
+  result: undefined,
+}));
+vi.mock(import('@votingworks/backend'), async (importActual) => {
+  const actual = await importActual();
+  const mocked: typeof actual = {
+    ...actual,
+    buildCastVoteRecordFiles: (...args) =>
+      buildOverride.result
+        ? Promise.resolve(
+            buildOverride.result as Awaited<
+              ReturnType<typeof actual.buildCastVoteRecordFiles>
+            >
+          )
+        : actual.buildCastVoteRecordFiles(...args),
+  };
+  return mocked;
+});
+
+const HOST_ADDRESS = 'http://192.168.1.10:3002';
+const POLLING_PLACE_ID = '23';
+
+// A type literal (not an interface) so it's assignable to grout's
+// index-signature-based Client type.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type MockHostApiClient = {
+  startCvrTransfer: Mock;
+  finishCvrTransfer: Mock;
+};
+
+let sheet: SheetOf<PageInterpretationWithFiles>;
+
+beforeAll(async () => {
+  const hmpbFixture = await generateHmpbFixture();
+  const [frontImagePath, backImagePath] = hmpbFixture.sheet;
+  const metadata: BallotMetadata = {
+    ballotHash: vxFamousNamesFixtures.electionDefinition.ballotHash,
+    ballotType: BallotType.Precinct,
+    ballotStyleId: '12',
+    precinctId: '23',
+    isTestMode: false,
+  };
+  function interpretationForPage(
+    imagePath: string,
+    pageNumber: number
+  ): PageInterpretationWithFiles {
+    return {
+      imagePath,
+      interpretation: {
+        type: 'InterpretedHmpbPage',
+        metadata: { ...metadata, pageNumber },
+        votes: {},
+        markInfo: {
+          ballotSize: { width: 0, height: 0 },
+          marks: [],
+        },
+        adjudicationInfo: {
+          requiresAdjudication: false,
+          enabledReasons: [],
+          enabledReasonInfos: [],
+          ignoredReasonInfos: [],
+        },
+        layout: {
+          pageSize: { width: 0, height: 0 },
+          metadata: { ...metadata, pageNumber },
+          contests: [],
+        },
+      },
+    };
+  }
+  sheet = [
+    interpretationForPage(frontImagePath, 1),
+    interpretationForPage(backImagePath, 2),
+  ];
+});
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: false });
+});
+
+afterEach(() => {
+  buildOverride.result = undefined;
+  vi.useRealTimers();
+  vi.resetAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function buildStore(): Store {
+  const store = Store.memoryStore();
+  store.setElectionAndJurisdiction({
+    electionData: vxFamousNamesFixtures.electionDefinition.electionData,
+    jurisdiction: TEST_JURISDICTION,
+    electionPackageHash: 'test-election-package-hash',
+  });
+  store.setSystemSettings(DEFAULT_SYSTEM_SETTINGS);
+  store.setPollingPlaceId(POLLING_PLACE_ID);
+  return store;
+}
+
+function addFinishedBatch(store: Store, sheetCount = 1): string {
+  const batchId = store.addBatch();
+  for (let i = 0; i < sheetCount; i += 1) {
+    // Image paths are unique per sheet in the store, so give each sheet its
+    // own copy of the fixture images.
+    const imageDirectory = makeTemporaryDirectory();
+    function copyPage(
+      page: PageInterpretationWithFiles,
+      side: number
+    ): PageInterpretationWithFiles {
+      const imagePath = path.join(imageDirectory, `page-${side}.png`);
+      fsSync.copyFileSync(page.imagePath, imagePath);
+      return { ...page, imagePath };
+    }
+    const sheetCopy: SheetOf<PageInterpretationWithFiles> = [
+      copyPage(sheet[0], 0),
+      copyPage(sheet[1], 1),
+    ];
+    store.addSheet(
+      vxFamousNamesFixtures.electionDefinition.election,
+      uuid(),
+      batchId,
+      sheetCopy
+    );
+  }
+  store.finishBatch({ batchId });
+  return batchId;
+}
+
+function setRegistered(store: Store): void {
+  const connection: NetworkConnectionInfo = {
+    status: 'online-host-detected',
+    hostMachineId: '0002',
+    hostAddress: HOST_ADDRESS,
+  };
+  store.setNetworkConnectionInfo(connection);
+}
+
+function createMockHostApiClient(): MockHostApiClient {
+  const mockClient: MockHostApiClient = {
+    startCvrTransfer: vi.fn().mockResolvedValue(ok({ alreadyComplete: false })),
+    finishCvrTransfer: vi.fn().mockResolvedValue(ok({ cvrCount: 1 })),
+  };
+  vi.mocked(grout.createClient).mockReturnValue(mockClient);
+  return mockClient;
+}
+
+function mockUploadResponses(status = 200): Mock {
+  const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+async function waitForFailure(
+  logger: ReturnType<typeof mockBaseLogger>,
+  step: string
+): Promise<void> {
+  // The send does real file I/O, which fake timers don't wait for
+  await vi.waitFor(
+    () =>
+      expect(logger.log).toHaveBeenCalledWith(
+        LogEventId.CentralScanNetworkStatus,
+        'system',
+        expect.objectContaining({ disposition: 'failure', step })
+      ),
+    { timeout: 30_000 }
+  );
+}
+
+async function advancePollingInterval(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+  await vi.advanceTimersByTimeAsync(NETWORK_POLLING_INTERVAL_MS);
+}
+
+test('does nothing until the scanner is registered with a host', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  const mockClient = createMockHostApiClient();
+  const fetchMock = mockUploadResponses();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+
+  expect(mockClient.startCvrTransfer).not.toHaveBeenCalled();
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+});
+
+test('sends a completed batch and marks it sent', async () => {
+  const store = buildStore();
+  const batchId = addFinishedBatch(store, 2);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.finishCvrTransfer.mockResolvedValue(ok({ cvrCount: 2 }));
+  const fetchMock = mockUploadResponses();
+  const logger = mockBaseLogger({ fn: vi.fn });
+
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  // The send does real file I/O, which fake timers don't wait for
+  await vi.waitFor(
+    () => expect(store.getNextBatchToSendToAdmin()).toBeUndefined(),
+    { timeout: 30_000 }
+  );
+
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledWith({
+    machineId: DEV_MACHINE_ID,
+    codeVersion: 'dev',
+    ballotHash: vxFamousNamesFixtures.electionDefinition.ballotHash,
+    batchId,
+    label: expect.any(String),
+    pollingPlaceId: POLLING_PLACE_ID,
+    sheetCount: 2,
+    startedAt: expect.any(String),
+    isTestMode: true,
+  });
+
+  // One upload per sheet, each a zip containing the CVR file set
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+  expect(url).toContain(
+    `${HOST_ADDRESS}/api/cvr-transfer/${DEV_MACHINE_ID}/${batchId}/`
+  );
+  expect(options.method).toEqual('POST');
+  const zip = await openZip(options.body as Uint8Array);
+  expect(getEntries(zip).map((entry) => entry.name)).toEqual(
+    expect.arrayContaining(['cast-vote-record-report.json'])
+  );
+
+  expect(mockClient.finishCvrTransfer).toHaveBeenCalledWith({
+    machineId: DEV_MACHINE_ID,
+    batchId,
+  });
+});
+
+test('sends batches oldest first, one per pass', async () => {
+  const store = buildStore();
+  const olderBatchId = addFinishedBatch(store);
+  const newerBatchId = addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockUploadResponses();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  await vi.waitFor(
+    () => expect(store.getNextBatchToSendToAdmin()?.id).toEqual(newerBatchId),
+    { timeout: 30_000 }
+  );
+
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(1);
+  expect(mockClient.startCvrTransfer.mock.calls[0][0].batchId).toEqual(
+    olderBatchId
+  );
+
+  await advancePollingInterval();
+  await vi.waitFor(
+    () => expect(store.getNextBatchToSendToAdmin()).toBeUndefined(),
+    { timeout: 30_000 }
+  );
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(2);
+  expect(mockClient.startCvrTransfer.mock.calls[1][0].batchId).toEqual(
+    newerBatchId
+  );
+});
+
+test('marks a batch sent without uploading when the host already has it', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockResolvedValue(ok({ alreadyComplete: true }));
+  const fetchMock = mockUploadResponses();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(mockClient.finishCvrTransfer).not.toHaveBeenCalled();
+  expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
+});
+
+test('retries on the next pass when the host refuses the transfer', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockResolvedValue(
+    err({ type: 'ballot-hash-mismatch' })
+  );
+  mockUploadResponses();
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  await waitForFailure(logger, 'start');
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+
+  await advancePollingInterval();
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(2);
+});
+
+test('retries on the next pass when an upload fails', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockUploadResponses(400);
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  await waitForFailure(logger, 'upload');
+
+  expect(mockClient.finishCvrTransfer).not.toHaveBeenCalled();
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+});
+
+test('retries on the next pass when the host is unreachable', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockRejectedValue(new Error('ECONNREFUSED'));
+  mockUploadResponses();
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  await waitForFailure(logger, 'start');
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+});
+
+test('does not mark a batch sent when finish fails', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.finishCvrTransfer.mockResolvedValue(
+    err({
+      type: 'sheet-count-mismatch',
+      expected: 1,
+      received: 0,
+    })
+  );
+  mockUploadResponses();
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  await waitForFailure(logger, 'finish');
+
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+});
+
+test('does not mark a batch sent when finish is unreachable', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.finishCvrTransfer.mockRejectedValue(new Error('ECONNRESET'));
+  mockUploadResponses();
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  await waitForFailure(logger, 'finish');
+
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+});
+
+test('retries on the next pass when an upload cannot reach the host', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')));
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  await waitForFailure(logger, 'upload');
+
+  expect(mockClient.finishCvrTransfer).not.toHaveBeenCalled();
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+});
+
+test('retries on the next pass when a cast vote record cannot be built', async () => {
+  const store = buildStore();
+  addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  const fetchMock = mockUploadResponses();
+  buildOverride.result = err({ type: 'missing-usb-drive' });
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+  await waitForFailure(logger, 'build');
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(mockClient.finishCvrTransfer).not.toHaveBeenCalled();
+  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+});
+
+test('does nothing when registered with no batches to send', async () => {
+  const store = buildStore();
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+
+  expect(mockClient.startCvrTransfer).not.toHaveBeenCalled();
+});

--- a/apps/central-scan/backend/src/cvr_sync.ts
+++ b/apps/central-scan/backend/src/cvr_sync.ts
@@ -1,0 +1,243 @@
+import { Buffer } from 'node:buffer';
+import * as grout from '@votingworks/grout';
+import { assertDefined, iter } from '@votingworks/basics';
+import type { ReadableFile } from '@votingworks/auth';
+import {
+  AcceptedSheet,
+  buildCastVoteRecordFiles,
+  ScannerStateUnchangedByExport,
+} from '@votingworks/backend';
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import {
+  getCvrTransferUploadPath,
+  NETWORK_POLLING_INTERVAL_MS,
+  VxAdminHostApi,
+} from '@votingworks/networking';
+import { BatchInfo } from '@votingworks/types';
+import { createZip } from '@votingworks/utils';
+import makeDebug from 'debug';
+import { getMachineConfig } from './machine_config.js';
+import { Store } from './store.js';
+
+const debug = makeDebug('scan:cvr-sync');
+
+/**
+ * Timeout for transfer requests to the host. Finishing a transfer imports
+ * the whole batch on the host, so this is much longer than the heartbeat
+ * timeout.
+ */
+export const CVR_TRANSFER_REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
+
+async function readableFileToBuffer(file: ReadableFile): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of file.open()) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Sends one batch's cast vote records to the host: start → one zip upload
+ * per sheet → finish. Any failure simply returns; the sync loop retries the
+ * same batch on its next pass, and the host's per-record dedupe makes
+ * re-sends safe.
+ */
+async function sendBatchToAdmin({
+  store,
+  logger,
+  hostAddress,
+  batch,
+}: {
+  store: Store;
+  logger: BaseLogger;
+  hostAddress: string;
+  batch: BatchInfo;
+}): Promise<void> {
+  const { machineId, codeVersion } = getMachineConfig();
+  const electionRecord = store.getElectionRecord();
+  /* istanbul ignore next - batches can't exist while unconfigured */
+  if (!electionRecord) return;
+  const { electionDefinition } = electionRecord;
+
+  const systemSettings = assertDefined(store.getSystemSettings());
+  const scannerState: ScannerStateUnchangedByExport = {
+    batches: store.getBatches(),
+    electionDefinition,
+    systemSettings,
+    inTestMode: store.getTestMode(),
+    markThresholds: systemSettings.markThresholds,
+  };
+
+  const sheets: AcceptedSheet[] = iter(store.forEachAcceptedSheet())
+    .filter((sheet) => sheet.batchId === batch.id)
+    .toArray();
+
+  const apiClient = grout.createClient<VxAdminHostApi>({
+    baseUrl: `${hostAddress}/api`,
+    timeout: CVR_TRANSFER_REQUEST_TIMEOUT_MS,
+  });
+
+  function logFailure(step: string, detail: string): void {
+    logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
+      message: `Sending batch ${batch.id} to VxAdmin failed at ${step}: ${detail} Will retry.`,
+      disposition: 'failure',
+      batchId: batch.id,
+      step,
+    });
+  }
+
+  logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
+    message: `Sending batch ${batch.id} (${sheets.length} sheets) to VxAdmin at ${hostAddress}.`,
+    batchId: batch.id,
+    sheetCount: sheets.length,
+    hostAddress,
+  });
+
+  let startResult;
+  try {
+    startResult = await apiClient.startCvrTransfer({
+      machineId,
+      codeVersion,
+      ballotHash: electionDefinition.ballotHash,
+      batchId: batch.id,
+      label: batch.label,
+      pollingPlaceId: batch.pollingPlaceId,
+      sheetCount: sheets.length,
+      startedAt: batch.startedAt,
+      isTestMode: scannerState.inTestMode,
+    });
+  } catch (error) {
+    logFailure('start', `host unreachable (${error}).`);
+    return;
+  }
+  if (startResult.isErr()) {
+    logFailure('start', `host refused transfer (${startResult.err().type}).`);
+    return;
+  }
+  if (startResult.ok().alreadyComplete) {
+    store.setBatchSentToAdmin(batch.id);
+    logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
+      message: `Batch ${batch.id} was already fully imported by VxAdmin.`,
+      batchId: batch.id,
+    });
+    return;
+  }
+
+  for (const sheet of sheets) {
+    const buildResult = await buildCastVoteRecordFiles(scannerState, sheet);
+    if (buildResult.isErr()) {
+      logFailure(
+        'build',
+        `could not build cast vote record for sheet ${sheet.id} (${
+          buildResult.err().type
+        }).`
+      );
+      return;
+    }
+    const { castVoteRecordId, files } = buildResult.ok();
+
+    const zipEntries: Record<string, Buffer> = {};
+    for (const file of files) {
+      zipEntries[file.fileName] = await readableFileToBuffer(file);
+    }
+    const zipData = await createZip(zipEntries);
+
+    let response: Response;
+    try {
+      response = await fetch(
+        hostAddress +
+          getCvrTransferUploadPath(machineId, batch.id, castVoteRecordId),
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/zip' },
+          body: new Uint8Array(zipData),
+          signal: AbortSignal.timeout(CVR_TRANSFER_REQUEST_TIMEOUT_MS),
+        }
+      );
+    } catch (error) {
+      logFailure('upload', `host unreachable (${error}).`);
+      return;
+    }
+    if (response.status !== 200) {
+      logFailure(
+        'upload',
+        `host rejected cast vote record ${castVoteRecordId} (status ${response.status}).`
+      );
+      return;
+    }
+  }
+
+  let finishResult;
+  try {
+    finishResult = await apiClient.finishCvrTransfer({
+      machineId,
+      batchId: batch.id,
+    });
+  } catch (error) {
+    logFailure('finish', `host unreachable (${error}).`);
+    return;
+  }
+  if (finishResult.isErr()) {
+    logFailure(
+      'finish',
+      `host could not complete the import (${finishResult.err().type}).`
+    );
+    return;
+  }
+
+  store.setBatchSentToAdmin(batch.id);
+  logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
+    message: `Sent batch ${batch.id} (${
+      finishResult.ok().cvrCount
+    } cast vote records) to VxAdmin.`,
+    disposition: 'success',
+    batchId: batch.id,
+    cvrCount: finishResult.ok().cvrCount,
+  });
+}
+
+/**
+ * Starts the CVR sync loop: while the scanner is registered with a VxAdmin
+ * host, sends completed batches' cast vote records to it, oldest first, one
+ * batch at a time.
+ */
+export function startCvrSync({
+  store,
+  logger,
+}: {
+  store: Store;
+  logger: BaseLogger;
+}): void {
+  debug('Starting CVR sync loop');
+  let isSending = false;
+
+  process.nextTick(() => {
+    setInterval(async () => {
+      /* istanbul ignore next - re-entrancy guard */
+      if (isSending) return;
+      isSending = true;
+      try {
+        const connection = store.getNetworkConnectionInfo();
+        if (
+          connection.status !== 'online-host-detected' ||
+          !connection.hostAddress
+        ) {
+          return;
+        }
+        const batch = store.getNextBatchToSendToAdmin();
+        if (!batch) return;
+        await sendBatchToAdmin({
+          store,
+          logger,
+          hostAddress: connection.hostAddress,
+          batch,
+        });
+      } catch (error) {
+        /* istanbul ignore next - defensive */
+        debug('Error in CVR sync loop: %s', error);
+      } finally {
+        isSending = false;
+      }
+    }, NETWORK_POLLING_INTERVAL_MS);
+  });
+}

--- a/apps/central-scan/backend/src/networking.test.ts
+++ b/apps/central-scan/backend/src/networking.test.ts
@@ -146,6 +146,7 @@ test('ignores a stale advertisement and connects to the single reachable host', 
   expect(store.getNetworkConnectionInfo()).toEqual({
     status: 'online-host-detected',
     hostMachineId: '0002',
+    hostAddress: HOST_MACHINE.address,
   });
   expect(staleClient.registerScanner).not.toHaveBeenCalled();
 });
@@ -257,6 +258,7 @@ test('reports host-detected when everything matches', async () => {
   expect(store.getNetworkConnectionInfo()).toEqual({
     status: 'online-host-detected',
     hostMachineId: '0002',
+    hostAddress: HOST_MACHINE.address,
   });
   expect(mockClient.registerScanner).toHaveBeenCalledWith({
     machineId: DEV_MACHINE_ID,
@@ -276,6 +278,7 @@ test('logs status transitions and returns to offline when the interface goes dow
   expect(store.getNetworkConnectionInfo()).toEqual({
     status: 'online-host-detected',
     hostMachineId: '0002',
+    hostAddress: HOST_MACHINE.address,
   });
   expect(logger.log).toHaveBeenCalledWith(
     expect.anything(),

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -164,6 +164,7 @@ export function startScannerNetworking({
         setConnectionInfo({
           status: 'online-host-detected',
           hostMachineId,
+          hostAddress: hostMachine.address,
         });
       } catch (error) {
         /* istanbul ignore next - defensive */

--- a/apps/central-scan/backend/src/server.ts
+++ b/apps/central-scan/backend/src/server.ts
@@ -28,6 +28,7 @@ import { buildCentralScannerApp } from './app.js';
 import { getUserRole } from './util/auth.js';
 import { isCentralScanNetworkingEnabled } from './networking_config.js';
 import { startScannerNetworking } from './networking.js';
+import { startCvrSync } from './cvr_sync.js';
 
 export interface StartOptions {
   port: number | string;
@@ -143,6 +144,10 @@ export function start({
 
   if (isCentralScanNetworkingEnabled()) {
     startScannerNetworking({
+      logger: baseLogger,
+      store: resolvedWorkspace.store,
+    });
+    startCvrSync({
       logger: baseLogger,
       store: resolvedWorkspace.store,
     });

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -856,6 +856,35 @@ export class Store {
   }
 
   /**
+   * Returns the oldest completed batch whose cast vote records have not yet
+   * been sent to a VxAdmin host, if any. Batches send strictly oldest-first.
+   */
+  getNextBatchToSendToAdmin(): BatchInfo | undefined {
+    const row = this.client.one(`
+      select id
+      from batches
+      where
+        ended_at is not null
+        and deleted_at is null
+        and sent_to_admin_at is null
+      order by started_at asc, batch_number asc
+      limit 1
+    `) as { id: string } | undefined;
+    return row ? this.getBatch(row.id) : undefined;
+  }
+
+  /**
+   * Records that a batch's cast vote records were successfully sent to a
+   * VxAdmin host.
+   */
+  setBatchSentToAdmin(batchId: string): void {
+    this.client.run(
+      'update batches set sent_to_admin_at = current_timestamp where id = ?',
+      batchId
+    );
+  }
+
+  /**
    * Gets a batch by ID, expecting it to exist.
    */
   getBatch(batchId: string): BatchInfo {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -812,6 +812,7 @@ export class Store {
       endedAt: string | null;
       error: string | null;
       count: number;
+      sentToAdminAt: string | null;
     }
     const batchInfo = this.client.all(`
       select
@@ -821,6 +822,7 @@ export class Store {
         batches.polling_place_id as pollingPlaceId,
         strftime('%s', started_at) as startedAt,
         (case when ended_at is null then ended_at else strftime('%s', ended_at) end) as endedAt,
+        (case when sent_to_admin_at is null then sent_to_admin_at else strftime('%s', sent_to_admin_at) end) as sentToAdminAt,
         error,
         sum(case when sheets.id is null then 0 else 1 end) as count
       from
@@ -852,6 +854,11 @@ export class Store {
         undefined,
       error: info.error || undefined,
       count: info.count,
+      sentToAdminAt:
+        (info.sentToAdminAt &&
+          // eslint-disable-next-line vx/gts-safe-number-parse
+          DateTime.fromSeconds(Number(info.sentToAdminAt)).toISO()) ||
+        undefined,
     }));
   }
 

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -44,6 +44,11 @@ export interface NetworkConnectionInfo {
    * Present whenever exactly one host was found on the network.
    */
   hostMachineId?: string;
+  /**
+   * Address of the host the scanner is registered with. Present only in the
+   * `online-host-detected` state; used by the CVR sync loop.
+   */
+  hostAddress?: string;
 }
 
 /** The scanner's network status, as reported to the frontend. */

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -44,6 +44,37 @@ test('null state', () => {
   screen.getByText('No ballots have been scanned');
 });
 
+test('shows a sent-to-VxAdmin column when networking is enabled', async () => {
+  apiMock.setNetworkStatus({
+    isEnabled: true,
+    connection: { status: 'online-host-detected', hostMachineId: '0002' },
+  });
+  const status: ScanStatus = mockStatus({
+    batches: [
+      mockBatch({
+        id: 'sent',
+        label: 'Batch 1',
+        sentToAdminAt: new Date(2026, 7, 25, 10, 0).toISOString(),
+      }),
+      mockBatch({ id: 'unsent', label: 'Batch 2' }),
+    ],
+  });
+  renderScreen({ status });
+  await screen.findByText('Sent At');
+  const rows = screen.getAllByRole('row').slice(1);
+  expect(rows[0]).toHaveTextContent('Batch 1');
+  expect(rows[0]).not.toHaveTextContent('Not sent');
+  expect(rows[1]).toHaveTextContent('Not sent');
+});
+
+test('hides the sent-to-VxAdmin column when networking is disabled', () => {
+  const status: ScanStatus = mockStatus({
+    batches: [mockBatch({ id: 'a' })],
+  });
+  renderScreen({ status });
+  expect(screen.queryByText('Sent At')).not.toBeInTheDocument();
+});
+
 test('shows scanned ballot count', () => {
   const status: ScanStatus = mockStatus({
     batches: [

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -20,7 +20,7 @@ import { DeleteBatchModal } from '../components/delete_batch_modal.js';
 import { NavigationScreen } from '../navigation_screen.js';
 import { ExportResultsModal } from '../components/export_results_modal.js';
 import { ScanButton } from '../components/scan_button.js';
-import { clearBallotData } from '../api.js';
+import { clearBallotData, getNetworkStatus } from '../api.js';
 
 pluralize.addIrregularRule('requires', 'require');
 pluralize.addIrregularRule('has', 'have');
@@ -35,6 +35,12 @@ function shortDateTime(iso8601Timestamp: string) {
     d.getDate()
   )} ${d.getHours()}:${z2(d.getMinutes())}:${z2(d.getSeconds())}`;
 }
+
+// Reserves enough width for a full timestamp so the column doesn't resize
+// when a batch flips from "Not sent" to its sent time.
+const SentAtCell = styled(TD)`
+  min-width: 12rem;
+`;
 
 const Content = styled.div`
   display: flex;
@@ -92,6 +98,8 @@ export function ScanBallotsScreen({
 
   const [isExportingCvrs, setIsExportingCvrs] = useState(false);
   const [pendingDeleteBatch, setPendingDeleteBatch] = useState<BatchInfo>();
+  const networkStatusQuery = getNetworkStatus.usePollingQuery();
+  const isNetworkingEnabled = networkStatusQuery.data?.isEnabled ?? false;
   const [deleteBallotDataFlowState, setDeleteBallotDataFlowState] = useState<
     'confirmation' | 'deleting'
   >();
@@ -173,6 +181,7 @@ export function ScanBallotsScreen({
                     <th>Sheet Count</th>
                     <th>Started At</th>
                     <th>Finished At</th>
+                    {isNetworkingEnabled && <th>Sent At</th>}
                     <th>&nbsp;</th>
                   </tr>
                 </thead>
@@ -191,6 +200,15 @@ export function ScanBallotsScreen({
                           shortDateTime(batch.endedAt)
                         ) : null}
                       </TD>
+                      {isNetworkingEnabled && (
+                        <SentAtCell nowrap>
+                          {batch.sentToAdminAt ? (
+                            shortDateTime(batch.sentToAdminAt)
+                          ) : (
+                            <Font weight="light">Not sent</Font>
+                          )}
+                        </SentAtCell>
+                      )}
                       <TD narrow>
                         <Button
                           icon="Delete"

--- a/libs/backend/src/cast_vote_records/export.ts
+++ b/libs/backend/src/cast_vote_records/export.ts
@@ -121,7 +121,7 @@ export type ScannerStore = CentralScannerStore | PrecinctScannerStore;
  * State that can be retrieved via the ScannerStore interface and that is unchanged by exporting
  * cast vote records
  */
-interface ScannerStateUnchangedByExport {
+export interface ScannerStateUnchangedByExport {
   batches: BatchInfo[];
   electionDefinition: ElectionDefinition;
   systemSettings: SystemSettings;
@@ -284,10 +284,9 @@ async function getExportDirectoryPathRelativeToUsbMountPoint(
 }
 
 function buildCastVoteRecordReportMetadata(
-  exportContext: ExportContext,
+  scannerState: ScannerStateUnchangedByExport,
   options: { hideTime?: boolean } = {}
 ): CVR.CastVoteRecordReport {
-  const { scannerState } = exportContext;
   const { batches, electionDefinition, inTestMode } = scannerState;
   const { election, ballotHash: electionId } = electionDefinition;
   const scannerId = getMachineId();
@@ -307,7 +306,7 @@ function buildCastVoteRecordReportMetadata(
 }
 
 async function buildCastVoteRecord(
-  exportContext: ExportContext,
+  scannerState: ScannerStateUnchangedByExport,
   sheet: AcceptedSheet,
   canonicalizedSheet: CanonicalizedSheet,
   referencedFiles?: {
@@ -315,7 +314,6 @@ async function buildCastVoteRecord(
     layoutFiles?: SheetOf<HashableFile>;
   }
 ): Promise<CVR.CVR> {
-  const { scannerState } = exportContext;
   const { electionDefinition, markThresholds } = scannerState;
   const { ballotHash: electionId } = electionDefinition;
   const scannerId = getMachineId();
@@ -369,27 +367,28 @@ async function buildCastVoteRecord(
 }
 
 /**
- * Exports the following for a single cast vote record:
+ * Builds the file set for a single cast vote record:
  * - The cast vote record report (JSON)
  * - The front image (PNG)
  * - The back image (PNG)
  * - If an HMPB, the front interpretation layout (JSON)
  * - If an HMPB, the back interpretation layout (JSON)
  *
- * Returns the cast vote record ID and a hash of the above contents.
+ * Used by both the USB export path and the network sync path.
  */
-async function exportCastVoteRecordFilesToUsbDrive(
-  exportContext: ExportContext,
-  sheet: AcceptedSheet,
-  exportDirectoryPathRelativeToUsbMountPoint: string
+export async function buildCastVoteRecordFiles(
+  scannerState: ScannerStateUnchangedByExport,
+  sheet: AcceptedSheet
 ): Promise<
   Result<
-    { castVoteRecordId: string; castVoteRecordHash: string },
+    {
+      castVoteRecordId: string;
+      castVoteRecordReportFile: ReadableFile;
+      files: ReadableFile[];
+    },
     ExportCastVoteRecordsToUsbDriveError
   >
 > {
-  const { exporter } = exportContext;
-
   const canonicalizeSheetResult = canonicalizeSheet(sheet.interpretation, [
     sheet.frontImagePath,
     sheet.backImagePath,
@@ -399,14 +398,14 @@ async function exportCastVoteRecordFilesToUsbDrive(
   }
   const canonicalizedSheet = canonicalizeSheetResult.ok();
 
-  const castVoteRecordFilesToExport: ReadableFile[] = [];
+  const files: ReadableFile[] = [];
 
   const [frontImagePath, backImagePath] = canonicalizedSheet.filenames;
   const imageFiles: SheetOf<ReadableFile> = [
     readableFileFromDisk(frontImagePath),
     readableFileFromDisk(backImagePath),
   ];
-  castVoteRecordFilesToExport.push(...imageFiles);
+  files.push(...imageFiles);
 
   let layoutFiles: SheetOf<ReadableFile> | undefined;
   if (canonicalizedSheet.type === 'hmpb') {
@@ -422,20 +421,20 @@ async function exportCastVoteRecordFilesToUsbDrive(
         JSON.stringify(backInterpretation.layout)
       ),
     ];
-    castVoteRecordFilesToExport.push(...layoutFiles);
+    files.push(...layoutFiles);
   }
 
-  const castVoteRecordReportMetadata = exportContext.scannerState.systemSettings
+  const castVoteRecordReportMetadata = scannerState.systemSettings
     .castVoteRecordsIncludeRedundantMetadata
     ? buildCastVoteRecordReportMetadata(
-        exportContext,
+        scannerState,
         // Hide the time in the metadata for individual cast vote records so that we don't reveal the
         // order in which ballots were cast
         { hideTime: true }
       )
     : undefined;
   const castVoteRecord = await buildCastVoteRecord(
-    exportContext,
+    scannerState,
     sheet,
     canonicalizedSheet,
     { imageFiles, layoutFiles }
@@ -452,9 +451,39 @@ async function exportCastVoteRecordFilesToUsbDrive(
     CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT,
     JSON.stringify(castVoteRecordReport)
   );
-  castVoteRecordFilesToExport.push(castVoteRecordReportFile);
+  files.push(castVoteRecordReportFile);
 
-  for (const file of castVoteRecordFilesToExport) {
+  return ok({ castVoteRecordId, castVoteRecordReportFile, files });
+}
+
+/**
+ * Exports the file set for a single cast vote record (see
+ * {@link buildCastVoteRecordFiles}) to a USB drive. Returns the cast vote
+ * record ID and a hash of the exported contents.
+ */
+async function exportCastVoteRecordFilesToUsbDrive(
+  exportContext: ExportContext,
+  sheet: AcceptedSheet,
+  exportDirectoryPathRelativeToUsbMountPoint: string
+): Promise<
+  Result<
+    { castVoteRecordId: string; castVoteRecordHash: string },
+    ExportCastVoteRecordsToUsbDriveError
+  >
+> {
+  const { exporter } = exportContext;
+
+  const buildResult = await buildCastVoteRecordFiles(
+    exportContext.scannerState,
+    sheet
+  );
+  if (buildResult.isErr()) {
+    return buildResult;
+  }
+  const { castVoteRecordId, castVoteRecordReportFile, files } =
+    buildResult.ok();
+
+  for (const file of files) {
     const exportResult = await exporter.exportDataToUsbDrive(
       exportDirectoryPathRelativeToUsbMountPoint,
       path.join(castVoteRecordId, file.fileName),
@@ -537,8 +566,9 @@ async function exportMetadataFileToUsbDrive(
 
   const metadata: CastVoteRecordExportMetadata = {
     arePollsClosed,
-    castVoteRecordReportMetadata:
-      buildCastVoteRecordReportMetadata(exportContext),
+    castVoteRecordReportMetadata: buildCastVoteRecordReportMetadata(
+      exportContext.scannerState
+    ),
     castVoteRecordRootHash,
     batchManifest: buildBatchManifest({
       batches: exportContext.scannerState.batches,

--- a/libs/backend/src/cast_vote_records/file_source.test.ts
+++ b/libs/backend/src/cast_vote_records/file_source.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest';
+import { Buffer } from 'node:buffer';
+import * as fs from 'node:fs';
+import path from 'node:path';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { isNonExistentFileOrDirectoryError } from '@votingworks/basics';
+import { directoryFileSource, inMemoryFileSource } from './file_source';
+
+test('directoryFileSource reads files relative to the directory', async () => {
+  const directoryPath = makeTemporaryDirectory();
+  fs.writeFileSync(path.join(directoryPath, 'a.json'), '{}');
+  const source = directoryFileSource(directoryPath);
+  expect(await source.readFile('a.json')).toEqual(Buffer.from('{}'));
+  await expect(source.readFile('missing.json')).rejects.toSatisfy(
+    isNonExistentFileOrDirectoryError
+  );
+});
+
+test('inMemoryFileSource reads from the given files', async () => {
+  const source = inMemoryFileSource({ 'a.json': Buffer.from('{}') });
+  expect(await source.readFile('a.json')).toEqual(Buffer.from('{}'));
+  await expect(source.readFile('missing.json')).rejects.toSatisfy(
+    isNonExistentFileOrDirectoryError
+  );
+});

--- a/libs/backend/src/cast_vote_records/file_source.ts
+++ b/libs/backend/src/cast_vote_records/file_source.ts
@@ -1,0 +1,43 @@
+import { Buffer } from 'node:buffer';
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Where a single cast vote record's file set (report, images, layouts) is
+ * read from. File names are relative to the record, as they appear in the
+ * report's `BallotImage` locations.
+ *
+ * `readFile` rejects with an `ENOENT`-coded error for a missing file, like
+ * `fs.readFile`, so callers can treat both sources alike.
+ */
+export interface CastVoteRecordFileSource {
+  readFile(fileName: string): Promise<Buffer>;
+}
+
+/** A record's files as exported to a directory (e.g. on a USB drive). */
+export function directoryFileSource(
+  directoryPath: string
+): CastVoteRecordFileSource {
+  return {
+    readFile: (fileName) => fs.readFile(path.join(directoryPath, fileName)),
+  };
+}
+
+/** A record's files already held in memory (e.g. received over the network). */
+export function inMemoryFileSource(
+  files: Readonly<Record<string, Buffer>>
+): CastVoteRecordFileSource {
+  return {
+    readFile: (fileName) => {
+      const contents = files[fileName];
+      if (!contents) {
+        return Promise.reject(
+          Object.assign(new Error(`ENOENT: no such file: ${fileName}`), {
+            code: 'ENOENT',
+          })
+        );
+      }
+      return Promise.resolve(contents);
+    },
+  };
+}

--- a/libs/backend/src/cast_vote_records/import.ts
+++ b/libs/backend/src/cast_vote_records/import.ts
@@ -45,8 +45,12 @@ import {
   referencedLayoutFile,
 } from './referenced_files';
 import { getImageHash, getLayoutHash } from './build_cast_vote_record';
+import { CastVoteRecordFileSource, directoryFileSource } from './file_source';
 
-interface CastVoteRecordAndReferencedFiles {
+/**
+ * A parsed cast vote record and references to its image/layout files
+ */
+export interface CastVoteRecordAndReferencedFiles {
   castVoteRecord: CVR.CVR;
   castVoteRecordBallotSheetId?: number;
   castVoteRecordCurrentSnapshot: CVR.CVRSnapshot;
@@ -90,50 +94,59 @@ export async function readCastVoteRecordExportMetadata(
   return parseResult;
 }
 
-async function* castVoteRecordGenerator(
-  exportDirectoryPath: string,
+/**
+ * Reads and parses a single cast vote record from its export directory (one
+ * directory per cast vote record, containing the report JSON, ballot images,
+ * and, for HMPBs, layout files). Performs the same basic validation as
+ * {@link readCastVoteRecordExport} does per record. Referenced image and
+ * layout files are not read; they're returned as hash-checked references.
+ */
+export function readCastVoteRecordFromDirectory(
+  castVoteRecordDirectoryPath: string,
   batchIds: Set<string>
-): AsyncGenerator<
-  Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError>
-> {
+): Promise<Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError>> {
+  return readCastVoteRecordFromSource(
+    directoryFileSource(castVoteRecordDirectoryPath),
+    batchIds
+  );
+}
+
+/**
+ * Reads and validates a single cast vote record from any
+ * {@link CastVoteRecordFileSource}, so records can be read the same way
+ * whether they arrive on a USB drive or over the network.
+ */
+export async function readCastVoteRecordFromSource(
+  source: CastVoteRecordFileSource,
+  batchIds: Set<string>
+): Promise<Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError>> {
   function wrapError(
     error: Omit<ReadCastVoteRecordError, 'type'>
   ): Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError> {
     return err({ ...error, type: 'invalid-cast-vote-record' });
   }
 
-  const castVoteRecordIds =
-    await getExportedCastVoteRecordIds(exportDirectoryPath);
-  for (const castVoteRecordId of castVoteRecordIds) {
-    const castVoteRecordDirectoryPath = path.join(
-      exportDirectoryPath,
-      castVoteRecordId
-    );
-    const castVoteRecordReportContents = await fs.readFile(
-      path.join(
-        castVoteRecordDirectoryPath,
+  {
+    const castVoteRecordReportContents = (
+      await source.readFile(
         CastVoteRecordExportFileName.CAST_VOTE_RECORD_REPORT
-      ),
-      'utf-8'
-    );
+      )
+    ).toString('utf-8');
     const parseResult = safeParseJson(
       castVoteRecordReportContents,
       CastVoteRecordReportWithoutMetadataSchema
     );
     if (parseResult.isErr()) {
-      yield wrapError({ subType: 'parse-error' });
-      return;
+      return wrapError({ subType: 'parse-error' });
     }
     const castVoteRecordReport = parseResult.ok();
     if (!castVoteRecordReport.CVR || castVoteRecordReport.CVR.length !== 1) {
-      yield wrapError({ subType: 'parse-error' });
-      return;
+      return wrapError({ subType: 'parse-error' });
     }
     const castVoteRecord = assertDefined(castVoteRecordReport.CVR[0]);
 
     if (!batchIds.has(castVoteRecord.BatchId)) {
-      yield wrapError({ subType: 'batch-id-not-found' });
-      return;
+      return wrapError({ subType: 'batch-id-not-found' });
     }
 
     // Only relevant for HMPBs and multi-page BMD ballots
@@ -143,16 +156,14 @@ async function* castVoteRecordGenerator(
         castVoteRecord.BallotSheetId
       );
       if (parseBallotSheetIdResult.isErr()) {
-        yield wrapError({ subType: 'invalid-ballot-sheet-id' });
-        return;
+        return wrapError({ subType: 'invalid-ballot-sheet-id' });
       }
       castVoteRecordBallotSheetId = parseBallotSheetIdResult.ok();
     }
 
     const castVoteRecordCurrentSnapshot = getCurrentSnapshot(castVoteRecord);
     if (!castVoteRecordCurrentSnapshot) {
-      yield wrapError({ subType: 'no-current-snapshot' });
-      return;
+      return wrapError({ subType: 'no-current-snapshot' });
     }
 
     // HMPB has an "interpreted" current snapshot, while BMD (including multi-page) has an "original"
@@ -166,23 +177,20 @@ async function* castVoteRecordGenerator(
     if (isHandMarkedPaperBallot) {
       castVoteRecordOriginalSnapshot = getOriginalSnapshot(castVoteRecord);
       if (!castVoteRecordOriginalSnapshot) {
-        yield wrapError({ subType: 'no-original-snapshot' });
-        return;
+        return wrapError({ subType: 'no-original-snapshot' });
       }
     }
 
     const castVoteRecordWriteIns =
       getWriteInsFromCastVoteRecord(castVoteRecord);
     if (!castVoteRecordWriteIns.every(isCastVoteRecordWriteInValid)) {
-      yield wrapError({ subType: 'invalid-write-in-field' });
-      return;
+      return wrapError({ subType: 'invalid-write-in-field' });
     }
 
     let referencedFiles: ReferencedFiles | undefined;
     if (castVoteRecord.BallotImage) {
       if (castVoteRecord.BallotImage.length !== 2) {
-        yield wrapError({ subType: 'invalid-ballot-image-field' });
-        return;
+        return wrapError({ subType: 'invalid-ballot-image-field' });
       }
       assert(castVoteRecord.BallotImage[0]);
       assert(castVoteRecord.BallotImage[1]);
@@ -194,27 +202,21 @@ async function* castVoteRecordGenerator(
         !castVoteRecord.BallotImage[0].Location.startsWith('file:') ||
         !castVoteRecord.BallotImage[1].Location.startsWith('file:')
       ) {
-        yield wrapError({ subType: 'invalid-ballot-image-field' });
-        return;
+        return wrapError({ subType: 'invalid-ballot-image-field' });
       }
       const imageHashes: SheetOf<string> = [
         getImageHash(castVoteRecord.BallotImage[0]),
         getImageHash(castVoteRecord.BallotImage[1]),
       ];
-      const imageRelativePaths: SheetOf<string> = [
+      const imageFileNames: SheetOf<string> = [
         castVoteRecord.BallotImage[0].Location.replace('file:', ''),
         castVoteRecord.BallotImage[1].Location.replace('file:', ''),
       ];
-      const imagePaths: SheetOf<string> = mapSheet(
-        imageRelativePaths,
-        (imageRelativePath) =>
-          path.join(castVoteRecordDirectoryPath, imageRelativePath)
-      );
       const imageFiles = mapSheet(
         imageHashes,
-        imagePaths,
-        (expectedFileHash, filePath) =>
-          referencedImageFile({ expectedFileHash, filePath })
+        imageFileNames,
+        (expectedFileHash, fileName) =>
+          referencedImageFile({ expectedFileHash, source, fileName })
       );
 
       const layoutFileHash1 = getLayoutHash(castVoteRecord.BallotImage[0]);
@@ -222,32 +224,31 @@ async function* castVoteRecordGenerator(
       let layoutFiles: SheetOf<ReferencedFile<BallotPageLayout>> | undefined;
       if (isHandMarkedPaperBallot) {
         if (!layoutFileHash1 || !layoutFileHash2) {
-          yield wrapError({ subType: 'invalid-ballot-image-field' });
-          return;
+          return wrapError({ subType: 'invalid-ballot-image-field' });
         }
         const layoutFileHashes: SheetOf<string> = [
           layoutFileHash1,
           layoutFileHash2,
         ];
-        const layoutFilePaths: SheetOf<string> = mapSheet(
-          imagePaths,
-          (imagePath) => {
-            const { dir, name } = path.parse(imagePath);
-            return path.join(dir, `${name}.layout.json`);
+        const layoutFileNames: SheetOf<string> = mapSheet(
+          imageFileNames,
+          (imageFileName) => {
+            const { dir, name } = path.posix.parse(imageFileName);
+            return path.posix.join(dir, `${name}.layout.json`);
           }
         );
         layoutFiles = mapSheet(
           layoutFileHashes,
-          layoutFilePaths,
-          (expectedFileHash, filePath) =>
-            referencedLayoutFile({ expectedFileHash, filePath })
+          layoutFileNames,
+          (expectedFileHash, fileName) =>
+            referencedLayoutFile({ expectedFileHash, source, fileName })
         );
       }
 
       referencedFiles = { imageFiles, layoutFiles };
     }
 
-    yield ok({
+    return ok({
       castVoteRecord,
       castVoteRecordBallotSheetId,
       castVoteRecordCurrentSnapshot,
@@ -255,6 +256,26 @@ async function* castVoteRecordGenerator(
       castVoteRecordWriteIns,
       referencedFiles,
     });
+  }
+}
+
+async function* castVoteRecordGenerator(
+  exportDirectoryPath: string,
+  batchIds: Set<string>
+): AsyncGenerator<
+  Result<CastVoteRecordAndReferencedFiles, ReadCastVoteRecordError>
+> {
+  const castVoteRecordIds =
+    await getExportedCastVoteRecordIds(exportDirectoryPath);
+  for (const castVoteRecordId of castVoteRecordIds) {
+    const result = await readCastVoteRecordFromDirectory(
+      path.join(exportDirectoryPath, castVoteRecordId),
+      batchIds
+    );
+    yield result;
+    if (result.isErr()) {
+      return;
+    }
   }
 }
 

--- a/libs/backend/src/cast_vote_records/index.ts
+++ b/libs/backend/src/cast_vote_records/index.ts
@@ -12,5 +12,6 @@ export {
   buildBatchManifest,
 } from './build_report_metadata';
 export * from './export';
+export * from './file_source';
 export * from './import';
 export * from './test_utils';

--- a/libs/backend/src/cast_vote_records/referenced_files.test.ts
+++ b/libs/backend/src/cast_vote_records/referenced_files.test.ts
@@ -12,6 +12,7 @@ import {
   ReadCastVoteRecordError,
 } from '@votingworks/types';
 
+import { directoryFileSource } from './file_source';
 import { referencedImageFile, referencedLayoutFile } from './referenced_files';
 
 vi.mock(import('node:fs/promises'), async (importActual) => ({
@@ -51,12 +52,14 @@ const expectedInvalidLayoutFileHash = createHash('sha256')
   .digest('hex');
 
 let tempDirectoryPath: string;
+let source: ReturnType<typeof directoryFileSource>;
 let imagePath: string;
 let layoutFilePath: string;
 let invalidLayoutFilePath: string;
 
 beforeEach(() => {
   tempDirectoryPath = makeTemporaryDirectory();
+  source = directoryFileSource(tempDirectoryPath);
   imagePath = path.join(tempDirectoryPath, 'file.jpg');
   fs.writeFileSync(imagePath, imageContents);
   layoutFilePath = path.join(tempDirectoryPath, 'file.layout.json');
@@ -72,7 +75,11 @@ afterEach(() => {
 test.each<{
   name: string;
   setupFn: () => void;
-  inputGenerator: () => { expectedFileHash: string; filePath: string };
+  inputGenerator: () => {
+    expectedFileHash: string;
+    source: ReturnType<typeof directoryFileSource>;
+    fileName: string;
+  };
   expectedOutput: Result<Buffer, ReadCastVoteRecordError>;
 }>([
   {
@@ -81,7 +88,8 @@ test.each<{
       vi.mocked(fsPromises.readFile).mockResolvedValue(imageContents),
     inputGenerator: () => ({
       expectedFileHash: expectedImageHash,
-      filePath: imagePath,
+      source,
+      fileName: 'file.jpg',
     }),
     expectedOutput: ok(imageContents),
   },
@@ -94,7 +102,8 @@ test.each<{
     },
     inputGenerator: () => ({
       expectedFileHash: expectedImageHash,
-      filePath: 'non-existent-file-path',
+      source,
+      fileName: 'non-existent-file-path',
     }),
     expectedOutput: err({
       type: 'invalid-cast-vote-record',
@@ -108,7 +117,8 @@ test.each<{
     },
     inputGenerator: () => ({
       expectedFileHash: expectedImageHash,
-      filePath: imagePath,
+      source,
+      fileName: 'file.jpg',
     }),
     expectedOutput: err({
       type: 'invalid-cast-vote-record',
@@ -121,7 +131,8 @@ test.each<{
       vi.mocked(fsPromises.readFile).mockResolvedValue(imageContents),
     inputGenerator: () => ({
       expectedFileHash: 'some-other-hash',
-      filePath: imagePath,
+      source,
+      fileName: 'file.jpg',
     }),
     expectedOutput: err({
       type: 'invalid-cast-vote-record',
@@ -140,7 +151,11 @@ test.each<{
 test.each<{
   name: string;
   setupFn: () => void;
-  inputGenerator: () => { expectedFileHash: string; filePath: string };
+  inputGenerator: () => {
+    expectedFileHash: string;
+    source: ReturnType<typeof directoryFileSource>;
+    fileName: string;
+  };
   expectedOutput: Result<BallotPageLayout, ReadCastVoteRecordError>;
 }>([
   {
@@ -149,7 +164,8 @@ test.each<{
       vi.mocked(fsPromises.readFile).mockResolvedValue(layoutFileContents),
     inputGenerator: () => ({
       expectedFileHash: expectedLayoutFileHash,
-      filePath: layoutFilePath,
+      source,
+      fileName: 'file.layout.json',
     }),
     expectedOutput: ok(layout),
   },
@@ -162,7 +178,8 @@ test.each<{
     },
     inputGenerator: () => ({
       expectedFileHash: expectedLayoutFileHash,
-      filePath: 'non-existent-file-path',
+      source,
+      fileName: 'non-existent-file-path',
     }),
     expectedOutput: err({
       type: 'invalid-cast-vote-record',
@@ -175,7 +192,8 @@ test.each<{
       vi.mocked(fsPromises.readFile).mockRejectedValue(new Error('Whoa!')),
     inputGenerator: () => ({
       expectedFileHash: expectedLayoutFileHash,
-      filePath: layoutFilePath,
+      source,
+      fileName: 'file.layout.json',
     }),
     expectedOutput: err({
       type: 'invalid-cast-vote-record',
@@ -188,7 +206,8 @@ test.each<{
       vi.mocked(fsPromises.readFile).mockResolvedValue(layoutFileContents),
     inputGenerator: () => ({
       expectedFileHash: 'some-other-hash',
-      filePath: layoutFilePath,
+      source,
+      fileName: 'file.layout.json',
     }),
     expectedOutput: err({
       type: 'invalid-cast-vote-record',
@@ -203,7 +222,8 @@ test.each<{
         .mockResolvedValue(invalidLayoutFileContents),
     inputGenerator: () => ({
       expectedFileHash: expectedInvalidLayoutFileHash,
-      filePath: invalidLayoutFilePath,
+      source,
+      fileName: 'invalid.layout.json',
     }),
     expectedOutput: err({
       type: 'invalid-cast-vote-record',

--- a/libs/backend/src/cast_vote_records/referenced_files.ts
+++ b/libs/backend/src/cast_vote_records/referenced_files.ts
@@ -1,5 +1,4 @@
 import { Buffer } from 'node:buffer';
-import * as fs from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import {
   err,
@@ -15,6 +14,7 @@ import {
   safeParseJson,
   SheetOf,
 } from '@votingworks/types';
+import { CastVoteRecordFileSource } from './file_source';
 
 /**
  * A file referenced by a cast vote record report
@@ -33,14 +33,15 @@ export interface ReferencedFiles {
 
 function referencedFile(input: {
   expectedFileHash: string;
-  filePath: string;
+  source: CastVoteRecordFileSource;
+  fileName: string;
   fileType: ReferencedFileType;
 }): ReferencedFile<Buffer> {
   return {
     read: async () => {
       let fileContents: Buffer;
       try {
-        fileContents = await fs.readFile(input.filePath);
+        fileContents = await input.source.readFile(input.fileName);
       } catch (error) {
         if (isNonExistentFileOrDirectoryError(error)) {
           return err({
@@ -75,7 +76,8 @@ function referencedFile(input: {
  */
 export function referencedImageFile(input: {
   expectedFileHash: string;
-  filePath: string;
+  source: CastVoteRecordFileSource;
+  fileName: string;
 }): ReferencedFile<Buffer> {
   return referencedFile({
     ...input,
@@ -89,7 +91,8 @@ export function referencedImageFile(input: {
  */
 export function referencedLayoutFile(input: {
   expectedFileHash: string;
-  filePath: string;
+  source: CastVoteRecordFileSource;
+  fileName: string;
 }): ReferencedFile<BallotPageLayout> {
   const file = referencedFile({
     ...input,

--- a/libs/networking/src/index.ts
+++ b/libs/networking/src/index.ts
@@ -14,8 +14,12 @@ export {
   machineIdFromVxAdminServiceName,
 } from './vx_admin_service.js';
 export type { VxAdminHostMachine } from './vx_admin_service.js';
+export { getCvrTransferUploadPath } from './vx_admin_host_api.js';
 export type {
+  CvrTransferManifest,
+  FinishCvrTransferError,
   RegisterScannerError,
+  StartCvrTransferError,
   VxAdminHostApi,
   VxAdminHostMachineConfig,
 } from './vx_admin_host_api.js';

--- a/libs/networking/src/vx_admin_host_api.test.ts
+++ b/libs/networking/src/vx_admin_host_api.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest';
+import { getCvrTransferUploadPath } from './vx_admin_host_api.js';
+
+test('getCvrTransferUploadPath encodes each path component', () => {
+  expect(getCvrTransferUploadPath('CS-01', 'batch-1', 'cvr-1')).toEqual(
+    '/api/cvr-transfer/CS-01/batch-1/cvr-1'
+  );
+  expect(getCvrTransferUploadPath('a b', 'x/y', 'c?d')).toEqual(
+    '/api/cvr-transfer/a%20b/x%2Fy/c%3Fd'
+  );
+});

--- a/libs/networking/src/vx_admin_host_api.ts
+++ b/libs/networking/src/vx_admin_host_api.ts
@@ -16,6 +16,49 @@ export type RegisterScannerError =
   | { type: 'ballot-hash-mismatch' };
 
 /**
+ * Manifest describing one scanned batch being transferred to a VxAdmin host.
+ * Mirrors the per-batch entries in a USB cast vote record export's batch
+ * manifest.
+ */
+export interface CvrTransferManifest {
+  machineId: string;
+  batchId: string;
+  label: string;
+  pollingPlaceId: string;
+  sheetCount: number;
+  /** ISO 8601 timestamp of when the batch was started. */
+  startedAt: string;
+  isTestMode: boolean;
+}
+
+/** Why a VxAdmin host refused to start a CVR transfer. */
+export type StartCvrTransferError =
+  | RegisterScannerError
+  | { type: 'invalid-mode'; currentMode: 'test' | 'official' };
+
+/** Why a VxAdmin host refused to finish a CVR transfer. */
+export type FinishCvrTransferError =
+  | { type: 'transfer-not-found' }
+  | { type: 'sheet-count-mismatch'; expected: number; received: number }
+  | { type: 'import-failed'; subType: string };
+
+/**
+ * The path of the host's (non-grout) CVR upload endpoint. One request per
+ * cast vote record, with an `application/zip` body containing the record's
+ * file set (report JSON, ballot images, and, for HMPBs, layout files) as
+ * flat entries.
+ */
+export function getCvrTransferUploadPath(
+  scannerMachineId: string,
+  batchId: string,
+  castVoteRecordId: string
+): string {
+  return `/api/cvr-transfer/${encodeURIComponent(
+    scannerMachineId
+  )}/${encodeURIComponent(batchId)}/${encodeURIComponent(castVoteRecordId)}`;
+}
+
+/**
  * The subset of VxAdmin's peer API used by networked central scanners.
  * VxAdmin's peer API statically implements this contract (via `satisfies` in
  * `apps/admin/backend/src/peer_app.ts`), so the two cannot drift apart.
@@ -36,4 +79,28 @@ export type VxAdminHostApi = Api<{
   getCurrentElectionMetadata: () =>
     | { electionDefinition: ElectionDefinition }
     | undefined;
+  /**
+   * Starts (or resumes) transferring one batch of cast vote records. The
+   * import record keyed by (scanner machineId, batchId) is the only transfer
+   * state, so re-starting an interrupted transfer is always safe. Returns
+   * `alreadyComplete: true` if the batch was already fully imported.
+   *
+   * The scanner then uploads one zip per cast vote record (see
+   * {@link getCvrTransferUploadPath}) and calls `finishCvrTransfer`.
+   */
+  startCvrTransfer: (
+    input: CvrTransferManifest & {
+      codeVersion: string;
+      ballotHash: string;
+    }
+  ) => Promise<Result<{ alreadyComplete: boolean }, StartCvrTransferError>>;
+  /**
+   * Completes a transfer started with `startCvrTransfer`: verifies the
+   * received cast vote records against the manifest's sheet count, imports
+   * them, and makes the import visible. Idempotent.
+   */
+  finishCvrTransfer: (input: {
+    machineId: string;
+    batchId: string;
+  }) => Promise<Result<{ cvrCount: number }, FinishCvrTransferError>>;
 }>;

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1473,6 +1473,11 @@ export interface BatchInfo {
   count: number;
   ballotCastingMode?: BallotCastingMode;
   pollingPlaceId: string;
+  /**
+   * When this batch's cast vote records were sent to a VxAdmin host over the
+   * network. Only used on VxCentralScan.
+   */
+  sentToAdminAt?: Iso8601Timestamp;
 }
 
 export const BallotCastingModeSchema = z.enum(['early_voting', 'election_day']);

--- a/libs/utils/src/file_reading.test.ts
+++ b/libs/utils/src/file_reading.test.ts
@@ -2,15 +2,16 @@ import { expect, test } from 'vitest';
 import { Buffer } from 'node:buffer';
 import JsZip, { JSZipObject } from 'jszip';
 import {
-  openZip,
+  createZip,
   getEntries,
   getEntryStream,
-  readEntry,
-  readTextEntry,
-  readJsonEntry,
-  getFilePrefixedByName,
   getFileByName,
+  getFilePrefixedByName,
   maybeGetFileByName,
+  openZip,
+  readEntry,
+  readJsonEntry,
+  readTextEntry,
 } from './file_reading';
 
 // Helper function to create mock JSZipObject entries
@@ -177,4 +178,21 @@ test('maybeGetFileByName returns undefined when file not found', () => {
 
   const result = maybeGetFileByName(entries, 'config.json');
   expect(result).toBeUndefined();
+});
+
+test('createZip round-trips through openZip with stored entries', async () => {
+  const zip = await openZip(
+    await createZip({ 'a.json': '{"a":1}', 'b.bin': Buffer.from([1, 2, 3]) })
+  );
+  const entries = getEntries(zip);
+  expect(entries.map((entry) => entry.name).sort()).toEqual([
+    'a.json',
+    'b.bin',
+  ]);
+  expect(await readTextEntry(getFileByName(entries, 'a.json'))).toEqual(
+    '{"a":1}'
+  );
+  expect(await readEntry(getFileByName(entries, 'b.bin'))).toEqual(
+    Buffer.from([1, 2, 3])
+  );
 });

--- a/libs/utils/src/file_reading.ts
+++ b/libs/utils/src/file_reading.ts
@@ -38,6 +38,21 @@ export function readFile(file: File): Promise<Buffer> {
   });
 }
 
+/**
+ * Builds a zip archive from named files. Entries are stored uncompressed —
+ * callers' payloads are already-compressed images and small JSON — so this
+ * is essentially a container format.
+ */
+export async function createZip(
+  files: Record<string, Buffer | Uint8Array | string>
+): Promise<Buffer> {
+  const zip = new JsZip();
+  for (const [name, data] of Object.entries(files)) {
+    zip.file(name, data);
+  }
+  return await zip.generateAsync({ type: 'nodebuffer', compression: 'STORE' });
+}
+
 export async function openZip(data: Uint8Array): Promise<JsZip> {
   return await new JsZip().loadAsync(data);
 }

--- a/script/src/run-dev/index.ts
+++ b/script/src/run-dev/index.ts
@@ -158,13 +158,16 @@ export async function main(
               env: extraEnv,
             }),
 
-            // Run the service with hot reloading.
+            // Run the service with hot reloading. Backends resolve their dev
+            // workspace relative to the built code (`build/dev-workspace`), and
+            // nodemon always watches `.json` files, so ignore the workspace or
+            // any JSON the running service writes there restarts it.
             npmBinCommand({
               name: `${name}:run`,
               command:
                 'while [ ! -f build/index.js ]; do echo "Waiting for build…"; sleep 1; done; ' +
-                'nodemon --watch build --delay 1 --exitcrash --exec ' +
-                'NODE_ENV=development pnpm start',
+                "nodemon --watch build --ignore 'build/dev-workspace/**' " +
+                '--delay 1 --exitcrash --exec NODE_ENV=development pnpm start',
               prefixColor: 'cyan',
               cwd: serviceRoot,
               env: extraEnv,


### PR DESCRIPTION
## Overview
Best reviewed by commit. See https://github.com/votingworks/vxsuite/pull/9229 for high level overview. 

Adds the ability to transfer cvrs to VxAdmin over the network. VxAdmin exposes a start and finalizeTransfer grout methods along with a 1-cvr file receive endpoint. Cvrs are staged into a temporary directory on disk and into the cvrs_staging db table until the finalize step when they are placed into cvrs and all the other db updates occur. 

More retry/error surfacing on the vxcentralscan side will come in future prs. 

Note currently we only store images for ballots that need adjudication. Drew has mentioned we will likely change this to store all images so the scale thinking here is based on that assumption, I also factor that decision into a helper function so its easier to change later and impact both the network and usb paths. 

## Demo Video or Screenshot

https://github.com/user-attachments/assets/73190b6e-198c-4edd-87c2-1c23341c8b8d


## Testing Plan
Ran Tests & Manual testing with both a scanner and admin running on the same machine in VM. I plan to do more multi-machine and physical hardware testing next week and iterate as needed

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
