### PR TITLE
VxAdmin: add `backups restore` subcommand and various other fixes/improvements

### DIFF
--- a/apps/admin/backend/bin/backups
+++ b/apps/admin/backend/bin/backups
@@ -1,9 +1,28 @@
 #!/usr/bin/env node
 
-import { main } from '../build/backup/cli/main.js';
+import { main, CANCELLED_EXIT_CODE } from '../build/backup/cli/main.js';
+
+// Ctrl-C cancels the running command rather than killing the process: a
+// backup or restore stopped partway leaves debris behind unless it is given
+// the chance to discard what it wrote. A second Ctrl-C gives up on that and
+// exits, so an operation that will not stop can still be escaped.
+const controller = new AbortController();
+process.on('SIGINT', () => {
+  if (controller.signal.aborted) {
+    process.exit(CANCELLED_EXIT_CODE);
+  }
+
+  process.stderr.write('\nCancelling… press Ctrl-C again to exit now.\n');
+  controller.abort();
+});
 
 try {
-  process.exitCode = await main(process.argv, process);
+  process.exitCode = await main(process.argv, {
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    signal: controller.signal,
+  });
 } catch (error) {
   console.error(error);
   process.exitCode = 1;

--- a/apps/admin/backend/src/backup/authenticated_backup.ts
+++ b/apps/admin/backend/src/backup/authenticated_backup.ts
@@ -1,0 +1,58 @@
+import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
+import { VXADMIN_BACKUP_MANIFEST_FILE_NAME } from '@votingworks/auth';
+import { Result } from '@votingworks/basics';
+import { BackupManifest } from './backup_manifest.js';
+import {
+  BackupManifestFile,
+  ReadManifestError,
+} from './backup_manifest_file.js';
+
+/**
+ * A backup whose manifest has been authenticated, and the only way to read one.
+ * Obtained from {@link Backup.open}.
+ *
+ * The manifest is read from a private copy taken while authenticating it, not
+ * from the backup itself, so the bytes parsed here are the same bytes whose
+ * signature was checked. A backup normally sits on removable media that we do
+ * not control, so re-reading it could yield something else entirely.
+ *
+ * That copy is a temporary directory, which is why this must be disposed:
+ *
+ * ```ts
+ * await using backup = (await new Backup(path).open()).unsafeUnwrap();
+ * ```
+ *
+ * Note that only the manifest is authenticated. The rest of the backup is
+ * covered by the hashes *within* the manifest, and still lives on untrusted
+ * media, so each file has to be verified against its manifest entry as it is
+ * read.
+ */
+export class AuthenticatedBackup implements AsyncDisposable {
+  constructor(
+    private readonly backupPath: string,
+    private readonly stagingPath: string
+  ) {}
+
+  /**
+   * Where the backup itself lives, i.e. where its files are to be read from.
+   */
+  get path(): string {
+    return this.backupPath;
+  }
+
+  /**
+   * Reads the authenticated manifest. Authentication proves the manifest is
+   * ours; this may still fail if it is a manifest we cannot understand, such as
+   * one from a newer release.
+   */
+  readManifest(): Promise<Result<BackupManifest, ReadManifestError>> {
+    return new BackupManifestFile(
+      join(this.stagingPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME)
+    ).readManifest();
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await rm(this.stagingPath, { recursive: true, force: true });
+  }
+}

--- a/apps/admin/backend/src/backup/backup.test.ts
+++ b/apps/admin/backend/src/backup/backup.test.ts
@@ -1,6 +1,25 @@
-import { expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { rm, truncate, writeFile } from 'node:fs/promises';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { makeBackup, mockDiskSpace } from '../../test/backup.js';
 import { Backup } from './backup.js';
-import { BackupManifestFile } from './backup_manifest_file.js';
+
+vi.mock(
+  import('@votingworks/backend'),
+  async (importActual): Promise<typeof import('@votingworks/backend')> => {
+    const actual = await importActual();
+    return { ...actual, getDiskSpaceSummaries: vi.fn() };
+  }
+);
+
+beforeEach(() => {
+  mockDiskSpace();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 test('exposes the backup path', () => {
   expect(new Backup('/media/vx/backup/vxadmin-backups/backup-1').path).toEqual(
@@ -8,10 +27,114 @@ test('exposes the backup path', () => {
   );
 });
 
-test('locates the manifest file within the backup', () => {
+test('locates the manifest and its signature within the backup', () => {
   const backup = new Backup('/media/vx/backup/vxadmin-backups/backup-1');
-  expect(backup.manifestFile).toBeInstanceOf(BackupManifestFile);
-  expect(backup.manifestFile.path).toEqual(
+  expect(backup.manifestPath).toEqual(
     '/media/vx/backup/vxadmin-backups/backup-1/manifest.json'
   );
+  expect(backup.signaturePath).toEqual(
+    '/media/vx/backup/vxadmin-backups/backup-1/manifest.json.vxsig'
+  );
+});
+
+test('opens a backup this machine signed', async () => {
+  const backup = await makeBackup();
+  await using authenticatedBackup = (await backup.open()).unsafeUnwrap();
+
+  // The files themselves stay where they are; only the manifest is copied.
+  expect(authenticatedBackup.path).toEqual(backup.path);
+  expect((await authenticatedBackup.readManifest()).ok()).toBeDefined();
+});
+
+test('a backup with no manifest cannot be read', async () => {
+  const backup = await makeBackup();
+  await rm(backup.manifestPath);
+
+  expect((await backup.open()).err()).toEqual({
+    type: 'read-failed',
+    message: expect.stringContaining(backup.manifestPath),
+  });
+});
+
+test('a manifest too large to be one of ours is refused before it is read', async () => {
+  const backup = await makeBackup();
+  // Sparse, so this costs nothing on disk: the point is that the size alone is
+  // enough to refuse it, without reading whatever it claims to hold.
+  await truncate(backup.manifestPath, 100_000_001);
+
+  expect((await backup.open()).err()).toEqual({
+    type: 'read-failed',
+    message: expect.stringContaining(backup.manifestPath),
+  });
+});
+
+test('a signature too large to be one of ours is refused before it is read', async () => {
+  const backup = await makeBackup();
+  await truncate(backup.signaturePath, 100_001);
+
+  // The signature is present, so this is not a backup with no claim to trust —
+  // it reads as damage, the same as an oversized manifest.
+  expect((await backup.open()).err()).toEqual({
+    type: 'read-failed',
+    message: expect.stringContaining(backup.signaturePath),
+  });
+});
+
+test('a backup with no signature cannot be authenticated', async () => {
+  const backup = await makeBackup();
+  await rm(backup.signaturePath);
+
+  expect((await backup.open()).err()).toEqual({
+    type: 'authentication-failed',
+    message: expect.stringContaining(backup.signaturePath),
+  });
+});
+
+test('a backup whose signature does not cover its manifest is refused', async () => {
+  const backup = await makeBackup();
+  await writeFile(backup.manifestPath, '{}');
+
+  expect((await backup.open()).err()).toMatchObject({
+    type: 'authentication-failed',
+  });
+});
+
+test('a backup that cannot be opened leaves no copy behind', async () => {
+  const backup = await makeBackup();
+  await rm(backup.signaturePath);
+
+  // Pointed somewhere empty so that what is left behind can be seen exactly,
+  // rather than picked out of whatever else is in the system temp directory.
+  const temporaryRoot = makeTemporaryDirectory();
+  vi.stubEnv('TMPDIR', temporaryRoot);
+
+  expect((await backup.open()).err()).toBeDefined();
+  expect(readdirSync(temporaryRoot)).toEqual([]);
+});
+
+test('the manifest read is the one that was authenticated', async () => {
+  const backup = await makeBackup();
+  await using authenticatedBackup = (await backup.open()).unsafeUnwrap();
+  const manifest = (await authenticatedBackup.readManifest()).unsafeUnwrap();
+
+  // Whatever the drive says after authentication is not what gets used: a
+  // backup normally sits on removable media we do not control.
+  await writeFile(
+    backup.manifestPath,
+    JSON.stringify({ ...manifest.toJSON(), machineId: 'VX-00-999' }, null, 2)
+  );
+
+  expect(
+    (await authenticatedBackup.readManifest()).unsafeUnwrap().machineId
+  ).toEqual(manifest.machineId);
+});
+
+test('an opened backup discards its copy of the manifest when disposed', async () => {
+  const backup = await makeBackup();
+  const authenticatedBackup = (await backup.open()).unsafeUnwrap();
+  expect((await authenticatedBackup.readManifest()).ok()).toBeDefined();
+
+  await authenticatedBackup[Symbol.asyncDispose]();
+
+  expect((await authenticatedBackup.readManifest()).err()).toBeDefined();
 });

--- a/apps/admin/backend/src/backup/backup.ts
+++ b/apps/admin/backend/src/backup/backup.ts
@@ -1,6 +1,26 @@
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { VXADMIN_BACKUP_MANIFEST_FILE_NAME } from '@votingworks/auth';
-import { BackupManifestFile } from './backup_manifest_file.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import {
+  authenticateArtifactUsingSignatureFile,
+  constructSignatureFilePath,
+  VXADMIN_BACKUP_MANIFEST_FILE_NAME,
+} from '@votingworks/auth';
+import { err, extractErrorMessage, ok, Result } from '@votingworks/basics';
+import { copyFile, CopyFileError } from '@votingworks/fs';
+import { AuthenticatedBackup } from './authenticated_backup.js';
+
+const BACKUP_MANIFEST_MAX_SIZE = 100_000_000; // 100 MB
+const BACKUP_MANIFEST_SIGNATURE_MAX_SIZE = 100_000; // 100 KB
+
+/**
+ * Why a backup could not be opened. Kept apart from each other because they
+ * mean different things to whoever is holding the drive: one is damage, the
+ * other is a backup this machine has no reason to trust.
+ */
+export type BackupOpenError =
+  | { type: 'read-failed'; message: string }
+  | { type: 'authentication-failed'; message: string };
 
 /**
  * Helper for managing a complete on-disk backup.
@@ -12,9 +32,99 @@ export class Backup {
     return this.backupPath;
   }
 
-  get manifestFile(): BackupManifestFile {
-    return new BackupManifestFile(
-      join(this.backupPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME)
-    );
+  get manifestPath(): string {
+    return join(this.backupPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME);
+  }
+
+  get signaturePath(): string {
+    return constructSignatureFilePath({
+      type: 'vxadmin_backup',
+      context: 'import',
+      directoryPath: this.backupPath,
+    });
+  }
+
+  /**
+   * Authenticates this backup's manifest, yielding the only handle from which
+   * a manifest can be read. Dispose of the result when done with it.
+   */
+  async open(): Promise<Result<AuthenticatedBackup, BackupOpenError>> {
+    const stagingPath = await mkdtemp(join(tmpdir(), 'vxadmin-backup-'));
+    let opened = false;
+
+    try {
+      const copyManifestResult = await copyFile({
+        source: this.manifestPath,
+        destination: join(stagingPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME),
+        maxSize: BACKUP_MANIFEST_MAX_SIZE,
+      });
+      if (copyManifestResult.isErr()) {
+        return err({
+          type: 'read-failed',
+          message: describeCopyFileError(
+            this.manifestPath,
+            copyManifestResult.err()
+          ),
+        });
+      }
+
+      const copySignatureResult = await copyFile({
+        source: this.signaturePath,
+        destination: constructSignatureFilePath({
+          type: 'vxadmin_backup',
+          context: 'import',
+          directoryPath: stagingPath,
+        }),
+        maxSize: BACKUP_MANIFEST_SIGNATURE_MAX_SIZE,
+      });
+      if (copySignatureResult.isErr()) {
+        const error = copySignatureResult.err();
+        // A signature that isn't there is a backup this machine can't trust;
+        // a signature that's there but can't be read is damage, the same as
+        // for any other file.
+        return err({
+          type:
+            error.type === 'OpenFileError'
+              ? 'authentication-failed'
+              : 'read-failed',
+          message: describeCopyFileError(this.signaturePath, error),
+        });
+      }
+
+      const authenticateResult = await authenticateArtifactUsingSignatureFile({
+        type: 'vxadmin_backup',
+        context: 'import',
+        directoryPath: stagingPath,
+      });
+      if (authenticateResult.isErr()) {
+        return err({
+          type: 'authentication-failed',
+          message: extractErrorMessage(authenticateResult.err()),
+        });
+      }
+
+      opened = true;
+      return ok(new AuthenticatedBackup(this.backupPath, stagingPath));
+    } finally {
+      if (!opened) {
+        await rm(stagingPath, { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+/**
+ * Describes a failure to copy one of a backup's files, naming the file, since
+ * whoever is holding the drive has no other way to tell which one went wrong.
+ */
+function describeCopyFileError(path: string, error: CopyFileError): string {
+  switch (error.type) {
+    case 'FileExceedsMaxSize': {
+      return `${path} is larger than the maximum of ${error.maxSize} bytes`;
+    }
+
+    default: {
+      return `${extractErrorMessage(error.error)} (${path})`;
+    }
   }
 }

--- a/apps/admin/backend/src/backup/backup.ts
+++ b/apps/admin/backend/src/backup/backup.ts
@@ -123,6 +123,12 @@ function describeCopyFileError(path: string, error: CopyFileError): string {
       return `${path} is larger than the maximum of ${error.maxSize} bytes`;
     }
 
+    /* istanbul ignore next: opening a backup passes no signal, so there is
+       nothing to cancel it */
+    case 'Cancelled': {
+      return `Reading ${path} was cancelled`;
+    }
+
     default: {
       return `${extractErrorMessage(error.error)} (${path})`;
     }

--- a/apps/admin/backend/src/backup/backup_manifest.ts
+++ b/apps/admin/backend/src/backup/backup_manifest.ts
@@ -12,6 +12,14 @@ import {
 export const BACKUP_MANIFEST_VERSION = 1;
 
 /**
+ * The directory within a backup holding the copied workspace files, and thus
+ * the first segment of every manifest entry's path. Shared by the create side,
+ * which writes files under it, and the restore side, which refuses a manifest
+ * entry outside it.
+ */
+export const BACKUP_WORKSPACE_DIR = 'workspace';
+
+/**
  * Schema for {@link ElectionMetadata}.
  */
 export const ElectionMetadataSchema = z.object({

--- a/apps/admin/backend/src/backup/backup_manifest_file.test.ts
+++ b/apps/admin/backend/src/backup/backup_manifest_file.test.ts
@@ -1,7 +1,6 @@
-import { writeFileSync } from 'node:fs';
+import { truncateSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from 'vitest';
-import { z } from 'zod/v4';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { BackupManifestFile } from './backup_manifest_file.js';
 import { BACKUP_MANIFEST_VERSION } from './backup_manifest.js';
@@ -43,9 +42,10 @@ test('returns an error when the manifest is missing', async () => {
   const manifestFile = new BackupManifestFile(join(dir, 'manifest.json'));
 
   const result = await manifestFile.readManifest();
-  expect(result.unsafeUnwrapErr()).toEqual(
-    expect.objectContaining({ type: 'OpenFileError' })
-  );
+  expect(result.unsafeUnwrapErr()).toMatchObject({
+    type: 'read-failed',
+    message: expect.stringContaining('ENOENT'),
+  });
 });
 
 test('returns an error when the manifest is not valid JSON', async () => {
@@ -54,14 +54,61 @@ test('returns an error when the manifest is not valid JSON', async () => {
   writeFileSync(manifestPath, 'not json');
 
   const result = await new BackupManifestFile(manifestPath).readManifest();
-  expect(result.unsafeUnwrapErr()).toBeInstanceOf(SyntaxError);
+  expect(result.unsafeUnwrapErr()).toMatchObject({ type: 'invalid-manifest' });
 });
 
 test('returns an error when the manifest does not match the schema', async () => {
   const dir = makeTemporaryDirectory();
   const manifestPath = join(dir, 'manifest.json');
-  writeFileSync(manifestPath, JSON.stringify({ version: 'invalid' }));
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({ version: BACKUP_MANIFEST_VERSION, machineId: 42 })
+  );
 
   const result = await new BackupManifestFile(manifestPath).readManifest();
-  expect(result.unsafeUnwrapErr()).toBeInstanceOf(z.ZodError);
+  expect(result.unsafeUnwrapErr()).toMatchObject({ type: 'invalid-manifest' });
+});
+
+test('a manifest from another version is its own answer, not a parse failure', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestPath = join(dir, 'manifest.json');
+  const futureVersion = BACKUP_MANIFEST_VERSION + 1;
+  writeFileSync(
+    manifestPath,
+    validManifestJson.replace(
+      `"version":${BACKUP_MANIFEST_VERSION}`,
+      `"version":${futureVersion}`
+    )
+  );
+
+  const result = await new BackupManifestFile(manifestPath).readManifest();
+  expect(result.unsafeUnwrapErr()).toEqual({
+    type: 'unsupported-version',
+    version: futureVersion,
+    message: expect.stringContaining(
+      `Expected backup version ${BACKUP_MANIFEST_VERSION}`
+    ),
+  });
+});
+
+test('a missing version field is a malformed manifest, not another version', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestPath = join(dir, 'manifest.json');
+  writeFileSync(manifestPath, JSON.stringify({ machineId: 'VX-00-001' }));
+
+  const result = await new BackupManifestFile(manifestPath).readManifest();
+  expect(result.unsafeUnwrapErr()).toMatchObject({ type: 'invalid-manifest' });
+});
+
+test('a manifest too large to be one of ours is refused before it is read', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestPath = join(dir, 'manifest.json');
+  writeFileSync(manifestPath, validManifestJson);
+  truncateSync(manifestPath, 100_000_001);
+
+  const result = await new BackupManifestFile(manifestPath).readManifest();
+  expect(result.unsafeUnwrapErr()).toMatchObject({
+    type: 'read-failed',
+    message: expect.stringContaining('100000000'),
+  });
 });

--- a/apps/admin/backend/src/backup/backup_manifest_file.ts
+++ b/apps/admin/backend/src/backup/backup_manifest_file.ts
@@ -1,8 +1,8 @@
 import { readFile, ReadFileError } from '@votingworks/fs';
-import { ok, Result } from '@votingworks/basics';
-import { safeParseJson } from '@votingworks/types';
-import { z } from 'zod/v4';
+import { err, extractErrorMessage, ok, Result } from '@votingworks/basics';
+import { safeParse, safeParseJson } from '@votingworks/types';
 import {
+  BACKUP_MANIFEST_VERSION,
   BackupManifest,
   BackupManifestStructSchema,
 } from './backup_manifest.js';
@@ -10,7 +10,31 @@ import {
 const BACKUP_MANIFEST_MAX_SIZE = 100_000_000; // 100 MB
 
 /**
- * Backup manifest manager for the on-disk `manifest.json` within a backup.
+ * Why a `manifest.json` could not be read as a {@link BackupManifest}. A
+ * mismatched version is its own answer rather than one shape of parse failure:
+ * a manifest from other software is not corrupt, it is just not ours to read.
+ */
+export type ReadManifestError =
+  | { type: 'read-failed'; message: string }
+  | { type: 'invalid-manifest'; message: string }
+  | { type: 'unsupported-version'; version: unknown; message: string };
+
+function describeReadFileError(error: ReadFileError): string {
+  switch (error.type) {
+    case 'FileExceedsMaxSize': {
+      return `file is larger than the maximum of ${error.maxSize} bytes`;
+    }
+
+    default: {
+      return extractErrorMessage(error.error);
+    }
+  }
+}
+
+/**
+ * Reads and parses a `manifest.json` at a given path. Says nothing about
+ * whether that manifest is authentic; see {@link AuthenticatedBackup}, which is
+ * the only thing that reads a manifest out of a backup.
  */
 export class BackupManifestFile {
   constructor(private readonly manifestPath: string) {}
@@ -19,19 +43,54 @@ export class BackupManifestFile {
     return this.manifestPath;
   }
 
-  async readManifest(): Promise<
-    Result<BackupManifest, ReadFileError | SyntaxError | z.ZodError<unknown>>
-  > {
+  async readManifest(): Promise<Result<BackupManifest, ReadManifestError>> {
     const readFileResult = await readFile(this.manifestPath, {
       maxSize: BACKUP_MANIFEST_MAX_SIZE,
     });
-    if (readFileResult.isErr()) return readFileResult;
-    const parseManifestResult = safeParseJson(
-      readFileResult.ok().toString('utf-8'),
-      BackupManifestStructSchema
+    if (readFileResult.isErr()) {
+      return err({
+        type: 'read-failed',
+        message: describeReadFileError(readFileResult.err()),
+      });
+    }
+
+    const parseJsonResult = safeParseJson(
+      readFileResult.ok().toString('utf-8')
     );
-    return parseManifestResult.isErr()
-      ? parseManifestResult
-      : ok(BackupManifest.fromStruct(parseManifestResult.ok()));
+    if (parseJsonResult.isErr()) {
+      return err({
+        type: 'invalid-manifest',
+        message: extractErrorMessage(parseJsonResult.err()),
+      });
+    }
+
+    // Checked apart from the schema, and before it, so that the version can be
+    // reported as what it is. The schema would reject a mismatch too, but only
+    // as an anonymous parse failure.
+    const raw = parseJsonResult.ok();
+    if (
+      typeof raw === 'object' &&
+      raw !== null &&
+      'version' in raw &&
+      raw.version !== BACKUP_MANIFEST_VERSION
+    ) {
+      return err({
+        type: 'unsupported-version',
+        version: raw.version,
+        message: `Expected backup version ${BACKUP_MANIFEST_VERSION}, but the manifest has version ${JSON.stringify(
+          raw.version
+        )}`,
+      });
+    }
+
+    const parseManifestResult = safeParse(BackupManifestStructSchema, raw);
+    if (parseManifestResult.isErr()) {
+      return err({
+        type: 'invalid-manifest',
+        message: extractErrorMessage(parseManifestResult.err()),
+      });
+    }
+
+    return ok(BackupManifest.fromStruct(parseManifestResult.ok()));
   }
 }

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -48,7 +48,12 @@ async function run(args: string[]): Promise<RunResult> {
     stdout: mockWritable(),
     stderr: mockWritable(),
   };
-  const code = await main(['node', 'backups', ...args], streams);
+  // A real logger would write JSON log lines to the test runner's stdout,
+  // interleaved with the command's own output.
+  const code = await main(['node', 'backups', ...args], {
+    ...streams,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
   return {
     code,
     stdout: streams.stdout.toString(),
@@ -122,6 +127,17 @@ test('prints help without error', async () => {
   const { code, stderr } = await run(['--help']);
   expect(code).toEqual(0);
   expect(stderr).toContain('Usage: backups <command> [options]');
+});
+
+test('a logger is optional, since the real entry point does not have one', async () => {
+  const stderr = mockWritable();
+  const code = await main(['node', 'backups', '--help'], {
+    stdin: mockReadable(),
+    stdout: mockWritable(),
+    stderr,
+  });
+  expect(code).toEqual(0);
+  expect(stderr.toString()).toContain('Usage: backups <command> [options]');
 });
 
 test('create requires a target', async () => {

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -22,6 +22,7 @@ import {
   safeParseJson,
 } from '@votingworks/types';
 import { createHash } from 'node:crypto';
+import { prepareSignatureFile } from '@votingworks/auth';
 import { readFile, stat } from 'node:fs/promises';
 import {
   BackupManifest,
@@ -81,28 +82,46 @@ async function makeWorkspace(logger: BaseLogger): Promise<Workspace> {
 
 const MANIFEST_CREATED_AT = '2026-08-18T12:00:00.000Z';
 
-function writeManifest(backupPath: string): void {
-  writeFileSync(
-    join(backupPath, 'manifest.json'),
-    JSON.stringify(
-      new BackupManifest(
-        '4.0.0',
-        'VX-00-001',
-        MANIFEST_CREATED_AT,
-        {
-          id: 'election-1',
-          title: 'General Election',
-          date: new DateWithoutTime('2026-11-03'),
-        },
-        [{ path: 'data/election.db', hash: '0a'.repeat(32), size: 1024 }]
-      )
+async function writeManifest(backupPath: string): Promise<void> {
+  const manifestFileContents = JSON.stringify(
+    new BackupManifest(
+      '4.0.0',
+      'VX-00-001',
+      MANIFEST_CREATED_AT,
+      {
+        id: 'election-1',
+        title: 'General Election',
+        date: new DateWithoutTime('2026-11-03'),
+      },
+      [{ path: 'data/election.db', hash: '0a'.repeat(32), size: 1024 }]
     )
+  );
+  await writeSignedManifest(backupPath, manifestFileContents);
+}
+
+/**
+ * Writes a manifest and, alongside it, the signature that authenticates it,
+ * since reading a manifest means authenticating it first.
+ */
+async function writeSignedManifest(
+  backupPath: string,
+  manifestFileContents: string
+): Promise<void> {
+  writeFileSync(join(backupPath, 'manifest.json'), manifestFileContents);
+  const signatureFile = await prepareSignatureFile({
+    type: 'vxadmin_backup',
+    context: 'export',
+    manifestFileContents,
+  });
+  writeFileSync(
+    join(backupPath, signatureFile.fileName),
+    signatureFile.fileContents
   );
 }
 
-function makeBackup(): string {
+async function makeBackup(): Promise<string> {
   const backup = makeTemporaryDirectory();
-  writeManifest(backup);
+  await writeManifest(backup);
   mkdirSync(join(backup, 'workspace'));
   return backup;
 }
@@ -279,7 +298,7 @@ test('create fails fast when the workspace cannot be opened for another reason',
 });
 
 test('validate lists the backup files', async () => {
-  const { code, stdout, stderr } = await run(['validate', makeBackup()]);
+  const { code, stdout, stderr } = await run(['validate', await makeBackup()]);
   expect(code).toEqual(0);
   expect(stderr).toContain('NOT IMPLEMENTED YET.');
   expect(stdout).toContain('Here are the backup files to be validated:');
@@ -301,8 +320,8 @@ test('list prints the backups on a backup drive', async () => {
   const backupsPath = join(target, 'vxadmin-backups');
   mkdirSync(join(backupsPath, 'backup-1'), { recursive: true });
   mkdirSync(join(backupsPath, 'backup-2'), { recursive: true });
-  writeManifest(join(backupsPath, 'backup-1'));
-  writeManifest(join(backupsPath, 'backup-2'));
+  await writeManifest(join(backupsPath, 'backup-1'));
+  await writeManifest(join(backupsPath, 'backup-2'));
 
   const { code, stdout, stderr } = await run(['list', target]);
   expect(code).toEqual(0);
@@ -325,7 +344,14 @@ test('list reports backups with unreadable manifests on stderr', async () => {
   const backupsPath = join(target, 'vxadmin-backups');
   mkdirSync(join(backupsPath, 'backup-1'), { recursive: true });
   mkdirSync(join(backupsPath, 'no-manifest'), { recursive: true });
-  writeManifest(join(backupsPath, 'backup-1'));
+  mkdirSync(join(backupsPath, 'damaged-manifest'), { recursive: true });
+  await writeManifest(join(backupsPath, 'backup-1'));
+  // Signed, so this is a backup of ours whose manifest did not survive the
+  // trip, as opposed to one we cannot authenticate at all.
+  await writeSignedManifest(
+    join(backupsPath, 'damaged-manifest'),
+    'not a manifest'
+  );
 
   const { code, stdout, stderr } = await run(['list', target]);
   expect(code).toEqual(0);
@@ -335,6 +361,13 @@ test('list reports backups with unreadable manifests on stderr', async () => {
     `[Unreadable Manifest] ${join(
       backupsPath,
       'no-manifest',
+      'manifest.json'
+    )} is invalid:`
+  );
+  expect(stderr).toContain(
+    `[Unreadable Manifest] ${join(
+      backupsPath,
+      'damaged-manifest',
       'manifest.json'
     )} is invalid:`
   );
@@ -361,7 +394,7 @@ test('restore prints the backup manifest', async () => {
     '--workspace',
     makeTemporaryDirectory(),
     '--backup',
-    makeBackup(),
+    await makeBackup(),
   ]);
   expect(code).toEqual(0);
   expect(stderr).toContain('NOT IMPLEMENTED YET.');

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -388,21 +388,65 @@ test('list fails when the target does not exist', async () => {
   );
 });
 
-test('restore prints the backup manifest', async () => {
+test('restore copies a backup into the workspace', async () => {
+  const logger = new BaseLogger(LogSource.VxAdminService);
+  const source = await makeWorkspace(logger);
+  const target = makeTemporaryDirectory();
+  expect(
+    (await run(['create', '--workspace', source.path, '--target', target])).code
+  ).toEqual(0);
+  const backup = join(
+    target,
+    'vxadmin-backups',
+    'franklin-county_lincoln-municipal-general-election_dc2aa66c40'
+  );
+
+  const workspace = makeTemporaryDirectory();
   const { code, stdout, stderr } = await run([
+    'restore',
+    '--workspace',
+    workspace,
+    '--backup',
+    backup,
+  ]);
+  expect(code).toEqual(0);
+
+  // Progress is reported on stderr, one line per step since the mock stream is
+  // not a terminal, and never mixed into stdout.
+  expect(stderr).toContain('Copying files');
+  expect(stderr).toContain('Verifying restored files');
+  expect(stderr).toContain('Flushing to disk');
+  // \u001b is ESC: nothing tries to move a cursor that isn't there.
+  expect(stderr).not.toContain('\u001b');
+
+  expect(stdout).toContain(`Restored ${backup} to ${workspace}.`);
+
+  const client = Client.fileClient(
+    join(workspace, 'data.db'),
+    mockBaseLogger({ fn: vi.fn })
+  );
+  const { count } = client.one('select count(*) as count from elections') as {
+    count: number;
+  };
+  expect(count).toEqual(1);
+});
+
+test('restore fails when the manifest cannot be read', async () => {
+  const backup = makeTemporaryDirectory();
+  await writeSignedManifest(backup, 'not a manifest');
+
+  const { code, stderr } = await run([
     'restore',
     '--workspace',
     makeTemporaryDirectory(),
     '--backup',
-    await makeBackup(),
+    backup,
   ]);
-  expect(code).toEqual(0);
-  expect(stderr).toContain('NOT IMPLEMENTED YET.');
-  expect(stdout).toContain('BackupManifest');
-  expect(stdout).toContain('VX-00-001');
+  expect(code).toEqual(1);
+  expect(stderr).toContain('Error: ');
 });
 
-test('restore fails when the manifest cannot be read', async () => {
+test('restore fails when the backup cannot be opened', async () => {
   const backup = makeTemporaryDirectory();
   const { code, stderr } = await run([
     'restore',
@@ -412,7 +456,21 @@ test('restore fails when the manifest cannot be read', async () => {
     backup,
   ]);
   expect(code).toEqual(1);
-  expect(stderr).toContain(
-    `Error: unable to read manifest at ${join(backup, 'manifest.json')}`
-  );
+  expect(stderr).toContain(`Error: `);
+  expect(stderr).toContain(join(backup, 'manifest.json'));
+});
+
+test('restore refuses a configured workspace', async () => {
+  const logger = new BaseLogger(LogSource.VxAdminService);
+  const workspace = await makeWorkspace(logger);
+
+  const { code, stderr } = await run([
+    'restore',
+    '--workspace',
+    workspace.path,
+    '--backup',
+    await makeBackup(),
+  ]);
+  expect(code).toEqual(1);
+  expect(stderr).toContain('Error: Expected workspace to be unconfigured');
 });

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -28,7 +28,7 @@ import {
   BackupManifest,
   BackupManifestStructSchema,
 } from '../backup_manifest.js';
-import { main } from './main.js';
+import { CANCELLED_EXIT_CODE, main } from './main.js';
 import { createWorkspace, Workspace } from '../../util/workspace.js';
 
 interface RunResult {
@@ -43,7 +43,10 @@ interface MockStreams {
   stderr: MockWritable;
 }
 
-async function run(args: string[]): Promise<RunResult> {
+async function run(
+  args: string[],
+  { signal }: { signal?: AbortSignal } = {}
+): Promise<RunResult> {
   const streams: MockStreams = {
     stdin: mockReadable(),
     stdout: mockWritable(),
@@ -54,6 +57,7 @@ async function run(args: string[]): Promise<RunResult> {
   const code = await main(['node', 'backups', ...args], {
     ...streams,
     logger: mockBaseLogger({ fn: vi.fn }),
+    signal,
   });
   return {
     code,
@@ -473,4 +477,47 @@ test('restore refuses a configured workspace', async () => {
   ]);
   expect(code).toEqual(1);
   expect(stderr).toContain('Error: Expected workspace to be unconfigured');
+});
+
+test('create reports a cancelled backup rather than a failed one', async () => {
+  const logger = new BaseLogger(LogSource.VxAdminService);
+  const source = await makeWorkspace(logger);
+  const target = makeTemporaryDirectory();
+
+  const { code, stdout, stderr } = await run(
+    ['create', '--workspace', source.path, '--target', target],
+    { signal: AbortSignal.abort() }
+  );
+
+  expect(code).toEqual(CANCELLED_EXIT_CODE);
+  expect(stderr).toContain('Cancelled. No backup was written.');
+  expect(stdout).toEqual('');
+  expect(readdirSync(target)).toEqual([]);
+});
+
+test('restore cancelled before it starts leaves the workspace as it was', async () => {
+  const logger = new BaseLogger(LogSource.VxAdminService);
+  const source = await makeWorkspace(logger);
+  const target = makeTemporaryDirectory();
+  expect(
+    (await run(['create', '--workspace', source.path, '--target', target])).code
+  ).toEqual(0);
+  const backup = join(
+    target,
+    'vxadmin-backups',
+    'franklin-county_lincoln-municipal-general-election_dc2aa66c40'
+  );
+
+  const workspace = makeTemporaryDirectory();
+  writeFileSync(join(workspace, 'already-here'), 'from before the restore');
+
+  const { code, stdout, stderr } = await run(
+    ['restore', '--workspace', workspace, '--backup', backup],
+    { signal: AbortSignal.abort() }
+  );
+
+  expect(code).toEqual(CANCELLED_EXIT_CODE);
+  expect(stderr).toContain('Cancelled. No backup was restored.');
+  expect(stdout).toEqual('');
+  expect(readdirSync(workspace)).toEqual(['already-here']);
 });

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -31,6 +31,14 @@ export interface Streams {
  */
 export interface MainContext extends Streams {
   logger?: BaseLogger;
+
+  /**
+   * When given, aborting this signal cancels a `create` or `restore` in
+   * progress. The entry point wires it to `SIGINT`, so Ctrl-C stops the
+   * command by discarding what it had written rather than by killing the
+   * process partway through writing it.
+   */
+  signal?: AbortSignal;
 }
 
 interface BackupArguments {
@@ -42,11 +50,17 @@ interface BackupArguments {
 }
 
 /**
+ * Exit code for a command the operator cancelled, following the shell
+ * convention of 128 plus the signal number for `SIGINT`.
+ */
+export const CANCELLED_EXIT_CODE = 130;
+
+/**
  * Entry point for the `backups` CLI.
  */
 export async function main(
   argv: readonly string[],
-  { stdin, stdout, stderr, logger: providedLogger }: MainContext
+  { stdin, stdout, stderr, logger: providedLogger, signal }: MainContext
 ): Promise<number> {
   const logger = providedLogger ?? new BaseLogger(LogSource.VxAdminService);
   const parser = yargs()
@@ -138,13 +152,13 @@ export async function main(
 
   switch (args._[0]) {
     case 'create':
-      return await create(args, { stdin, stdout, stderr, logger });
+      return await create(args, { stdin, stdout, stderr, logger, signal });
     case 'validate':
       return await validate(args, { stdin, stdout, stderr });
     case 'list':
       return await list(args, { stdin, stdout, stderr });
     case 'restore':
-      return await restore(args, { stdin, stdout, stderr, logger });
+      return await restore(args, { stdin, stdout, stderr, logger, signal });
     /* istanbul ignore next: `strict` rejects unknown commands */
     default:
       throw new Error(`Unknown command: ${args._[0]}`);
@@ -211,7 +225,12 @@ function openWorkspaceIfPresent(
  */
 async function create(
   args: BackupArguments,
-  { stdout, stderr, logger }: Streams & { logger: BaseLogger }
+  {
+    stdout,
+    stderr,
+    logger,
+    signal,
+  }: Streams & { logger: BaseLogger; signal?: AbortSignal }
 ): Promise<number> {
   assert(typeof args.workspace === 'string');
   assert(typeof args.target === 'string');
@@ -236,13 +255,21 @@ async function create(
     workspace,
     target: args.target,
     logger,
+    signal,
     onProgressEvent: (event) => display.update(displayProgress(event)),
   });
 
   if (createBackupResult.isErr()) {
-    // Leave the bar where it stopped: it says which step failed.
+    const error = createBackupResult.err();
+    // Leave the bar where it stopped: it says which step was interrupted.
     display.finish();
-    stderr.write(`Error: ${createBackupResult.err().message}\n`);
+
+    if (error.type === 'cancelled') {
+      stderr.write('Cancelled. No backup was written.\n');
+      return CANCELLED_EXIT_CODE;
+    }
+
+    stderr.write(`Error: ${error.message}\n`);
     return 1;
   }
 
@@ -338,7 +365,12 @@ async function list(
  */
 async function restore(
   args: BackupArguments,
-  { stdout, stderr, logger }: Streams & { logger: BaseLogger }
+  {
+    stdout,
+    stderr,
+    logger,
+    signal,
+  }: Streams & { logger: BaseLogger; signal?: AbortSignal }
 ): Promise<number> {
   assert(typeof args.workspace === 'string');
   assert(typeof args.backup === 'string');
@@ -354,13 +386,21 @@ async function restore(
     backup: args.backup,
     workspace: args.workspace,
     logger,
+    signal,
     onProgressEvent: (event) => display.update(displayProgress(event)),
   });
 
   if (restoreBackupResult.isErr()) {
-    // Leave the bar where it stopped: it says which step failed.
+    const error = restoreBackupResult.err();
+    // Leave the bar where it stopped: it says which step was interrupted.
     display.finish();
-    stderr.write(`Error: ${restoreBackupResult.err().message}\n`);
+
+    if (error.type === 'cancelled') {
+      stderr.write('Cancelled. No backup was restored.\n');
+      return CANCELLED_EXIT_CODE;
+    }
+
+    stderr.write(`Error: ${error.message}\n`);
     return 1;
   }
 

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -14,7 +14,7 @@ import { StyledPrinter } from './styled_printer.js';
 import { DisplayProgress, ProgressDisplay } from './progress_display.js';
 import * as views from './views.js';
 import { Backup } from '../backup.js';
-import { ProgressEvent } from '../create/types.js';
+import { ProgressEvent } from '../progress.js';
 import { createBackup } from '../create/index.js';
 import { openWorkspace, Workspace } from '../../util/workspace.js';
 

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -165,6 +165,8 @@ const PROGRESS_LABELS: Record<ProgressEvent['type'], string> = {
   writing_manifest: 'Writing manifest',
   flushing_backup: 'Flushing to device',
   swapping_backup: 'Swapping into place',
+  verifying: 'Verifying restored files',
+  flushing_workspace: 'Flushing to disk',
 };
 
 function displayProgress(event: ProgressEvent): DisplayProgress {

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -9,12 +9,10 @@ import { BackupRoot } from '../backup_root.js';
 import { StyledPrinter } from './styled_printer.js';
 import { DisplayProgress, ProgressDisplay } from './progress_display.js';
 import * as views from './views.js';
-import { inspect } from 'node:util';
 import { ProgressEvent } from '../progress.js';
 import { createBackup } from '../create/index.js';
 import { openWorkspace, Workspace } from '../../util/workspace.js';
-import { Backup } from '../backup.js';
-import { BackupManifestFile } from '../backup_manifest_file.js';
+import { restoreBackup } from '../restore/index.js';
 
 /**
  * IO streams given to the CLI.
@@ -146,7 +144,7 @@ export async function main(
     case 'list':
       return await list(args, { stdin, stdout, stderr });
     case 'restore':
-      return await restore(args, { stdin, stdout, stderr });
+      return await restore(args, { stdin, stdout, stderr, logger });
     /* istanbul ignore next: `strict` rejects unknown commands */
     default:
       throw new Error(`Unknown command: ${args._[0]}`);
@@ -340,32 +338,36 @@ async function list(
  */
 async function restore(
   args: BackupArguments,
-  { stdout, stderr }: Streams
+  { stdout, stderr, logger }: Streams & { logger: BaseLogger }
 ): Promise<number> {
   assert(typeof args.workspace === 'string');
   assert(typeof args.backup === 'string');
 
-  stderr.write('NOT IMPLEMENTED YET.\n');
+  // Progress goes to stderr so that stdout carries only the command's own
+  // output, and so redirecting one doesn't garble the other.
+  const display = new ProgressDisplay(
+    stderr,
+    Boolean((stderr as NodeJS.WriteStream).isTTY)
+  );
 
-  const backup = new Backup(args.backup);
-  const readManifestResult = await new BackupManifestFile(
-    backup.manifestPath
-  ).readManifest();
+  const restoreBackupResult = await restoreBackup({
+    backup: args.backup,
+    workspace: args.workspace,
+    logger,
+    onProgressEvent: (event) => display.update(displayProgress(event)),
+  });
 
-  if (readManifestResult.isErr()) {
-    stderr.write(
-      `Error: unable to read manifest at ${backup.manifestPath}: ${
-        readManifestResult.err().message
-      }`
-    );
+  if (restoreBackupResult.isErr()) {
+    // Leave the bar where it stopped: it says which step failed.
+    display.finish();
+    stderr.write(`Error: ${restoreBackupResult.err().message}\n`);
     return 1;
   }
 
-  const manifest = readManifestResult.ok();
-  stdout.write(inspect(manifest));
-  stdout.write('\n');
+  display.clear();
+  stdout.write(`Restored ${args.backup} to ${args.workspace}.\n`);
 
-  return await Promise.resolve(0);
+  return 0;
 }
 
 async function enumerateSourceFiles(

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -27,6 +27,16 @@ export interface Streams {
   stderr: NodeJS.WritableStream;
 }
 
+/**
+ * Everything the CLI needs from its caller: the IO streams, and optionally
+ * where to send log messages. Without a logger, log messages go to a real
+ * {@link BaseLogger}, i.e. to stdout as JSON lines — tests pass a mock so log
+ * output doesn't interleave with the command's own.
+ */
+export interface MainContext extends Streams {
+  logger?: BaseLogger;
+}
+
 interface BackupArguments {
   _: Array<string | number>;
   workspace?: string;
@@ -40,8 +50,9 @@ interface BackupArguments {
  */
 export async function main(
   argv: readonly string[],
-  { stdin, stdout, stderr }: Streams
+  { stdin, stdout, stderr, logger: providedLogger }: MainContext
 ): Promise<number> {
+  const logger = providedLogger ?? new BaseLogger(LogSource.VxAdminService);
   const parser = yargs()
     .scriptName('backups')
     .usage('Usage: $0 <command> [options]')
@@ -117,9 +128,21 @@ export async function main(
     return parseError ? 1 : 0;
   }
 
+  // Every command authenticates backups through `libs/auth`, which reads
+  // `NODE_ENV` and `VX_MACHINE_TYPE` straight from the environment and throws
+  // when they aren't set, so normalize whatever we resolved into the
+  // environment instead of making the caller export them.
+  const nodeEnv = getNodeEnv();
+  assert(
+    nodeEnv !== 'production',
+    `the backups CLI is a development tool, but NODE_ENV is ${nodeEnv}`
+  );
+  (process.env as { NODE_ENV?: string }).NODE_ENV = nodeEnv;
+  (process.env as { VX_MACHINE_TYPE?: string }).VX_MACHINE_TYPE = 'admin';
+
   switch (args._[0]) {
     case 'create':
-      return await create(args, { stdin, stdout, stderr });
+      return await create(args, { stdin, stdout, stderr, logger });
     case 'validate':
       return await validate(args, { stdin, stdout, stderr });
     case 'list':
@@ -190,24 +213,10 @@ function openWorkspaceIfPresent(
  */
 async function create(
   args: BackupArguments,
-  { stdout, stderr }: Streams
+  { stdout, stderr, logger }: Streams & { logger: BaseLogger }
 ): Promise<number> {
   assert(typeof args.workspace === 'string');
   assert(typeof args.target === 'string');
-
-  // The `backups` CLI is a development tool. `libs/auth` reads `NODE_ENV`
-  // straight from the environment and throws when it isn't set, so normalize
-  // whatever we resolved into the environment instead of making the caller
-  // export it.
-  const nodeEnv = getNodeEnv();
-  assert(
-    nodeEnv !== 'production',
-    `the backups CLI is a development tool, but NODE_ENV is ${nodeEnv}`
-  );
-  (process.env as { NODE_ENV?: string }).NODE_ENV = nodeEnv;
-  (process.env as { VX_MACHINE_TYPE?: string }).VX_MACHINE_TYPE = 'admin';
-
-  const logger = new BaseLogger(LogSource.VxAdminService);
 
   // Progress goes to stderr so that stdout carries only the command's own
   // output, and so redirecting one doesn't garble the other.

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -1,11 +1,7 @@
 import assert from 'node:assert';
 import { relative } from 'node:path';
-import { inspect } from 'node:util';
 import yargs from 'yargs';
-import {
-  extractErrorMessage,
-  isNonExistentFileOrDirectoryError,
-} from '@votingworks/basics';
+import { isNonExistentFileOrDirectoryError } from '@votingworks/basics';
 import { FileSystemEntryType, listDirectoryRecursive } from '@votingworks/fs';
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import { getNodeEnv } from '@votingworks/backend';
@@ -13,10 +9,12 @@ import { BackupRoot } from '../backup_root.js';
 import { StyledPrinter } from './styled_printer.js';
 import { DisplayProgress, ProgressDisplay } from './progress_display.js';
 import * as views from './views.js';
-import { Backup } from '../backup.js';
+import { inspect } from 'node:util';
 import { ProgressEvent } from '../progress.js';
 import { createBackup } from '../create/index.js';
 import { openWorkspace, Workspace } from '../../util/workspace.js';
+import { Backup } from '../backup.js';
+import { BackupManifestFile } from '../backup_manifest_file.js';
 
 /**
  * IO streams given to the CLI.
@@ -303,11 +301,21 @@ async function list(
   let printedBackup = false;
 
   for (const backup of backups) {
-    const readManifestResult = await backup.manifestFile.readManifest();
+    const openBackupResult = await backup.open();
+    if (openBackupResult.isErr()) {
+      views.unreadableManifest(errorPrinter, {
+        manifestPath: backup.manifestPath,
+        error: openBackupResult.err().message,
+      });
+      continue;
+    }
+
+    await using authenticatedBackup = openBackupResult.ok();
+    const readManifestResult = await authenticatedBackup.readManifest();
     if (readManifestResult.isErr()) {
       views.unreadableManifest(errorPrinter, {
-        manifestPath: backup.manifestFile.path,
-        error: readManifestResult.err(),
+        manifestPath: backup.manifestPath,
+        error: readManifestResult.err().message,
       });
       continue;
     }
@@ -338,13 +346,15 @@ async function restore(
   stderr.write('NOT IMPLEMENTED YET.\n');
 
   const backup = new Backup(args.backup);
-  const readManifestResult = await backup.manifestFile.readManifest();
+  const readManifestResult = await new BackupManifestFile(
+    backup.manifestPath
+  ).readManifest();
 
   if (readManifestResult.isErr()) {
     stderr.write(
-      `Error: unable to read manifest at ${
-        backup.manifestFile.path
-      }: ${extractErrorMessage(readManifestResult.err())}`
+      `Error: unable to read manifest at ${backup.manifestPath}: ${
+        readManifestResult.err().message
+      }`
     );
     return 1;
   }

--- a/apps/admin/backend/src/backup/create/copy_step.test.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.test.ts
@@ -1,21 +1,16 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
-import { Buffer } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
 import { assertDefined } from '@votingworks/basics';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { DEV_MACHINE_ID, LATEST_SOFTWARE_VERSION } from '@votingworks/types';
+import { mockBaseLogger } from '@votingworks/logging';
 import {
-  electionFamousNames2021Fixtures,
-  makeTemporaryDirectory,
-} from '@votingworks/fixtures';
-import {
-  DEFAULT_SYSTEM_SETTINGS,
-  DEV_MACHINE_ID,
-  LATEST_SOFTWARE_VERSION,
-} from '@votingworks/types';
-import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
-import { getDiskSpaceSummaries } from '@votingworks/backend';
-import { createWorkspace, Workspace } from '../../util/workspace.js';
+  addCvrWithBallotImage,
+  makeConfiguredWorkspace,
+  mockDiskSpace,
+} from '../../../test/backup.js';
 import { prepare } from './prepare_step.js';
 import { copy } from './copy_step.js';
 import { ProgressEvent } from '../progress.js';
@@ -31,109 +26,13 @@ vi.mock(
   }
 );
 
-const GENEROUS_AVAILABLE_KB = 1_000_000_000; // 1 TB, i.e. "don't worry about space"
-
 beforeEach(() => {
-  vi.mocked(getDiskSpaceSummaries).mockImplementation((paths) =>
-    Promise.resolve(
-      paths.map((path) => ({
-        path,
-        mountpoint: '/',
-        total: GENEROUS_AVAILABLE_KB,
-        used: 0,
-        available: GENEROUS_AVAILABLE_KB,
-      }))
-    )
-  );
+  mockDiskSpace();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
-
-async function makeConfiguredWorkspace(): Promise<Workspace> {
-  const logger = new BaseLogger(LogSource.VxAdminService);
-  const workspace = createWorkspace(makeTemporaryDirectory(), logger);
-  const { electionPackage, readElectionDefinition } =
-    electionFamousNames2021Fixtures;
-  const electionId = await workspace.store.addElection({
-    electionData: readElectionDefinition().electionData,
-    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
-    electionPackageSourceFilePath: electionPackage.asFilePath(),
-    electionPackageHash: createHash('sha256')
-      .update(electionPackage.asBuffer())
-      .digest('hex'),
-  });
-  workspace.store.setCurrentElectionId(electionId);
-  return workspace;
-}
-
-/**
- * Adds a single CVR with a ballot image directly via low-level store calls,
- * bypassing the CVR export/import pipeline entirely.
- */
-function addCvrWithBallotImage(
-  workspace: Workspace,
-  { ballotId = 'ballot-1' }: { ballotId?: string } = {}
-): void {
-  const { store } = workspace;
-  const electionId = store.getCurrentElectionId();
-  if (!electionId) throw new Error('workspace has no current election');
-  const electionRecord = store.getElection(electionId);
-  if (!electionRecord) throw new Error('current election not found');
-  const { election } = electionRecord.electionDefinition;
-
-  store.addScannerBatch({
-    batchId: 'batch-1',
-    scannerId: 'scanner-1',
-    label: 'Batch 1',
-    electionId,
-    startedAt: new Date().toISOString(),
-  });
-  store.addCastVoteRecordFileRecord({
-    id: 'cvr-file-1',
-    electionId,
-    isTestMode: false,
-    filename: 'cvrs.jsonl',
-    exportedTimestamp: new Date().toISOString(),
-    sha256Hash: 'hash',
-    scannerIds: new Set(['scanner-1']),
-    pollingPlaceIds: new Set(),
-    batchIds: ['batch-1'],
-  });
-  const result = store.addCastVoteRecordFileEntry({
-    electionId,
-    cvrFileId: 'cvr-file-1',
-    ballotId,
-    cvr: {
-      ballotStyleGroupId: election.ballotStyles[0]!.groupId,
-      batchId: 'batch-1',
-      card: { type: 'bmd' },
-      precinctId: election.precincts[0]!.id,
-      votes: {},
-      votingMethod: 'precinct',
-    },
-    adjudicationFlags: {
-      isBlank: false,
-      hasOvervote: false,
-      hasUndervote: false,
-      hasWriteIn: true,
-      hasMarginalMark: false,
-      hasCrossoverVote: false,
-    },
-  });
-  if (result.isErr()) {
-    throw new Error(`failed to add cvr: ${JSON.stringify(result.err())}`);
-  }
-  const { cvrId: insertedCvrId } = result.ok();
-
-  store.addBallotImage({
-    cvrId: insertedCvrId,
-    electionDefinitionId: election.id,
-    imageData: Buffer.from('fake-front-image-data'),
-    side: 'front',
-  });
-}
 
 test('copies staged files to the backup directory and builds a manifest', async () => {
   const workspace = await makeConfiguredWorkspace();

--- a/apps/admin/backend/src/backup/create/copy_step.test.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import { rmSync } from 'node:fs';
 import { assertDefined } from '@votingworks/basics';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { DEV_MACHINE_ID, LATEST_SOFTWARE_VERSION } from '@votingworks/types';
@@ -51,14 +52,16 @@ test('copies staged files to the backup directory and builds a manifest', async 
   const electionMetadata = assertDefined(
     snapshotStore.getElectionMetadata(electionId)
   );
-  const manifest = await copy({
-    electionId,
-    source,
-    store: snapshotStore,
-    backup: backupPath,
-    logger: mockBaseLogger({ fn: vi.fn }),
-    onProgressEvent: (event) => progressEvents.push(event),
-  });
+  const manifest = (
+    await copy({
+      electionId,
+      source,
+      store: snapshotStore,
+      backup: backupPath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+      onProgressEvent: (event) => progressEvents.push(event),
+    })
+  ).unsafeUnwrap();
 
   // Every staged file landed at `<backup>/<relativePath>` with the exact
   // bytes it had in the staging area, and the manifest describes it
@@ -135,15 +138,17 @@ async function copyWithProgress(
   } = prepareResult.unsafeUnwrap();
   const events: ProgressEvent[] = [];
 
-  await copy({
-    electionId,
-    source,
-    store,
-    backup: join(makeTemporaryDirectory(), 'backup'),
-    logger: mockBaseLogger({ fn: vi.fn }),
-    progressEventIntervalBytes,
-    onProgressEvent: (event) => events.push(event),
-  });
+  (
+    await copy({
+      electionId,
+      source,
+      store,
+      backup: join(makeTemporaryDirectory(), 'backup'),
+      logger: mockBaseLogger({ fn: vi.fn }),
+      progressEventIntervalBytes,
+      onProgressEvent: (event) => events.push(event),
+    })
+  ).unsafeUnwrap();
 
   const { fileCount } = source;
   await source.cleanup();
@@ -206,4 +211,32 @@ test('throttles progress to the given interval', async () => {
   // An interval no file can cross leaves only the events that bracket the copy
   // and the one announcing each file.
   expect(events).toHaveLength(fileCount + 2);
+});
+
+test('reports a staged file that cannot be read', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(workspace);
+
+  const prepareResult = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+  const { electionId, source, snapshotStore } = prepareResult.unsafeUnwrap();
+
+  // The staging area holds links to the workspace's own files, which a failing
+  // disk can stop producing between being staged and being copied.
+  rmSync(assertDefined(source.listStagedFiles()[0]).path);
+
+  const result = await copy({
+    electionId,
+    source,
+    store: snapshotStore,
+    backup: join(makeTemporaryDirectory(), 'backup'),
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toMatchObject({ type: 'OpenFileError' });
+
+  await source.cleanup();
 });

--- a/apps/admin/backend/src/backup/create/copy_step.test.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.test.ts
@@ -18,7 +18,7 @@ import { getDiskSpaceSummaries } from '@votingworks/backend';
 import { createWorkspace, Workspace } from '../../util/workspace.js';
 import { prepare } from './prepare_step.js';
 import { copy } from './copy_step.js';
-import { ProgressEvent } from './types.js';
+import { ProgressEvent } from '../progress.js';
 
 vi.mock(
   import('@votingworks/backend'),

--- a/apps/admin/backend/src/backup/create/copy_step.test.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.test.ts
@@ -240,3 +240,37 @@ test('reports a staged file that cannot be read', async () => {
 
   await source.cleanup();
 });
+
+test('stops copying when cancelled between files', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(workspace);
+
+  const prepareResult = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+  const { electionId, source, snapshotStore } = prepareResult.unsafeUnwrap();
+  const backup = join(makeTemporaryDirectory(), 'backup');
+  const controller = new AbortController();
+
+  const result = await copy({
+    electionId,
+    source,
+    store: snapshotStore,
+    backup,
+    logger: mockBaseLogger({ fn: vi.fn }),
+    signal: controller.signal,
+    onProgressEvent(event) {
+      // Abort once the first file has landed, so the copy stops with files
+      // still to go rather than after it would have finished anyway.
+      if (event.type === 'copy_files' && event.copiedCount === 1) {
+        controller.abort();
+      }
+    },
+  });
+
+  expect(result.err()).toEqual({ type: 'Cancelled' });
+
+  await source.cleanup();
+});

--- a/apps/admin/backend/src/backup/create/copy_step.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.ts
@@ -1,14 +1,14 @@
-import { Buffer } from 'node:buffer';
 import { mkdir } from 'node:fs/promises';
 import { dirname, join, relative } from 'node:path';
-import { createReadStream, createWriteStream } from 'node:fs';
-import { createHash } from 'node:crypto';
-import { pipeline } from 'node:stream/promises';
-import { Transform } from 'node:stream';
 import { DateTime } from 'luxon';
-import { assert, assertDefined } from '@votingworks/basics';
+import { assert, assertDefined, ok, Result } from '@votingworks/basics';
+import { copyFile, CopyFileError } from '@votingworks/fs';
 import { LATEST_SOFTWARE_VERSION } from '@votingworks/types';
-import { BackupManifest, BackupManifestEntry } from '../backup_manifest.js';
+import {
+  BACKUP_WORKSPACE_DIR,
+  BackupManifest,
+  BackupManifestEntry,
+} from '../backup_manifest.js';
 import { CopyBackupOptions } from './types.js';
 import { getMachineConfig } from '../../machine_config.js';
 
@@ -25,7 +25,7 @@ const DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES = 8_000_000; // 8 MB
  */
 export async function copy(
   options: CopyBackupOptions
-): Promise<BackupManifest> {
+): Promise<Result<BackupManifest, CopyFileError>> {
   const { electionId, source, store } = options;
   const progressEventIntervalBytes =
     options.progressEventIntervalBytes ?? DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES;
@@ -42,7 +42,7 @@ export async function copy(
     totalBytes,
   });
   const backupPath = options.backup;
-  const backupWorkspacePath = join(backupPath, 'workspace');
+  const backupWorkspacePath = join(backupPath, BACKUP_WORKSPACE_DIR);
 
   // `prepare` resolved this election ID against the same snapshot, so its
   // metadata is necessarily there.
@@ -59,39 +59,35 @@ export async function copy(
     });
     const targetFilePath = join(backupWorkspacePath, file.relativePath);
     await mkdir(dirname(targetFilePath), { recursive: true });
-    const reader = createReadStream(file.path);
-    const writer = createWriteStream(targetFilePath);
-    const hash = createHash('sha256');
     const baseCopiedCount = copiedCount;
     const baseCopiedBytes = copiedBytes;
-    let size = 0;
     let reportedSize = 0;
 
-    await pipeline(
-      reader,
-      new Transform({
-        transform(chunk: Buffer, _encoding, callback) {
-          hash.write(chunk);
-          size += chunk.byteLength;
+    const copyFileResult = await copyFile({
+      source: file.path,
+      destination: targetFilePath,
+      maxSize: file.size,
+      digest: 'sha256',
+      onProgress(fileCopiedBytes) {
+        if (fileCopiedBytes - reportedSize >= progressEventIntervalBytes) {
+          reportedSize = fileCopiedBytes;
+          options.onProgressEvent?.({
+            type: 'copy_files',
+            current: file.relativePath,
+            copiedCount: baseCopiedCount,
+            totalCount,
+            copiedBytes: baseCopiedBytes + fileCopiedBytes,
+            totalBytes,
+          });
+        }
+      },
+    });
 
-          if (size - reportedSize >= progressEventIntervalBytes) {
-            reportedSize = size;
-            options.onProgressEvent?.({
-              type: 'copy_files',
-              current: file.relativePath,
-              copiedCount: baseCopiedCount,
-              totalCount,
-              copiedBytes: baseCopiedBytes + size,
-              totalBytes,
-            });
-          }
+    if (copyFileResult.isErr()) {
+      return copyFileResult;
+    }
 
-          callback(null, chunk);
-        },
-      }),
-      writer
-    );
-
+    const { size, sha256: hash } = copyFileResult.ok();
     copiedCount += 1;
     copiedBytes += file.size;
 
@@ -103,7 +99,7 @@ export async function copy(
     backupManifestEntries.push({
       path: relative(backupPath, targetFilePath),
       size,
-      hash: hash.digest('hex'),
+      hash,
     });
   }
 
@@ -126,11 +122,13 @@ export async function copy(
   const softwareVersion = LATEST_SOFTWARE_VERSION;
   const machineConfig = getMachineConfig();
 
-  return new BackupManifest(
-    softwareVersion,
-    machineConfig.machineId,
-    DateTime.now().toISO(),
-    electionMetadata,
-    backupManifestEntries
+  return ok(
+    new BackupManifest(
+      softwareVersion,
+      machineConfig.machineId,
+      DateTime.now().toISO(),
+      electionMetadata,
+      backupManifestEntries
+    )
   );
 }

--- a/apps/admin/backend/src/backup/create/copy_step.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.ts
@@ -22,11 +22,16 @@ const DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES = 8_000_000; // 8 MB
 /**
  * Copies files from a backup staging area to the target, building a manifest
  * as it does so.
+ *
+ * Cancelling is left to {@link copyFile}, which refuses to open a file once
+ * `signal` has aborted and stops between chunks of one it is partway through.
+ * A cancel between two files is therefore reported by the next file's copy
+ * rather than by this loop.
  */
 export async function copy(
   options: CopyBackupOptions
 ): Promise<Result<BackupManifest, CopyFileError>> {
-  const { electionId, source, store } = options;
+  const { electionId, signal, source, store } = options;
   const progressEventIntervalBytes =
     options.progressEventIntervalBytes ?? DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES;
   let copiedCount = 0;
@@ -68,6 +73,7 @@ export async function copy(
       destination: targetFilePath,
       maxSize: file.size,
       digest: 'sha256',
+      signal,
       onProgress(fileCopiedBytes) {
         if (fileCopiedBytes - reportedSize >= progressEventIntervalBytes) {
           reportedSize = fileCopiedBytes;

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -1,23 +1,20 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { err, ok } from '@votingworks/basics';
 import { dirname, join } from 'node:path';
-import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
-import { Buffer } from 'node:buffer';
-import {
-  electionFamousNames2021Fixtures,
-  makeTemporaryDirectory,
-} from '@votingworks/fixtures';
-import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
-import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
-import { getDiskSpaceSummaries } from '@votingworks/backend';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import { mockBaseLogger } from '@votingworks/logging';
 import { generateElectionBasedSubfolderName } from '@votingworks/utils';
 import {
   authenticateArtifactUsingSignatureFile,
   VXADMIN_BACKUP_MANIFEST_FILE_NAME,
 } from '@votingworks/auth';
-import { createWorkspace, Workspace } from '../../util/workspace.js';
+import {
+  addCvrWithBallotImage,
+  makeConfiguredWorkspace,
+  mockDiskSpace,
+} from '../../../test/backup.js';
 import { Store } from '../../store.js';
 import { createBackup } from './index.js';
 import { BackupRoot } from '../backup_root.js';
@@ -69,109 +66,17 @@ vi.mock(
   }
 );
 
-const GENEROUS_AVAILABLE_KB = 1_000_000_000; // 1 TB, i.e. "don't worry about space"
-
 beforeEach(() => {
-  vi.mocked(getDiskSpaceSummaries).mockImplementation((paths) =>
-    Promise.resolve(
-      paths.map((path) => ({
-        path,
-        mountpoint: '/',
-        total: GENEROUS_AVAILABLE_KB,
-        used: 0,
-        available: GENEROUS_AVAILABLE_KB,
-      }))
-    )
-  );
+  mockDiskSpace();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function makeConfiguredWorkspace(): Promise<Workspace> {
-  const logger = new BaseLogger(LogSource.VxAdminService);
-  const workspace = createWorkspace(makeTemporaryDirectory(), logger);
-  const { electionPackage, readElectionDefinition } =
-    electionFamousNames2021Fixtures;
-  const electionId = await workspace.store.addElection({
-    electionData: readElectionDefinition().electionData,
-    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
-    electionPackageSourceFilePath: electionPackage.asFilePath(),
-    electionPackageHash: createHash('sha256')
-      .update(electionPackage.asBuffer())
-      .digest('hex'),
-  });
-  workspace.store.setCurrentElectionId(electionId);
-  return workspace;
-}
-
-function addCvrWithBallotImage(
-  workspace: Workspace,
-  { ballotId }: { ballotId: string }
-): void {
-  const { store } = workspace;
-  const electionId = store.getCurrentElectionId();
-  if (!electionId) throw new Error('workspace has no current election');
-  const electionRecord = store.getElection(electionId);
-  if (!electionRecord) throw new Error('current election not found');
-  const { election } = electionRecord.electionDefinition;
-
-  const result = store.addCastVoteRecordFileEntry({
-    electionId,
-    cvrFileId: 'cvr-file-1',
-    ballotId,
-    cvr: {
-      ballotStyleGroupId: election.ballotStyles[0]!.groupId,
-      batchId: 'batch-1',
-      card: { type: 'bmd' },
-      precinctId: election.precincts[0]!.id,
-      votes: {},
-      votingMethod: 'precinct',
-    },
-    adjudicationFlags: {
-      isBlank: false,
-      hasOvervote: false,
-      hasUndervote: false,
-      hasWriteIn: true,
-      hasMarginalMark: false,
-      hasCrossoverVote: false,
-    },
-  });
-  if (result.isErr()) {
-    throw new Error(`failed to add cvr: ${JSON.stringify(result.err())}`);
-  }
-  const { cvrId } = result.ok();
-
-  store.addBallotImage({
-    cvrId,
-    electionDefinitionId: election.id,
-    imageData: Buffer.from(`fake-image-data-for-${ballotId}`),
-    side: 'front',
-  });
-}
-
 test('a second backup atomically replaces the first, leaving no leftovers', async () => {
   const workspace = await makeConfiguredWorkspace();
   const electionId = workspace.store.getCurrentElectionId()!;
-  workspace.store.addScannerBatch({
-    batchId: 'batch-1',
-    scannerId: 'scanner-1',
-    label: 'Batch 1',
-    electionId,
-    startedAt: new Date().toISOString(),
-  });
-  workspace.store.addCastVoteRecordFileRecord({
-    id: 'cvr-file-1',
-    electionId,
-    isTestMode: false,
-    filename: 'cvrs.jsonl',
-    exportedTimestamp: new Date().toISOString(),
-    sha256Hash: 'hash',
-    scannerIds: new Set(['scanner-1']),
-    pollingPlaceIds: new Set(),
-    batchIds: ['batch-1'],
-  });
   addCvrWithBallotImage(workspace, { ballotId: 'ballot-1' });
 
   const target = makeTemporaryDirectory();

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { readdirSync, readFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
-import { mockBaseLogger } from '@votingworks/logging';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import { generateElectionBasedSubfolderName } from '@votingworks/utils';
 import {
   authenticateArtifactUsingSignatureFile,
@@ -92,6 +92,22 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
     logger,
   });
   const firstCreated = firstResult.unsafeUnwrap();
+
+  // A backup copies off the machine's entire data state, so both the attempt
+  // and its outcome belong in the audit log.
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupCreateInit,
+    'system',
+    expect.objectContaining({ message: expect.stringContaining(target) })
+  );
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupCreateComplete,
+    'system',
+    expect.objectContaining({
+      disposition: 'success',
+      message: expect.stringContaining(firstCreated.path),
+    })
+  );
 
   // The staging area holding the snapshot is deleted once the copy is done, so
   // its connection has to be closed or the space it holds is never reclaimed.
@@ -188,16 +204,25 @@ test('reports an error when copying the backup fails', async () => {
   const target = makeTemporaryDirectory();
   vi.mocked(copy).mockRejectedValueOnce(outOfSpaceError());
 
+  const logger = mockBaseLogger({ fn: vi.fn });
   const result = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger,
   });
 
   expect(result.err()).toEqual({
     type: 'backup-write-failed',
     message: 'no space left on device',
   });
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupCreateComplete,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      errorType: 'backup-write-failed',
+    })
+  );
 });
 
 test('reports an error when writing the manifest fails, leaving no partial backup', async () => {

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -380,3 +380,102 @@ test('reports a failed swap rather than a created backup', async () => {
     message: 'could not swap',
   });
 });
+
+test('a cancelled copy leaves no partial backup behind', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+  vi.mocked(copy).mockResolvedValueOnce(err({ type: 'Cancelled' }));
+
+  // No signal here: what is under test is how the orchestration handles a
+  // copy that reports it was cancelled, not where the cancel came from.
+  const logger = mockBaseLogger({ fn: vi.fn });
+  const result = await createBackup({
+    workspace,
+    target,
+    logger,
+  });
+
+  expect(result.err()).toEqual({
+    type: 'cancelled',
+    message: 'Backup cancelled',
+  });
+  expect(readdirSync(new BackupRoot(target).pathFor('.'))).toEqual([]);
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupCreateComplete,
+    'system',
+    expect.objectContaining({ disposition: 'failure', errorType: 'cancelled' })
+  );
+});
+
+test('cancelling after the copy finishes stops before the manifest is written', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(workspace);
+  const target = makeTemporaryDirectory();
+  const controller = new AbortController();
+
+  const result = await createBackup({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+    signal: controller.signal,
+    onProgressEvent(event) {
+      // The event announcing the last file copied: everything is written but
+      // nothing has been signed or swapped into place yet.
+      if (
+        event.type === 'copy_files' &&
+        event.copiedCount === event.totalCount
+      ) {
+        controller.abort();
+      }
+    },
+  });
+
+  expect(result.err()).toEqual({
+    type: 'cancelled',
+    message: 'Backup cancelled',
+  });
+  expect(vi.mocked(writeManifest)).not.toHaveBeenCalled();
+
+  // An unsigned pile of copied files is not a backup, so it is discarded
+  // rather than left where `listBackups` would find it.
+  expect(readdirSync(new BackupRoot(target).pathFor('.'))).toEqual([]);
+});
+
+test('a backup already in place survives a cancelled attempt to replace it', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(workspace);
+  const target = makeTemporaryDirectory();
+
+  const firstResult = await createBackup({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+  const backupPath = firstResult.unsafeUnwrap().path;
+  const backupContentsBefore = readdirSync(backupPath).sort();
+
+  const controller = new AbortController();
+  const secondResult = await createBackup({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+    signal: controller.signal,
+    onProgressEvent(event) {
+      if (event.type === 'db_snapshot') {
+        controller.abort();
+      }
+    },
+  });
+
+  expect(secondResult.err()).toEqual({
+    type: 'cancelled',
+    message: 'Backup cancelled',
+  });
+
+  // Cancelling replaces nothing: the backup the operator already had is the
+  // backup they still have.
+  expect(readdirSync(backupPath).sort()).toEqual(backupContentsBefore);
+  expect(readdirSync(new BackupRoot(target).pathFor('.'))).toEqual([
+    relative(new BackupRoot(target).pathFor('.'), backupPath),
+  ]);
+});

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { err, ok } from '@votingworks/basics';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { readdirSync, readFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
@@ -191,6 +191,30 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
   // What `create` wrote is what `list` finds: the two agreed on the layout.
   const listed = (await new BackupRoot(target).listBackups()).unsafeUnwrap();
   expect(listed.map((b) => b.path)).toEqual([backupPath]);
+});
+
+test('resolves a relative target path', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+
+  const result = await createBackup({
+    workspace,
+    target: relative(process.cwd(), target),
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // The backup landed in the target, reported at its absolute path.
+  const electionRecord = workspace.store.getElection(
+    workspace.store.getCurrentElectionId()!
+  )!;
+  expect(result.unsafeUnwrap().path).toEqual(
+    new BackupRoot(target).pathFor(
+      generateElectionBasedSubfolderName(
+        electionRecord.electionDefinition.election,
+        electionRecord.electionDefinition.ballotHash
+      )
+    )
+  );
 });
 
 function outOfSpaceError(): NodeJS.ErrnoException {

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -249,6 +249,48 @@ test('reports an error when copying the backup fails', async () => {
   );
 });
 
+test('reports a backup file that could not be copied, leaving no partial backup', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+  vi.mocked(copy).mockResolvedValueOnce(
+    err({ type: 'WriteFileError', error: outOfSpaceError() })
+  );
+
+  const result = await createBackup({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toEqual({
+    type: 'backup-write-failed',
+    message: 'no space left on device',
+  });
+  expect(readdirSync(new BackupRoot(target).pathFor('.'))).toEqual([]);
+});
+
+test('reports a staged file that outgrew the size it was measured at', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+  vi.mocked(copy).mockResolvedValueOnce(
+    err({ type: 'FileExceedsMaxSize', maxSize: 1024 })
+  );
+
+  const result = await createBackup({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // A staged file is copied under the size staging measured for it, so this
+  // means the workspace changed underneath the backup rather than that some
+  // limit of ours was too small.
+  expect(result.err()).toEqual({
+    type: 'backup-write-failed',
+    message: expect.stringContaining('grew past its measured size'),
+  });
+});
+
 test('reports an error when writing the manifest fails, leaving no partial backup', async () => {
   const workspace = await makeConfiguredWorkspace();
   const target = makeTemporaryDirectory();

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -7,6 +7,7 @@ import {
   ok,
   Result,
 } from '@votingworks/basics';
+import { LogEventId } from '@votingworks/logging';
 import { prepare, PrepareError } from './prepare_step.js';
 import { PrepareBackupOptions } from './types.js';
 import { copy } from './copy_step.js';
@@ -56,6 +57,33 @@ export interface CreatedBackup {
  * database, ballot images, and election packages.
  */
 export async function createBackup(
+  options: PrepareBackupOptions
+): Promise<Result<CreatedBackup, CreateBackupError>> {
+  const { logger } = options;
+  logger.log(LogEventId.BackupCreateInit, 'system', {
+    message: `Creating a backup at ${options.target}...`,
+  });
+
+  const result = await tryCreateBackup(options);
+
+  if (result.isOk()) {
+    logger.log(LogEventId.BackupCreateComplete, 'system', {
+      disposition: 'success',
+      message: `Backup created successfully at ${result.ok().path}.`,
+    });
+  } else {
+    const error = result.err();
+    logger.log(LogEventId.BackupCreateComplete, 'system', {
+      disposition: 'failure',
+      errorType: error.type,
+      message: `Failed to create backup: ${error.message}`,
+    });
+  }
+
+  return result;
+}
+
+async function tryCreateBackup(
   options: PrepareBackupOptions
 ): Promise<Result<CreatedBackup, CreateBackupError>> {
   const prepareResult = await prepare(options);

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { mkdir, rm } from 'node:fs/promises';
 import {
   assertDefined,
@@ -57,8 +57,14 @@ export interface CreatedBackup {
  * database, ballot images, and election packages.
  */
 export async function createBackup(
-  options: PrepareBackupOptions
+  rawOptions: PrepareBackupOptions
 ): Promise<Result<CreatedBackup, CreateBackupError>> {
+  // The staging area requires absolute paths, so resolve what the caller gave
+  // us up front and use the same absolute path everywhere.
+  const options: PrepareBackupOptions = {
+    ...rawOptions,
+    target: resolve(rawOptions.target),
+  };
   const { logger } = options;
   logger.log(LogEventId.BackupCreateInit, 'system', {
     message: `Creating a backup at ${options.target}...`,

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -121,7 +121,7 @@ async function tryCreateBackup(
       // Clear the leftovers of any interrupted run before writing.
       await rm(inProgressBackupPath, { recursive: true, force: true });
 
-      manifest = await copy({
+      const copyResult = await copy({
         electionId,
         source,
         store: snapshotStore,
@@ -129,6 +129,26 @@ async function tryCreateBackup(
         logger: options.logger,
         onProgressEvent: options.onProgressEvent,
       });
+      if (copyResult.isErr()) {
+        const error = copyResult.err();
+
+        // Same cleanup as a thrown write error below: discard what we managed
+        // to write, best effort.
+        try {
+          await rm(inProgressBackupPath, { recursive: true, force: true });
+        } catch {
+          // ignored
+        }
+
+        return err({
+          type: 'backup-write-failed',
+          message:
+            error.type === 'FileExceedsMaxSize'
+              ? `A staged file grew past its measured size (max ${error.maxSize} bytes)`
+              : extractErrorMessage(error.error),
+        });
+      }
+      manifest = copyResult.ok();
     } finally {
       // Close the snapshot's connection before deleting the file it holds
       // open, or the space it occupies won't be reclaimed until we exit.

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -26,9 +26,21 @@ export interface WriteBackupError {
 }
 
 /**
+ * Reported when the caller cancelled the backup.
+ */
+export interface CancelBackupError {
+  type: 'cancelled';
+  message: string;
+}
+
+/**
  * Possible expected errors that can occur when creating a backup.
  */
-export type CreateBackupError = PrepareError | WriteBackupError | SwapError;
+export type CreateBackupError =
+  | PrepareError
+  | WriteBackupError
+  | CancelBackupError
+  | SwapError;
 
 /**
  * Error codes we expect from writing a backup to its target: the drive filling
@@ -89,6 +101,29 @@ export async function createBackup(
   return result;
 }
 
+/**
+ * Reported when the caller cancelled the backup.
+ */
+const CANCELLED_ERROR: CreateBackupError = {
+  type: 'cancelled',
+  message: 'Backup cancelled',
+};
+
+/**
+ * Throws away a backup that will never be finished. Best effort: whatever
+ * stopped the write may stop the cleanup too, and the next run clears the path
+ * before it writes anything.
+ */
+async function discardInProgressBackup(
+  inProgressBackupPath: string
+): Promise<void> {
+  try {
+    await rm(inProgressBackupPath, { recursive: true, force: true });
+  } catch {
+    // ignored
+  }
+}
+
 async function tryCreateBackup(
   options: PrepareBackupOptions
 ): Promise<Result<CreatedBackup, CreateBackupError>> {
@@ -128,16 +163,15 @@ async function tryCreateBackup(
         backup: inProgressBackupPath,
         logger: options.logger,
         onProgressEvent: options.onProgressEvent,
+        signal: options.signal,
       });
       if (copyResult.isErr()) {
         const error = copyResult.err();
 
-        // Same cleanup as a thrown write error below: discard what we managed
-        // to write, best effort.
-        try {
-          await rm(inProgressBackupPath, { recursive: true, force: true });
-        } catch {
-          // ignored
+        await discardInProgressBackup(inProgressBackupPath);
+
+        if (error.type === 'Cancelled') {
+          return err(CANCELLED_ERROR);
         }
 
         return err({
@@ -156,6 +190,14 @@ async function tryCreateBackup(
       await source.cleanup();
     }
 
+    // The last point a backup can be abandoned cheaply: past the swap below
+    // there is a new backup in place of the old one, and the operator is
+    // better served by a finished backup than by a half-swapped directory.
+    if (options.signal?.aborted) {
+      await discardInProgressBackup(inProgressBackupPath);
+      return err(CANCELLED_ERROR);
+    }
+
     await writeManifest({
       manifest,
       backup: inProgressBackupPath,
@@ -168,15 +210,9 @@ async function tryCreateBackup(
       throw error;
     }
 
-    // The backup at its final path is still intact, so discard what we managed
-    // to write instead of leaving it for a later run to clean up. Best effort:
-    // whatever stopped the write may stop the cleanup too, and the next run
-    // clears the path before it writes anything.
-    try {
-      await rm(inProgressBackupPath, { recursive: true, force: true });
-    } catch {
-      // ignored
-    }
+    // The backup at its final path is still intact, so what this run managed
+    // to write is discarded rather than left for a later run to clean up.
+    await discardInProgressBackup(inProgressBackupPath);
 
     return err({
       type: 'backup-write-failed',

--- a/apps/admin/backend/src/backup/create/manifest_step.test.ts
+++ b/apps/admin/backend/src/backup/create/manifest_step.test.ts
@@ -19,7 +19,7 @@ import {
   BackupManifestStructSchema,
 } from '../backup_manifest.js';
 import { writeManifest } from './manifest_step.js';
-import { ProgressEvent } from './types.js';
+import { ProgressEvent } from '../progress.js';
 
 function makeManifest(): BackupManifest {
   const { election } = electionFamousNames2021Fixtures.readElectionDefinition();

--- a/apps/admin/backend/src/backup/create/manifest_step.ts
+++ b/apps/admin/backend/src/backup/create/manifest_step.ts
@@ -17,7 +17,7 @@ export async function writeManifest(
 
   const manifestFileContents = JSON.stringify(manifest, null, 2);
   await writeFile(
-    new Backup(backup).manifestFile.path,
+    new Backup(backup).manifestPath,
     manifestFileContents,
     'utf-8'
   );

--- a/apps/admin/backend/src/backup/create/prepare_step.test.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.test.ts
@@ -365,3 +365,105 @@ test('fails loudly when a referenced ballot image is missing from disk', async (
     path: imagePath,
   });
 });
+
+test('cancels before doing any work when the signal is already aborted', async () => {
+  const workspace = await makeConfiguredWorkspace();
+
+  const result = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+    signal: AbortSignal.abort(),
+  });
+
+  expect(result.err()).toEqual({
+    type: 'cancelled',
+    message: 'Backup cancelled',
+  });
+
+  // Nothing was claimed, so a later run has no leftovers to reclaim.
+  expect(existsSync(BackupStagingArea.pathIn(workspace.path))).toEqual(false);
+});
+
+test('cancels before snapshotting the database', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const controller = new AbortController();
+
+  // Measuring free space is the last thing that happens before the snapshot,
+  // which is the expensive part a cancel is meant to avoid paying for.
+  vi.mocked(getDiskSpaceSummaries).mockImplementation((paths) => {
+    controller.abort();
+    return Promise.resolve(
+      paths.map((path) => ({
+        path,
+        mountpoint: '/',
+        total: GENEROUS_AVAILABLE_KB,
+        used: 0,
+        available: GENEROUS_AVAILABLE_KB,
+      }))
+    );
+  });
+
+  const result = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+    signal: controller.signal,
+  });
+
+  expect(result.err()).toEqual({
+    type: 'cancelled',
+    message: 'Backup cancelled',
+  });
+});
+
+test('cancels partway through snapshotting the database', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(workspace);
+  const controller = new AbortController();
+
+  const result = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+    signal: controller.signal,
+    onProgressEvent: (event) => {
+      if (event.type === 'db_snapshot') {
+        controller.abort();
+      }
+    },
+  });
+
+  expect(result.err()).toEqual({
+    type: 'cancelled',
+    message: 'Backup cancelled',
+  });
+
+  // The snapshot the aborted backup was writing is not left behind.
+  expect(existsSync(BackupStagingArea.pathIn(workspace.path))).toEqual(false);
+});
+
+test('cancels after staging files, before measuring the target', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(workspace);
+  const controller = new AbortController();
+
+  const result = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+    signal: controller.signal,
+    onProgressEvent: (event) => {
+      if (event.type === 'staging_files') {
+        controller.abort();
+      }
+    },
+  });
+
+  expect(result.err()).toEqual({
+    type: 'cancelled',
+    message: 'Backup cancelled',
+  });
+
+  expect(existsSync(BackupStagingArea.pathIn(workspace.path))).toEqual(false);
+});

--- a/apps/admin/backend/src/backup/create/prepare_step.test.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { join } from 'node:path';
-import { createHash } from 'node:crypto';
 import {
   existsSync,
   mkdirSync,
@@ -9,15 +8,16 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { Buffer } from 'node:buffer';
-import {
-  electionFamousNames2021Fixtures,
-  makeTemporaryDirectory,
-} from '@votingworks/fixtures';
-import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
-import { createWorkspace, Workspace } from '../../util/workspace.js';
+import {
+  addCvrWithBallotImage,
+  GENEROUS_AVAILABLE_KB,
+  makeConfiguredWorkspace,
+  mockDiskSpace,
+} from '../../../test/backup.js';
+import { createWorkspace } from '../../util/workspace.js';
 import { Store } from '../../store.js';
 import { BackupStagingArea } from '../staging_area.js';
 import { prepare } from './prepare_step.js';
@@ -33,117 +33,13 @@ vi.mock(
   }
 );
 
-const GENEROUS_AVAILABLE_KB = 1_000_000_000; // 1 TB, i.e. "don't worry about space"
-
 beforeEach(() => {
-  vi.mocked(getDiskSpaceSummaries).mockImplementation((paths) =>
-    Promise.resolve(
-      paths.map((path) => ({
-        path,
-        mountpoint: '/',
-        total: GENEROUS_AVAILABLE_KB,
-        used: 0,
-        available: GENEROUS_AVAILABLE_KB,
-      }))
-    )
-  );
+  mockDiskSpace();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
-
-async function makeConfiguredWorkspace(): Promise<Workspace> {
-  const logger = new BaseLogger(LogSource.VxAdminService);
-  const workspace = createWorkspace(makeTemporaryDirectory(), logger);
-  const { electionPackage, readElectionDefinition } =
-    electionFamousNames2021Fixtures;
-  const electionId = await workspace.store.addElection({
-    electionData: readElectionDefinition().electionData,
-    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
-    electionPackageSourceFilePath: electionPackage.asFilePath(),
-    electionPackageHash: createHash('sha256')
-      .update(electionPackage.asBuffer())
-      .digest('hex'),
-  });
-  workspace.store.setCurrentElectionId(electionId);
-  return workspace;
-}
-
-/**
- * Adds a single CVR with a ballot image directly via low-level store calls,
- * bypassing the CVR export/import pipeline entirely.
- */
-function addCvrWithBallotImage(
-  workspace: Workspace,
-  { ballotId = 'ballot-1' }: { ballotId?: string } = {}
-): { imagePath: string } {
-  const { store } = workspace;
-  const electionId = store.getCurrentElectionId();
-  if (!electionId) throw new Error('workspace has no current election');
-  const electionRecord = store.getElection(electionId);
-  if (!electionRecord) throw new Error('current election not found');
-  const { election } = electionRecord.electionDefinition;
-
-  store.addScannerBatch({
-    batchId: 'batch-1',
-    scannerId: 'scanner-1',
-    label: 'Batch 1',
-    electionId,
-    startedAt: new Date().toISOString(),
-  });
-  store.addCastVoteRecordFileRecord({
-    id: 'cvr-file-1',
-    electionId,
-    isTestMode: false,
-    filename: 'cvrs.jsonl',
-    exportedTimestamp: new Date().toISOString(),
-    sha256Hash: 'hash',
-    scannerIds: new Set(['scanner-1']),
-    pollingPlaceIds: new Set(),
-    batchIds: ['batch-1'],
-  });
-  const result = store.addCastVoteRecordFileEntry({
-    electionId,
-    cvrFileId: 'cvr-file-1',
-    ballotId,
-    cvr: {
-      ballotStyleGroupId: election.ballotStyles[0]!.groupId,
-      batchId: 'batch-1',
-      card: { type: 'bmd' },
-      precinctId: election.precincts[0]!.id,
-      votes: {},
-      votingMethod: 'precinct',
-    },
-    adjudicationFlags: {
-      isBlank: false,
-      hasOvervote: false,
-      hasUndervote: false,
-      hasWriteIn: true,
-      hasMarginalMark: false,
-      hasCrossoverVote: false,
-    },
-  });
-  if (result.isErr()) {
-    throw new Error(`failed to add cvr: ${JSON.stringify(result.err())}`);
-  }
-  const { cvrId: insertedCvrId } = result.ok();
-
-  store.addBallotImage({
-    cvrId: insertedCvrId,
-    electionDefinitionId: election.id,
-    imageData: Buffer.from('fake-front-image-data'),
-    side: 'front',
-  });
-
-  return {
-    imagePath: join(
-      workspace.store.getBallotImagesPath(),
-      election.id,
-      `${insertedCvrId}-front`
-    ),
-  };
-}
 
 test('reclaims a killed run’s staging area before measuring free space', async () => {
   const workspace = await makeConfiguredWorkspace();
@@ -380,16 +276,8 @@ test('fails fast when the target disk space check fails for another reason', asy
 
 test('fails with insufficient-workspace-storage when the workspace volume is too full', async () => {
   const workspace = await makeConfiguredWorkspace();
-  vi.mocked(getDiskSpaceSummaries).mockImplementation((paths) =>
-    Promise.resolve(
-      paths.map((path) => ({
-        path,
-        mountpoint: '/',
-        total: 100,
-        used: 99,
-        available: path === workspace.path ? 1 : GENEROUS_AVAILABLE_KB,
-      }))
-    )
+  mockDiskSpace((path) =>
+    path === workspace.path ? 1 : GENEROUS_AVAILABLE_KB
   );
 
   const result = await prepare({
@@ -407,17 +295,7 @@ test('fails with insufficient-target-storage when the target volume is too full'
   const workspace = await makeConfiguredWorkspace();
   addCvrWithBallotImage(workspace);
   const target = makeTemporaryDirectory();
-  vi.mocked(getDiskSpaceSummaries).mockImplementation((paths) =>
-    Promise.resolve(
-      paths.map((path) => ({
-        path,
-        mountpoint: '/',
-        total: 100,
-        used: 99,
-        available: path === target ? 1 : GENEROUS_AVAILABLE_KB,
-      }))
-    )
-  );
+  mockDiskSpace((path) => (path === target ? 1 : GENEROUS_AVAILABLE_KB));
 
   // Installed after the workspace exists so the last store built is the
   // snapshot's.
@@ -439,7 +317,7 @@ test('fails with insufficient-target-storage when the target volume is too full'
 
 test('stages a database snapshot, election package, and ballot images', async () => {
   const workspace = await makeConfiguredWorkspace();
-  const { imagePath } = addCvrWithBallotImage(workspace);
+  const { imagePath, imageData } = addCvrWithBallotImage(workspace);
   const progressEvents: Array<{ type: string }> = [];
 
   const result = await prepare({
@@ -465,7 +343,7 @@ test('stages a database snapshot, election package, and ballot images', async ()
 
   await stagingArea.cleanup();
   // the original file must be untouched by staging
-  expect(readFileSync(imagePath)).toEqual(Buffer.from('fake-front-image-data'));
+  expect(readFileSync(imagePath)).toEqual(imageData);
 });
 
 test('fails loudly when a referenced ballot image is missing from disk', async () => {

--- a/apps/admin/backend/src/backup/create/prepare_step.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.ts
@@ -30,6 +30,10 @@ async function statOrUndefined(path: string): Promise<Stats | undefined> {
  */
 export type PrepareError =
   | {
+      type: 'cancelled';
+      message: string;
+    }
+  | {
       type: 'file-not-found';
       path: string;
       message: string;
@@ -63,6 +67,21 @@ export type PrepareError =
       required: number;
       message: string;
     };
+
+/**
+ * Reported when the caller cancelled the backup.
+ */
+const CANCELLED_ERROR: PrepareError = {
+  type: 'cancelled',
+  message: 'Backup cancelled',
+};
+
+/**
+ * Thrown from the database snapshot's progress callback to abort it, which is
+ * the only way to stop a snapshot partway: `better-sqlite3` closes the backup
+ * and rejects when its progress callback throws.
+ */
+class CancelledError extends Error {}
 
 /**
  * Reported when the database cannot be snapshotted because something else is
@@ -103,10 +122,14 @@ export interface PreparedBackup {
 export async function prepare(
   options: PrepareBackupOptions
 ): Promise<Result<PreparedBackup, PrepareError>> {
-  const { logger, onProgressEvent, target, workspace } = options;
+  const { logger, onProgressEvent, signal, target, workspace } = options;
   const minAvailableStorageBytes =
     options.minAvailableStorageBytes ?? DEFAULT_MIN_AVAILABLE_STORAGE_BYTES;
   onProgressEvent?.({ type: 'preparing' });
+
+  if (signal?.aborted) {
+    return err(CANCELLED_ERROR);
+  }
 
   // Check the target up front: an unmounted backup drive is the likeliest
   // reason for a backup to fail, and snapshotting the database before noticing
@@ -193,8 +216,18 @@ export async function prepare(
       return err(WRITE_IN_PROGRESS_ERROR);
     }
 
+    // So that a backup cancelled before the snapshot starts never copies a
+    // page of it.
+    if (signal?.aborted) {
+      return err(CANCELLED_ERROR);
+    }
+
     await dbClient.backup(dbSnapshotPath, {
       progress(info) {
+        if (signal?.aborted) {
+          throw new CancelledError();
+        }
+
         onProgressEvent?.({
           type: 'db_snapshot',
           progress: (info.totalPages - info.remainingPages) / info.totalPages,
@@ -246,6 +279,13 @@ export async function prepare(
       })
     );
 
+    // Linking is cheap enough that the images already started are left to
+    // finish; this only keeps the expensive target measurement below from
+    // running for a backup nobody is waiting for.
+    if (signal?.aborted) {
+      return err(CANCELLED_ERROR);
+    }
+
     const backupSizeBytes = await iter(stagingArea.listStagedFiles())
       .async()
       .map(({ size }) => size)
@@ -285,6 +325,10 @@ export async function prepare(
       snapshotStore,
     });
   } catch (error) {
+    if (error instanceof CancelledError) {
+      return err(CANCELLED_ERROR);
+    }
+
     if (isNonExistentFileOrDirectoryError(error)) {
       return err({
         type: 'file-not-found',

--- a/apps/admin/backend/src/backup/create/swap_step.test.ts
+++ b/apps/admin/backend/src/backup/create/swap_step.test.ts
@@ -6,7 +6,7 @@ import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { mockBaseLogger } from '@votingworks/logging';
 import { exchangePaths, syncFilesystem, SyscallError } from '@votingworks/fs';
 import { swap } from './swap_step.js';
-import { ProgressEvent } from './types.js';
+import { ProgressEvent } from '../progress.js';
 
 vi.mock(
   import('@votingworks/fs'),

--- a/apps/admin/backend/src/backup/create/types.ts
+++ b/apps/admin/backend/src/backup/create/types.ts
@@ -1,44 +1,9 @@
-import { BaseLogger } from '@votingworks/logging';
 import { Id } from '@votingworks/types';
 import { BackupStagingArea } from '../staging_area.js';
 import { Store } from '../../store.js';
 import { BackupManifest } from '../backup_manifest.js';
 import { Workspace } from '../../util/workspace.js';
-
-/**
- * Basic options for all steps.
- */
-export interface ProgressTracking {
-  /**
-   * When given this callback will be called repeatedly as the backup
-   * progresses.
-   */
-  onProgressEvent?: (event: ProgressEvent) => void;
-
-  /**
-   * Where to send log messages during the backup.
-   */
-  logger: BaseLogger;
-}
-
-/**
- * All expected events that may occur during a backup operation.
- */
-export type ProgressEvent =
-  | { type: 'preparing' }
-  | { type: 'db_snapshot'; progress: number }
-  | { type: 'staging_files'; progress: number }
-  | {
-      type: 'copy_files';
-      current?: string;
-      copiedCount: number;
-      totalCount: number;
-      copiedBytes: number;
-      totalBytes: number;
-    }
-  | { type: 'writing_manifest' }
-  | { type: 'flushing_backup' }
-  | { type: 'swapping_backup' };
+import { ProgressTracking } from '../progress.js';
 
 /**
  * Options for preparing a backup to copy from the given workspace to a target.

--- a/apps/admin/backend/src/backup/progress.ts
+++ b/apps/admin/backend/src/backup/progress.ts
@@ -17,7 +17,10 @@ export interface ProgressTracking {
 }
 
 /**
- * All expected events that may occur during a backup operation.
+ * All expected events that may occur while creating or restoring a backup. The
+ * two operations share the vocabulary where the work is the same (`preparing`,
+ * `copy_files`), so a progress display can serve both; the remaining phases
+ * each belong to one side.
  */
 export type ProgressEvent =
   | { type: 'preparing' }
@@ -33,4 +36,6 @@ export type ProgressEvent =
     }
   | { type: 'writing_manifest' }
   | { type: 'flushing_backup' }
-  | { type: 'swapping_backup' };
+  | { type: 'swapping_backup' }
+  | { type: 'verifying' }
+  | { type: 'flushing_workspace' };

--- a/apps/admin/backend/src/backup/progress.ts
+++ b/apps/admin/backend/src/backup/progress.ts
@@ -1,0 +1,36 @@
+import { BaseLogger } from '@votingworks/logging';
+
+/**
+ * Basic options for all backup and restore steps.
+ */
+export interface ProgressTracking {
+  /**
+   * When given this callback will be called repeatedly as the operation
+   * progresses.
+   */
+  onProgressEvent?: (event: ProgressEvent) => void;
+
+  /**
+   * Where to send log messages during the operation.
+   */
+  logger: BaseLogger;
+}
+
+/**
+ * All expected events that may occur during a backup operation.
+ */
+export type ProgressEvent =
+  | { type: 'preparing' }
+  | { type: 'db_snapshot'; progress: number }
+  | { type: 'staging_files'; progress: number }
+  | {
+      type: 'copy_files';
+      current?: string;
+      copiedCount: number;
+      totalCount: number;
+      copiedBytes: number;
+      totalBytes: number;
+    }
+  | { type: 'writing_manifest' }
+  | { type: 'flushing_backup' }
+  | { type: 'swapping_backup' };

--- a/apps/admin/backend/src/backup/progress.ts
+++ b/apps/admin/backend/src/backup/progress.ts
@@ -14,6 +14,19 @@ export interface ProgressTracking {
    * Where to send log messages during the operation.
    */
   logger: BaseLogger;
+
+  /**
+   * When given, aborting this signal stops the operation at the next point it
+   * can stop cleanly, and it reports `cancelled` rather than succeeding. What
+   * has already been written is discarded, so a cancelled operation leaves
+   * nothing half-finished behind.
+   *
+   * Cancelling is honored up to the point where the operation commits — where
+   * a backup is swapped into its final location, and where a restore has all
+   * the files down and only has to verify and flush them. Past that, finishing
+   * is both quick and the only way to leave the disk in a state anyone can use.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/apps/admin/backend/src/backup/restore/copy_step.ts
+++ b/apps/admin/backend/src/backup/restore/copy_step.ts
@@ -1,0 +1,147 @@
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import {
+  err,
+  extractErrorMessage,
+  iter,
+  ok,
+  Result,
+  throwIllegalValue,
+} from '@votingworks/basics';
+import { copyFile } from '@votingworks/fs';
+import { AuthenticatedBackup } from '../authenticated_backup.js';
+import { BACKUP_WORKSPACE_DIR, BackupManifest } from '../backup_manifest.js';
+import { ProgressEvent } from '../progress.js';
+import { RestoreError } from './types.js';
+
+/**
+ * How many bytes of a single file must be copied before another progress event
+ * is emitted. The database restores as one multi-gigabyte file, so reporting
+ * every chunk would emit thousands of events for it.
+ */
+const DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES = 8_000_000; // 8 MB
+
+/**
+ * Copies every file the manifest promises into the workspace, verifying each
+ * against its manifest entry as it lands.
+ */
+export async function copyBackupFiles({
+  backup,
+  manifest,
+  workspacePath,
+  onProgressEvent,
+  progressEventIntervalBytes = DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES,
+}: {
+  backup: AuthenticatedBackup;
+  manifest: BackupManifest;
+  workspacePath: string;
+  onProgressEvent?: (event: ProgressEvent) => void;
+  progressEventIntervalBytes?: number;
+}): Promise<Result<void, RestoreError>> {
+  const workspacePrefix = `${BACKUP_WORKSPACE_DIR}/`;
+  let copiedCount = 0;
+  let copiedBytes = 0;
+  const totalCount = manifest.files.length;
+  const totalBytes = iter(manifest.files).sum((file) => file.size);
+  onProgressEvent?.({
+    type: 'copy_files',
+    copiedCount,
+    totalCount,
+    copiedBytes,
+    totalBytes,
+  });
+
+  for (const file of manifest.files) {
+    onProgressEvent?.({
+      type: 'copy_files',
+      current: file.path,
+      copiedCount,
+      totalCount,
+      copiedBytes,
+      totalBytes,
+    });
+
+    const destinationPath = join(
+      workspacePath,
+      file.path.slice(workspacePrefix.length)
+    );
+    await mkdir(dirname(destinationPath), { recursive: true });
+
+    // Capped at what the manifest promises, so a file that has grown is
+    // stopped at the limit rather than copied in full and rejected after.
+    let lastReportedFileBytes = 0;
+    const copiedCountBeforeFile = copiedCount;
+    const copiedBytesBeforeFile = copiedBytes;
+    const copyResult = await copyFile({
+      source: join(backup.path, file.path),
+      destination: destinationPath,
+      maxSize: file.size,
+      digest: 'sha256',
+      onProgress: (fileBytes) => {
+        if (fileBytes - lastReportedFileBytes >= progressEventIntervalBytes) {
+          lastReportedFileBytes = fileBytes;
+          onProgressEvent?.({
+            type: 'copy_files',
+            current: file.path,
+            copiedCount: copiedCountBeforeFile,
+            totalCount,
+            copiedBytes: copiedBytesBeforeFile + fileBytes,
+            totalBytes,
+          });
+        }
+      },
+    });
+
+    if (copyResult.isErr()) {
+      const error = copyResult.err();
+      switch (error.type) {
+        case 'OpenFileError': {
+          return err({
+            type: 'backup-verification-failed',
+            message: `Missing backup file: ${file.path}`,
+          });
+        }
+
+        case 'FileExceedsMaxSize': {
+          return err({
+            type: 'backup-verification-failed',
+            message: `File is larger than its manifest entry: ${file.path}`,
+          });
+        }
+
+        case 'ReadFileError':
+        case 'WriteFileError': {
+          return err({
+            type: 'backup-read-failed',
+            message: `${extractErrorMessage(error.error)} (${file.path})`,
+          });
+        }
+
+        /* istanbul ignore next: Compile-time check for completeness */
+        default: {
+          throwIllegalValue(error, 'type');
+        }
+      }
+    }
+
+    const { size, sha256 } = copyResult.ok();
+    if (size !== file.size || sha256 !== file.hash) {
+      return err({
+        type: 'backup-verification-failed',
+        message: `File does not match expected size or content: ${file.path}`,
+      });
+    }
+
+    copiedCount += 1;
+    copiedBytes += size;
+    onProgressEvent?.({
+      type: 'copy_files',
+      copiedCount,
+      totalCount,
+      copiedBytes,
+      totalBytes,
+    });
+  }
+
+  return ok();
+}

--- a/apps/admin/backend/src/backup/restore/copy_step.ts
+++ b/apps/admin/backend/src/backup/restore/copy_step.ts
@@ -22,20 +22,35 @@ import { RestoreError } from './types.js';
 const DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES = 8_000_000; // 8 MB
 
 /**
+ * Reported when the caller cancelled the restore.
+ */
+const CANCELLED_ERROR: RestoreError = {
+  type: 'cancelled',
+  message: 'Restore cancelled',
+};
+
+/**
  * Copies every file the manifest promises into the workspace, verifying each
  * against its manifest entry as it lands.
+ *
+ * Cancelling is left to {@link copyFile}, which refuses to open a file once
+ * `signal` has aborted and stops between chunks of one it is partway through.
+ * A cancel between two files is therefore reported by the next file's copy
+ * rather than by this loop.
  */
 export async function copyBackupFiles({
   backup,
   manifest,
   workspacePath,
   onProgressEvent,
+  signal,
   progressEventIntervalBytes = DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES,
 }: {
   backup: AuthenticatedBackup;
   manifest: BackupManifest;
   workspacePath: string;
   onProgressEvent?: (event: ProgressEvent) => void;
+  signal?: AbortSignal;
   progressEventIntervalBytes?: number;
 }): Promise<Result<void, RestoreError>> {
   const workspacePrefix = `${BACKUP_WORKSPACE_DIR}/`;
@@ -77,6 +92,7 @@ export async function copyBackupFiles({
       destination: destinationPath,
       maxSize: file.size,
       digest: 'sha256',
+      signal,
       onProgress: (fileBytes) => {
         if (fileBytes - lastReportedFileBytes >= progressEventIntervalBytes) {
           lastReportedFileBytes = fileBytes;
@@ -95,6 +111,10 @@ export async function copyBackupFiles({
     if (copyResult.isErr()) {
       const error = copyResult.err();
       switch (error.type) {
+        case 'Cancelled': {
+          return err(CANCELLED_ERROR);
+        }
+
         case 'OpenFileError': {
           return err({
             type: 'backup-verification-failed',

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -1,0 +1,931 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { appendFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import {
+  electionFamousNames2021Fixtures,
+  makeTemporaryDirectory,
+} from '@votingworks/fixtures';
+import { assertDefined, err, iter, ok } from '@votingworks/basics';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
+import {
+  authenticateArtifactUsingSignatureFile,
+  prepareSignatureFile,
+  SIGNATURE_FILE_EXTENSION,
+  VXADMIN_BACKUP_MANIFEST_FILE_NAME,
+} from '@votingworks/auth';
+import {
+  DEV_MACHINE_ID,
+  LATEST_SOFTWARE_VERSION,
+  safeParseJson,
+} from '@votingworks/types';
+import { exists } from 'fs-extra';
+import { syncFilesystem } from '@votingworks/fs';
+import {
+  addCvrWithBallotImage,
+  makeBackup,
+  makeConfiguredWorkspace,
+  mockDiskSpace,
+} from '../../../test/backup.js';
+import {
+  ADMIN_WORKSPACE_DATABASE_NAME,
+  createWorkspace,
+  openWorkspace,
+} from '../../util/workspace.js';
+import { createBackup } from '../create/index.js';
+import { Backup } from '../backup.js';
+import {
+  BackupManifest,
+  BACKUP_MANIFEST_VERSION,
+  BackupManifestStruct,
+  BackupManifestStructSchema,
+} from '../backup_manifest.js';
+import { restoreBackup, RESTORE_IN_PROGRESS_MARKER_FILENAME } from './index.js';
+import { ProgressEvent } from '../progress.js';
+
+vi.mock(
+  import('@votingworks/backend'),
+  async (importActual): Promise<typeof import('@votingworks/backend')> => {
+    const actual = await importActual();
+    return {
+      ...actual,
+      getDiskSpaceSummaries: vi.fn(),
+    };
+  }
+);
+
+vi.mock(
+  import('@votingworks/fs'),
+  async (importActual): Promise<typeof import('@votingworks/fs')> => {
+    const actual = await importActual();
+    return {
+      ...actual,
+      syncFilesystem: vi.fn(actual.syncFilesystem),
+    };
+  }
+);
+
+beforeEach(() => {
+  mockDiskSpace();
+});
+
+/**
+ * Creates an empty, unconfigured workspace to restore into, leaving nothing
+ * holding its database open.
+ */
+function makeUnconfiguredWorkspacePath(): string {
+  const path = makeTemporaryDirectory();
+  using workspace = createWorkspace(path, mockBaseLogger({ fn: vi.fn }));
+  expect(workspace.store.getCurrentElectionId()).toBeUndefined();
+  return path;
+}
+
+/**
+ * Creates a workspace configured with an election, a CVR, and a ballot image,
+ * leaving nothing holding its database open.
+ */
+async function makeConfiguredWorkspacePath(): Promise<string> {
+  using workspace = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(workspace, { ballotId: 'existing-ballot' });
+  return workspace.path;
+}
+
+/**
+ * Lists everything in a workspace, ignoring the database's sidecar files since
+ * those come and go as the database is opened and closed.
+ */
+function listWorkspace(workspacePath: string): string[] {
+  return readdirSync(workspacePath, { recursive: true })
+    .map(String)
+    .filter((name) => !name.startsWith(`${ADMIN_WORKSPACE_DATABASE_NAME}-`))
+    .sort();
+}
+
+/**
+ * Reads a backup's manifest, authenticating it as any reader must.
+ */
+async function readBackupManifest(backup: Backup): Promise<BackupManifest> {
+  await using authenticatedBackup = (await backup.open()).unsafeUnwrap();
+  return (await authenticatedBackup.readManifest()).unsafeUnwrap();
+}
+
+/**
+ * Rewrites a backup's `manifest.json` as whatever `revise` returns, bypassing
+ * the schema so that manifests restore has to reject can be built. Note that
+ * this invalidates the backup's signature.
+ */
+async function rewriteManifest(
+  backup: Backup,
+  revise: (manifest: BackupManifestStruct) => BackupManifestStruct,
+  { sign = true }: { sign?: boolean } = {}
+): Promise<void> {
+  const manifest = safeParseJson(
+    await readFile(backup.manifestPath, 'utf-8'),
+    BackupManifestStructSchema
+  ).unsafeUnwrap();
+  await writeManifestContents(
+    backup,
+    JSON.stringify(revise(manifest), null, 2),
+    { sign }
+  );
+}
+
+/**
+ * Writes a backup's `manifest.json` verbatim, so that contents no schema would
+ * produce can be built.
+ *
+ * Re-signed by default so that a test about some other kind of bad manifest
+ * keeps testing that, rather than tripping the signature check first. Pass
+ * `sign: false` to leave the signature stale on purpose.
+ */
+async function writeManifestContents(
+  backup: Backup,
+  contents: string,
+  { sign = true }: { sign?: boolean } = {}
+): Promise<void> {
+  await writeFile(backup.manifestPath, contents, 'utf-8');
+
+  if (sign) {
+    const signatureFile = await prepareSignatureFile({
+      type: 'vxadmin_backup',
+      context: 'export',
+      manifestFileContents: contents,
+    });
+    await writeFile(
+      join(backup.path, signatureFile.fileName),
+      signatureFile.fileContents
+    );
+  }
+}
+
+/**
+ * Replaces one of a backup's files with the contents of `sourcePath`, keeping
+ * the manifest's size and hash for it accurate so that the backup still passes
+ * file verification. Note that this invalidates the backup's signature.
+ */
+async function replaceBackupFile(
+  backup: Backup,
+  manifestPath: string,
+  sourcePath: string
+): Promise<void> {
+  const contents = await readFile(sourcePath);
+  await writeFile(join(backup.path, manifestPath), contents);
+  await rewriteManifest(backup, (manifest) => ({
+    ...manifest,
+    files: manifest.files.map((file) =>
+      file.path === manifestPath
+        ? {
+            ...file,
+            size: contents.byteLength,
+            hash: createHash('sha256').update(contents).digest('hex'),
+          }
+        : file
+    ),
+  }));
+}
+
+test('restore copies the database, ballot images, and election packages', async () => {
+  const logger = mockBaseLogger({ fn: vi.fn });
+  using source = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(source, { ballotId: 'ballot-1' });
+  addCvrWithBallotImage(source, { ballotId: 'ballot-2' });
+
+  const electionId = source.store.getCurrentElectionId()!;
+  const sourceBallotImagePaths = source.store
+    .getAllBallotImagePaths(electionId)
+    .sort();
+  expect(sourceBallotImagePaths).toHaveLength(2);
+  const sourceElectionPackagePath =
+    source.store.getElectionPackageFilePath(electionId)!;
+
+  const created = (
+    await createBackup({
+      workspace: source.path,
+      target: makeTemporaryDirectory(),
+      logger,
+    })
+  ).unsafeUnwrap();
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const events: ProgressEvent[] = [];
+  expect(
+    await restoreBackup({
+      backup: created.path,
+      workspace: workspacePath,
+      logger,
+      onProgressEvent: (event) => events.push(event),
+    })
+  ).toEqual(ok());
+
+  // Progress walks through the phases in order, and the copy events account
+  // for every file and byte the manifest promised.
+  expect(events[0]).toEqual({ type: 'preparing' });
+  expect(events.at(-2)).toEqual({ type: 'verifying' });
+  expect(events.at(-1)).toEqual({ type: 'flushing_workspace' });
+  const copyEvents = events.filter((event) => event.type === 'copy_files');
+  const manifest = await readBackupManifest(new Backup(created.path));
+  expect(copyEvents[0]).toMatchObject({ copiedCount: 0, copiedBytes: 0 });
+  expect(copyEvents.at(-1)).toEqual({
+    type: 'copy_files',
+    copiedCount: manifest.files.length,
+    totalCount: manifest.files.length,
+    copiedBytes: iter(manifest.files).sum(({ size }) => size),
+    totalBytes: iter(manifest.files).sum(({ size }) => size),
+  });
+
+  // Restoring replaces the machine's entire data state, so both the attempt
+  // and its outcome belong in the audit log.
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupRestoreInit,
+    'system',
+    expect.objectContaining({ message: expect.stringContaining(created.path) })
+  );
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupRestoreComplete,
+    'system',
+    expect.objectContaining({ disposition: 'success' })
+  );
+
+  using restored = openWorkspace(workspacePath, logger);
+
+  // The database came across whole: same election, same current election, same
+  // CVR data hanging off it.
+  expect(restored.store.getCurrentElectionId()).toEqual(electionId);
+  expect(restored.store.getElection(electionId)).toEqual(
+    source.store.getElection(electionId)
+  );
+
+  // Ballot images land at the same workspace-relative paths, with the same
+  // contents.
+  const restoredBallotImagePaths = restored.store
+    .getAllBallotImagePaths(electionId)
+    .sort();
+  expect(
+    restoredBallotImagePaths.map((path) => relative(restored.path, path))
+  ).toEqual(sourceBallotImagePaths.map((path) => relative(source.path, path)));
+  for (const [index, restoredPath] of restoredBallotImagePaths.entries()) {
+    expect(readFileSync(restoredPath)).toEqual(
+      readFileSync(sourceBallotImagePaths[index]!)
+    );
+  }
+
+  // As does the election package.
+  const restoredElectionPackagePath =
+    restored.store.getElectionPackageFilePath(electionId)!;
+  expect(relative(restored.path, restoredElectionPackagePath)).toEqual(
+    relative(source.path, sourceElectionPackagePath)
+  );
+  expect(readFileSync(restoredElectionPackagePath)).toEqual(
+    readFileSync(sourceElectionPackagePath)
+  );
+});
+
+test('restore recreates workspace directories the backup has no files in', async () => {
+  const logger = mockBaseLogger({ fn: vi.fn });
+
+  // A workspace that is configured but has no CVRs loaded holds an empty
+  // `ballot-images` directory, which a backup — a manifest of files — cannot
+  // record.
+  using source = await makeConfiguredWorkspace();
+  const created = (
+    await createBackup({
+      workspace: source.path,
+      target: makeTemporaryDirectory(),
+      logger,
+    })
+  ).unsafeUnwrap();
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  expect(
+    await restoreBackup({
+      backup: created.path,
+      workspace: workspacePath,
+      logger,
+    })
+  ).toEqual(ok());
+
+  using restored = openWorkspace(workspacePath, logger);
+  expect(restored.store.getCurrentElectionId()).toEqual(
+    source.store.getCurrentElectionId()
+  );
+});
+
+test('restore resolves relative workspace and backup paths', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const logger = mockBaseLogger({ fn: vi.fn });
+
+  expect(
+    await restoreBackup({
+      backup: relative(process.cwd(), backup.path),
+      workspace: relative(process.cwd(), workspacePath),
+      logger,
+    })
+  ).toEqual(ok());
+
+  // The audit log records the resolved absolute path.
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupRestoreInit,
+    'system',
+    expect.objectContaining({ message: expect.stringContaining(backup.path) })
+  );
+});
+
+test('restore fails if there is no backup manifest', async () => {
+  const backup = await makeBackup();
+  await rm(backup.manifestPath);
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // The CLI renders a failed restore as `Error: ${err().message}`, the same as
+  // it does a failed create, so every error has to carry a message naming what
+  // could not be read.
+  expect(result.err()).toEqual({
+    type: 'backup-read-failed',
+    message: expect.stringContaining(backup.manifestPath),
+  });
+
+  // Vetting failed before the restore touched the workspace, so the workspace
+  // keeps what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
+});
+
+test('restore fails if the backup manifest is not readable', async () => {
+  const backup = await makeBackup();
+  // Signed, so this gets past authentication and fails where a damaged-but-
+  // genuine backup would.
+  await writeManifestContents(backup, 'not a manifest');
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toMatchObject({ type: 'backup-read-failed' });
+
+  // Vetting failed before the restore touched the workspace, so the workspace
+  // keeps what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
+});
+
+test('restore fails if the backup manifest version does not match', async () => {
+  const backup = await makeBackup();
+  const futureVersion = BACKUP_MANIFEST_VERSION + 1;
+  await rewriteManifest(backup, (manifest) => ({
+    ...manifest,
+    version: futureVersion as typeof BACKUP_MANIFEST_VERSION,
+  }));
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // A version field exists to explain *why* a backup can't be read, so this
+  // has to be distinguishable from a corrupt manifest. Matched loosely so the
+  // error may carry the versions as fields too.
+  expect(result.err()).toMatchObject({
+    type: 'unsupported-backup-version',
+    message: expect.stringContaining(
+      `Expected backup version ${BACKUP_MANIFEST_VERSION}`
+    ),
+  });
+
+  // Vetting failed before the restore touched the workspace, so the workspace
+  // keeps what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
+});
+
+test('restore fails if the backup manifest software version does not match', async () => {
+  const backup = await makeBackup();
+  // The real predecessor release, i.e. a drive carried over from a machine
+  // that was never upgraded.
+  await rewriteManifest(backup, (manifest) => ({
+    ...manifest,
+    softwareVersion: 'v4.0',
+  }));
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toMatchObject({
+    type: 'unsupported-software-version',
+    message: expect.stringContaining(
+      `Expected software version ${LATEST_SOFTWARE_VERSION}`
+    ),
+  });
+
+  // Vetting failed before the restore touched the workspace, so the workspace
+  // keeps what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
+});
+
+test('restore warns but does not fail if the machine ID does not match', async () => {
+  const backup = await makeBackup();
+  const otherMachineId = 'VX-00-999';
+  await rewriteManifest(backup, (manifest) => ({
+    ...manifest,
+    machineId: otherMachineId,
+  }));
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const logger = mockBaseLogger({ fn: vi.fn });
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger,
+  });
+
+  // Moving a backup between machines is a legitimate thing to do — replacing
+  // failed hardware — so this is worth recording, not refusing.
+  expect(result).toEqual(ok());
+  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  expect(workspace.store.getCurrentElectionId()).toBeDefined();
+
+  // The event id is left to the implementation, but the log has to say which
+  // machine made the backup and which one is reading it, or it can't be told
+  // apart from a restore onto the machine that made it.
+  const warnings = vi
+    .mocked(logger.log)
+    .mock.calls.filter((call) => JSON.stringify(call).includes(otherMachineId));
+  expect(warnings).toHaveLength(1);
+  expect(JSON.stringify(warnings[0])).toContain(DEV_MACHINE_ID);
+});
+
+test.each<{ description: string; tamper: (backup: Backup) => Promise<void> }>([
+  {
+    description: 'signature does not match the manifest',
+    // A change restore would otherwise accept, so that only the signature
+    // check can be what rejects this backup.
+    tamper: (backup) =>
+      rewriteManifest(
+        backup,
+        (manifest) => ({ ...manifest, machineId: 'VX-00-999' }),
+        { sign: false }
+      ),
+  },
+  {
+    description: 'signature is missing entirely',
+    tamper: (backup) =>
+      rm(
+        join(
+          backup.path,
+          `${VXADMIN_BACKUP_MANIFEST_FILE_NAME}${SIGNATURE_FILE_EXTENSION}`
+        )
+      ),
+  },
+])('restore fails if the backup $description', async ({ tamper }) => {
+  const backup = await makeBackup();
+  // Proves the tampering below is what breaks authentication, not the fixture.
+  expect(
+    await authenticateArtifactUsingSignatureFile({
+      type: 'vxadmin_backup',
+      context: 'import',
+      directoryPath: backup.path,
+    })
+  ).toEqual(ok());
+
+  await tamper(backup);
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // Every hash in the manifest is only as trustworthy as the manifest itself,
+  // so an unauthenticated manifest makes the whole backup unverifiable. This is
+  // its own failure: the backup is well-formed and internally consistent, it
+  // just did not come from a machine this one trusts.
+  expect(result.err()).toMatchObject({
+    type: 'backup-authentication-failed',
+  });
+
+  // Vetting failed before the restore touched the workspace, so the workspace
+  // keeps what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
+});
+
+test('restore fails if a backup file cannot be read', async () => {
+  const backup = await makeBackup();
+  const manifest = await readBackupManifest(backup);
+  const unreadableFile = assertDefined(manifest.files.at(-1));
+  const unreadablePath = join(backup.path, unreadableFile.path);
+  // A directory in place of the file reads as EISDIR, standing in for the
+  // whole class of errors a dying USB drive raises mid-copy — EIO, EACCES —
+  // which, unlike ENOENT, say nothing about whether the backup is intact.
+  await rm(unreadablePath);
+  await mkdir(unreadablePath);
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // Any failure to copy has to be reported. Reporting success here hands the
+  // operator a workspace missing a file they will not learn about until
+  // something later needs it.
+  // The error type is left open: this is a broken drive, not a claim about
+  // whether the backup itself is valid.
+  expect(result.err()).toMatchObject({
+    message: expect.stringContaining(unreadableFile.path),
+  });
+
+  await expect(
+    exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).resolves.toBeFalsy();
+});
+
+test('restore fails on missing files from the backup manifest', async () => {
+  const backup = await makeBackup();
+  const manifest = await readBackupManifest(backup);
+  // The last file, so that an implementation copying as it walks the manifest
+  // would already have written everything else by the time it noticed.
+  const missingFile = assertDefined(manifest.files.at(-1));
+  await rm(join(backup.path, missingFile.path));
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toMatchObject({
+    type: 'backup-verification-failed',
+    message: expect.stringContaining(missingFile.path),
+  });
+
+  await expect(
+    exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).resolves.toBeFalsy();
+});
+
+test('restore fails if any backup files are an unexpected size', async () => {
+  const backup = await makeBackup();
+  const manifest = await readBackupManifest(backup);
+  const grownFile = assertDefined(manifest.files.at(-1));
+  // Grown rather than truncated: a copy that reads only the number of bytes the
+  // manifest promises would silently succeed on this and drop the difference.
+  await appendFile(join(backup.path, grownFile.path), 'extra');
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // The file is present and readable, so existence is not enough — the size the
+  // manifest records has to be checked against the file on disk.
+  expect(result.err()).toMatchObject({
+    type: 'backup-verification-failed',
+    message: expect.stringContaining(grownFile.path),
+  });
+
+  await expect(
+    exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).resolves.toBeFalsy();
+});
+
+test('restore fails if any backup files have unexpected content (by hash)', async () => {
+  const backup = await makeBackup();
+  const manifest = await readBackupManifest(backup);
+  const editedFile = assertDefined(manifest.files.at(-1));
+  const editedFilePath = join(backup.path, editedFile.path);
+  const contents = await readFile(editedFilePath);
+  expect(contents).not.toHaveLength(0);
+  // Edited in place so the file is exactly as long as the manifest says it is:
+  // corruption on a USB drive rewrites bytes, it does not change file lengths.
+  // eslint-disable-next-line no-bitwise
+  contents[0]! ^= 0xff;
+  await writeFile(editedFilePath, contents);
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toMatchObject({
+    type: 'backup-verification-failed',
+    message: expect.stringContaining(editedFile.path),
+  });
+
+  await expect(
+    exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).resolves.toBeFalsy();
+});
+
+test.each<{ description: string; makePath: (escapeTarget: string) => string }>([
+  {
+    description: 'absolute',
+    makePath: (escapeTarget) => escapeTarget,
+  },
+  {
+    description: 'backup root-escaping',
+    // Kept under `workspace/` so that stripping that prefix, as a restore must,
+    // still leaves a path that climbs out of the workspace.
+    makePath: (escapeTarget) =>
+      join('workspace', relative(join('/backup', 'workspace'), escapeTarget)),
+  },
+])(
+  'restore fails if any backup files have $description paths',
+  async ({ makePath }) => {
+    const backup = await makeBackup();
+    const escapeTarget = join(makeTemporaryDirectory(), 'escaped-file');
+    await rewriteManifest(backup, (manifest) => ({
+      ...manifest,
+      files: [
+        {
+          path: makePath(escapeTarget),
+          hash: 'a'.repeat(64),
+          size: 0,
+        },
+      ],
+    }));
+
+    const workspacePath = makeUnconfiguredWorkspacePath();
+    const result = await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+    });
+
+    // A backup comes off a USB drive an operator was handed, so its manifest is
+    // untrusted input: a path in it must never be able to name a file outside
+    // the workspace being restored into. The manifest schema is what refuses
+    // these today, which is why they read as unreadable rather than as their
+    // own error type.
+    expect(result.err()).toMatchObject({ type: 'backup-read-failed' });
+
+    await expect(exists(escapeTarget)).resolves.toBeFalsy();
+    // Vetting failed before the restore touched the workspace, so the
+    // workspace keeps what it had.
+    expect(listWorkspace(workspacePath)).toEqual([
+      'ballot-images',
+      ADMIN_WORKSPACE_DATABASE_NAME,
+      'election-packages',
+    ]);
+  }
+);
+
+test('restore refuses a manifest entry it does not know how to restore', async () => {
+  const backup = await makeBackup();
+  await rewriteManifest(backup, (manifest) => ({
+    ...manifest,
+    files: [
+      ...manifest.files,
+      { path: 'extras/from-the-future.db', hash: 'a'.repeat(64), size: 0 },
+    ],
+  }));
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // The manifest is the signed statement of what the backup holds, so an entry
+  // this software cannot restore means the backup cannot be reproduced
+  // faithfully. Skipping it silently would report success while dropping data.
+  expect(result.err()).toMatchObject({
+    type: 'backup-verification-failed',
+    message: expect.stringContaining('extras/from-the-future.db'),
+  });
+
+  // Vetting failed before the restore touched the workspace, so the workspace
+  // keeps what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
+});
+
+test('restore fails if there is no current election in the backup', async () => {
+  const backup = await makeBackup();
+  // The manifest still promises the election it was made from, so this is a
+  // backup whose files verify but whose database does not hold what the
+  // manifest says it does.
+  await replaceBackupFile(
+    backup,
+    join('workspace', ADMIN_WORKSPACE_DATABASE_NAME),
+    join(makeUnconfiguredWorkspacePath(), ADMIN_WORKSPACE_DATABASE_NAME)
+  );
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // Restoring this would report success and leave the machine unconfigured,
+  // which reads to an operator as the election having been lost, so it has to
+  // fail naming the election the operator was told they were restoring.
+  expect(result.err()).toMatchObject({
+    type: 'backup-verification-failed',
+    message: expect.stringContaining(
+      electionFamousNames2021Fixtures.readElectionDefinition().election.id
+    ),
+  });
+
+  await expect(
+    exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).resolves.toBeFalsy();
+});
+
+test('restore clears whatever an unconfigured workspace already holds', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  await mkdir(join(workspacePath, 'stray-directory'));
+  await writeFile(
+    join(workspacePath, 'stray-directory', 'stray-file'),
+    'left over from before'
+  );
+
+  const events: ProgressEvent[] = [];
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+      onProgressEvent: (event) => events.push(event),
+      // Low enough that even these small files report mid-copy progress.
+      progressEventIntervalBytes: 1,
+    })
+  ).toEqual(ok());
+
+  // A file bigger than the reporting interval emits progress while it is still
+  // copying, named as the current file.
+  expect(
+    events.some(
+      (event) =>
+        event.type === 'copy_files' &&
+        event.current !== undefined &&
+        event.copiedBytes > 0 &&
+        event.copiedCount < event.totalCount
+    )
+  ).toEqual(true);
+
+  // The workspace has to end up holding exactly what the backup provided:
+  // anything already there would otherwise merge into the restored state.
+  await expect(
+    exists(join(workspacePath, 'stray-directory'))
+  ).resolves.toBeFalsy();
+  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  expect(workspace.store.getCurrentElectionId()).toBeDefined();
+});
+
+test('an interrupted restore can be recovered by restoring again', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+    })
+  ).toEqual(ok());
+
+  // Simulate a crash after the database was copied but before the restore
+  // finished: the workspace looks configured, but the marker is still there.
+  const markerPath = join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME);
+  await writeFile(markerPath, '');
+
+  // The configured election is half-restored debris, not data to protect, so
+  // this must restore rather than refuse — refusing would leave the operator
+  // with no way forward.
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+    })
+  ).toEqual(ok());
+
+  await expect(exists(markerPath)).resolves.toBeFalsy();
+  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  expect(workspace.store.getCurrentElectionId()).toBeDefined();
+});
+
+test('restore refuses a backup the workspace volume cannot hold', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  mockDiskSpace(() => 1);
+
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+    minAvailableStorageBytes: 1024,
+  });
+
+  expect(result.err()).toMatchObject({
+    type: 'insufficient-workspace-storage',
+    available: 1024,
+  });
+
+  // Refused before anything was written, so the workspace keeps what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
+});
+
+test('restore fails if the restored files cannot be flushed to disk', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  vi.mocked(syncFilesystem).mockResolvedValueOnce(
+    err({ code: 'EIO', message: 'EIO: the device rejected the data' })
+  );
+
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // Success is declared by removing the marker, which must not happen while
+  // the restored files live only in the page cache.
+  expect(result.err()).toMatchObject({
+    type: 'workspace-flush-failed',
+    message: expect.stringContaining('EIO'),
+  });
+  expect(listWorkspace(workspacePath)).toEqual([]);
+});
+
+test('restoring into a configured workspace fails', async () => {
+  const backup = await makeBackup();
+  const workspacePath = await makeConfiguredWorkspacePath();
+
+  const before = listWorkspace(workspacePath);
+  const logger = mockBaseLogger({ fn: vi.fn });
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: workspacePath,
+    logger,
+  });
+
+  expect(result.err()).toMatchObject({ type: 'workspace-already-configured' });
+
+  // A refused restore is still a restore that was attempted, so the failure
+  // and its reason belong in the audit log.
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupRestoreComplete,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      errorType: 'workspace-already-configured',
+    })
+  );
+
+  // The refusal has to happen before anything is written or cleaned up: a
+  // restore that wipes the election already on the machine and then reports
+  // failure has destroyed the very data it declined to replace.
+  expect(listWorkspace(workspacePath)).toEqual(before);
+  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  expect(workspace.store.getAllBallotImagePaths(electionId)).toHaveLength(1);
+});

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -201,7 +201,7 @@ test('restore copies the database, ballot images, and election packages', async 
 
   const created = (
     await createBackup({
-      workspace: source.path,
+      workspace: source,
       target: makeTemporaryDirectory(),
       logger,
     })
@@ -290,7 +290,7 @@ test('restore recreates workspace directories the backup has no files in', async
   using source = await makeConfiguredWorkspace();
   const created = (
     await createBackup({
-      workspace: source.path,
+      workspace: source,
       target: makeTemporaryDirectory(),
       logger,
     })

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -24,6 +24,7 @@ import { exists } from 'fs-extra';
 import { syncFilesystem } from '@votingworks/fs';
 import {
   addCvrWithBallotImage,
+  GENEROUS_AVAILABLE_KB,
   makeBackup,
   makeConfiguredWorkspace,
   mockDiskSpace,
@@ -928,4 +929,113 @@ test('restoring into a configured workspace fails', async () => {
   using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
   const electionId = assertDefined(workspace.store.getCurrentElectionId());
   expect(workspace.store.getAllBallotImagePaths(electionId)).toHaveLength(1);
+});
+
+test('a restore cancelled before it starts leaves the workspace alone', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  await writeFile(join(workspacePath, 'stray-file'), 'left over from before');
+  const contentsBefore = listWorkspace(workspacePath);
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger,
+      signal: AbortSignal.abort(),
+    })
+  ).toEqual(err({ type: 'cancelled', message: 'Restore cancelled' }));
+
+  expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
+  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+    LogEventId.BackupRestoreComplete,
+    'system',
+    expect.objectContaining({ disposition: 'failure', errorType: 'cancelled' })
+  );
+});
+
+test('a restore cancelled while vetting the backup leaves the workspace alone', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  await writeFile(join(workspacePath, 'stray-file'), 'left over from before');
+  const contentsBefore = listWorkspace(workspacePath);
+  const controller = new AbortController();
+
+  // Measuring the workspace volume is the last thing that happens before the
+  // workspace is claimed and emptied.
+  mockDiskSpace(() => {
+    controller.abort();
+    return GENEROUS_AVAILABLE_KB;
+  });
+
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+      signal: controller.signal,
+    })
+  ).toEqual(err({ type: 'cancelled', message: 'Restore cancelled' }));
+
+  // Nothing was claimed, so what the operator had is what they still have.
+  expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
+});
+
+test('a restore cancelled between files empties the workspace it had claimed', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const controller = new AbortController();
+
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+      signal: controller.signal,
+      onProgressEvent(event) {
+        // Abort once one file has landed, so files remain to be copied.
+        if (event.type === 'copy_files' && event.copiedCount === 1) {
+          controller.abort();
+        }
+      },
+    })
+  ).toEqual(err({ type: 'cancelled', message: 'Restore cancelled' }));
+
+  // A partly-restored workspace is not something to leave behind: it must be
+  // as empty as a failed restore leaves it, and the marker must be gone with
+  // it so the next restore is not told it is recovering an interrupted one.
+  expect(listWorkspace(workspacePath)).toEqual([]);
+});
+
+test('a restore cancelled partway through a file empties the workspace', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const controller = new AbortController();
+
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: workspacePath,
+      logger: mockBaseLogger({ fn: vi.fn }),
+      signal: controller.signal,
+      // Low enough that even these small files report mid-copy progress.
+      progressEventIntervalBytes: 1,
+      onProgressEvent(event) {
+        // Mid-file: bytes have landed for a file that is not yet counted as
+        // copied, so the abort has to be noticed by the copy itself rather
+        // than by the loop around it.
+        if (
+          event.type === 'copy_files' &&
+          event.current !== undefined &&
+          event.copiedBytes > 0 &&
+          event.copiedCount < event.totalCount
+        ) {
+          controller.abort();
+        }
+      },
+    })
+  ).toEqual(err({ type: 'cancelled', message: 'Restore cancelled' }));
+
+  expect(listWorkspace(workspacePath)).toEqual([]);
 });

--- a/apps/admin/backend/src/backup/restore/index.ts
+++ b/apps/admin/backend/src/backup/restore/index.ts
@@ -1,0 +1,143 @@
+import { resolve } from 'node:path';
+import { Result } from '@votingworks/basics';
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { copyBackupFiles } from './copy_step.js';
+import { openBackup, vetManifest } from './open_step.js';
+import {
+  abandonFailedRestore,
+  checkWorkspaceHasSufficientSpace,
+  checkWorkspaceIsRestorable,
+  claimWorkspace,
+  completeRestore,
+} from './prepare_step.js';
+import { RestoreBackupOptions, RestoreError } from './types.js';
+import {
+  flushRestoredWorkspace,
+  verifyRestoredWorkspace,
+} from './verify_step.js';
+
+export { RESTORE_IN_PROGRESS_MARKER_FILENAME } from './prepare_step.js';
+
+/**
+ * Restores a backup from disk, typically an external USB drive. Includes the
+ * database, ballot images, and election packages.
+ *
+ * The workspace's contents belong to the restore: it is emptied before copying
+ * begins and again if the restore fails, so the result is exactly what the
+ * backup provided or nothing. All vetting of the backup happens before the
+ * workspace is touched, so a backup that was never going to restore leaves it
+ * as it was. Aborts if the destination workspace is already configured with a
+ * current election — unless a marker left by an interrupted restore shows that
+ * the apparent configuration is half-restored debris, in which case the
+ * restore is what recovers the workspace.
+ */
+export async function restoreBackup(
+  rawOptions: RestoreBackupOptions
+): Promise<Result<void, RestoreError>> {
+  // Resolve the caller-supplied paths up front, as `createBackup` does, so the
+  // workspace paths `openWorkspace` resolves and the paths we log and derive
+  // here agree.
+  const options: RestoreBackupOptions = {
+    ...rawOptions,
+    workspace: resolve(rawOptions.workspace),
+    backup: resolve(rawOptions.backup),
+  };
+  const { logger } = options;
+  logger.log(LogEventId.BackupRestoreInit, 'system', {
+    message: `Restoring a backup from ${options.backup}…`,
+  });
+
+  return logRestoreResult(logger, await tryRestoreBackup(options));
+}
+
+async function tryRestoreBackup(
+  options: RestoreBackupOptions
+): Promise<Result<void, RestoreError>> {
+  const { logger, onProgressEvent } = options;
+  onProgressEvent?.({ type: 'preparing' });
+
+  const checkResult = checkWorkspaceIsRestorable(options.workspace, logger);
+  if (checkResult.isErr()) {
+    return checkResult;
+  }
+
+  const openResult = await openBackup(options.backup);
+  if (openResult.isErr()) {
+    return openResult;
+  }
+
+  await using backup = openResult.ok();
+  const vetResult = await vetManifest(backup, logger);
+  if (vetResult.isErr()) {
+    return vetResult;
+  }
+  const manifest = vetResult.ok();
+
+  const spaceResult = await checkWorkspaceHasSufficientSpace({
+    workspacePath: options.workspace,
+    manifest,
+    minAvailableStorageBytes: options.minAvailableStorageBytes,
+  });
+  if (spaceResult.isErr()) {
+    return spaceResult;
+  }
+
+  await claimWorkspace(options.workspace);
+  let succeeded = false;
+  try {
+    const copyResult = await copyBackupFiles({
+      backup,
+      manifest,
+      workspacePath: options.workspace,
+      onProgressEvent,
+      progressEventIntervalBytes: options.progressEventIntervalBytes,
+    });
+    if (copyResult.isErr()) {
+      return copyResult;
+    }
+
+    onProgressEvent?.({ type: 'verifying' });
+    const verifyResult = verifyRestoredWorkspace({
+      manifest,
+      workspacePath: options.workspace,
+      logger,
+    });
+    if (verifyResult.isErr()) {
+      return verifyResult;
+    }
+
+    // Flushed before the marker comes off: removing the marker declares the
+    // restore complete, which must not happen while the restored files live
+    // only in the page cache.
+    onProgressEvent?.({ type: 'flushing_workspace' });
+    const flushResult = await flushRestoredWorkspace(options.workspace);
+    succeeded = flushResult.isOk();
+    return flushResult;
+  } finally {
+    if (succeeded) {
+      await completeRestore(options.workspace);
+    } else {
+      await abandonFailedRestore(options.workspace);
+    }
+  }
+}
+
+function logRestoreResult(
+  logger: BaseLogger,
+  result: Result<void, RestoreError>
+): Result<void, RestoreError> {
+  if (result.isOk()) {
+    logger.log(LogEventId.BackupRestoreComplete, 'system', {
+      disposition: 'success',
+      message: 'Backup restored successfully.',
+    });
+  } else {
+    const error = result.err();
+    logger.log(LogEventId.BackupRestoreComplete, 'system', {
+      disposition: 'failure',
+      errorType: error.type,
+      message: `Failed to restore backup: ${error.message}`,
+    });
+  }
+  return result;
+}

--- a/apps/admin/backend/src/backup/restore/index.ts
+++ b/apps/admin/backend/src/backup/restore/index.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { Result } from '@votingworks/basics';
+import { err, Result } from '@votingworks/basics';
 import { BaseLogger, LogEventId } from '@votingworks/logging';
 import { copyBackupFiles } from './copy_step.js';
 import { openBackup, vetManifest } from './open_step.js';
@@ -50,11 +50,23 @@ export async function restoreBackup(
   return logRestoreResult(logger, await tryRestoreBackup(options));
 }
 
+/**
+ * Reported when the caller cancelled the restore.
+ */
+const CANCELLED_ERROR: RestoreError = {
+  type: 'cancelled',
+  message: 'Restore cancelled',
+};
+
 async function tryRestoreBackup(
   options: RestoreBackupOptions
 ): Promise<Result<void, RestoreError>> {
-  const { logger, onProgressEvent } = options;
+  const { logger, onProgressEvent, signal } = options;
   onProgressEvent?.({ type: 'preparing' });
+
+  if (signal?.aborted) {
+    return err(CANCELLED_ERROR);
+  }
 
   const checkResult = checkWorkspaceIsRestorable(options.workspace, logger);
   if (checkResult.isErr()) {
@@ -82,6 +94,13 @@ async function tryRestoreBackup(
     return spaceResult;
   }
 
+  // The last point a restore can be abandoned without touching the workspace:
+  // claiming it empties it, so from here on the only way out is to empty it
+  // again rather than to leave it as it was.
+  if (signal?.aborted) {
+    return err(CANCELLED_ERROR);
+  }
+
   await claimWorkspace(options.workspace);
   let succeeded = false;
   try {
@@ -90,6 +109,7 @@ async function tryRestoreBackup(
       manifest,
       workspacePath: options.workspace,
       onProgressEvent,
+      signal,
       progressEventIntervalBytes: options.progressEventIntervalBytes,
     });
     if (copyResult.isErr()) {

--- a/apps/admin/backend/src/backup/restore/open_step.ts
+++ b/apps/admin/backend/src/backup/restore/open_step.ts
@@ -1,0 +1,103 @@
+import { err, ok, Result, throwIllegalValue } from '@votingworks/basics';
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { LATEST_SOFTWARE_VERSION } from '@votingworks/types';
+import { getMachineConfig } from '../../machine_config.js';
+import { AuthenticatedBackup } from '../authenticated_backup.js';
+import { Backup } from '../backup.js';
+import { BACKUP_WORKSPACE_DIR, BackupManifest } from '../backup_manifest.js';
+import { RestoreError } from './types.js';
+
+/**
+ * Opens and authenticates the backup to restore. Dispose of the result when
+ * done with it.
+ */
+export async function openBackup(
+  backupPath: string
+): Promise<Result<AuthenticatedBackup, RestoreError>> {
+  const openBackupResult = await new Backup(backupPath).open();
+  if (openBackupResult.isErr()) {
+    const error = openBackupResult.err();
+    return err({
+      type:
+        error.type === 'authentication-failed'
+          ? 'backup-authentication-failed'
+          : 'backup-read-failed',
+      message: error.message,
+    });
+  }
+
+  return ok(openBackupResult.ok());
+}
+
+/**
+ * Reads the authenticated manifest and checks that it describes a backup this
+ * software can restore. A backup made by a different machine is recorded
+ * rather than refused: moving a backup between machines is how failed hardware
+ * is replaced.
+ */
+export async function vetManifest(
+  backup: AuthenticatedBackup,
+  logger: BaseLogger
+): Promise<Result<BackupManifest, RestoreError>> {
+  const readManifestResult = await backup.readManifest();
+
+  if (readManifestResult.isErr()) {
+    const error = readManifestResult.err();
+    switch (error.type) {
+      case 'unsupported-version': {
+        return err({
+          type: 'unsupported-backup-version',
+          message: error.message,
+        });
+      }
+
+      /* istanbul ignore next: the manifest was read whole while it was being
+         authenticated, so a read that fails now means its private copy went
+         missing underneath us */
+      case 'read-failed':
+      case 'invalid-manifest': {
+        return err({
+          type: 'backup-read-failed',
+          message: error.message,
+        });
+      }
+
+      /* istanbul ignore next: Compile-time check for completeness */
+      default: {
+        throwIllegalValue(error, 'type');
+      }
+    }
+  }
+  const manifest = readManifestResult.ok();
+
+  if (manifest.softwareVersion !== LATEST_SOFTWARE_VERSION) {
+    return err({
+      type: 'unsupported-software-version',
+      message: `Expected software version ${LATEST_SOFTWARE_VERSION}`,
+    });
+  }
+
+  const { machineId } = getMachineConfig();
+  if (manifest.machineId !== machineId) {
+    logger.log(LogEventId.BackupRestoreMachineMismatch, 'system', {
+      backupManifestMachineId: manifest.machineId,
+      machineId,
+      message: `Backup was created by ${manifest.machineId} which does not match ${machineId}`,
+    });
+  }
+
+  const workspacePrefix = `${BACKUP_WORKSPACE_DIR}/`;
+  for (const file of manifest.files) {
+    // The manifest is the signed statement of what the backup holds, so an
+    // entry this software does not know how to restore means the backup cannot
+    // be reproduced faithfully. Refusing loudly beats silently skipping it.
+    if (!file.path.startsWith(workspacePrefix)) {
+      return err({
+        type: 'backup-verification-failed',
+        message: `Manifest names a file this software does not know how to restore: ${file.path}`,
+      });
+    }
+  }
+
+  return ok(manifest);
+}

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -1,0 +1,104 @@
+import { existsSync } from 'node:fs';
+import { rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { emptydir } from 'fs-extra';
+import { err, iter, ok, Result } from '@votingworks/basics';
+import { getDiskSpaceSummaries } from '@votingworks/backend';
+import { BaseLogger } from '@votingworks/logging';
+import { createWorkspace } from '../../util/workspace.js';
+import { BackupManifest } from '../backup_manifest.js';
+import { RestoreError } from './types.js';
+
+const DEFAULT_MIN_AVAILABLE_STORAGE_BYTES = 50_000_000; // 50 MB
+
+/**
+ * Dropped into the workspace while a restore is running and removed only on
+ * success. Its presence afterwards means a restore was interrupted, so what
+ * the workspace holds is half-restored debris rather than data to protect.
+ */
+export const RESTORE_IN_PROGRESS_MARKER_FILENAME = 'restore-in-progress';
+
+function getMarkerPath(workspacePath: string): string {
+  return join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME);
+}
+
+/**
+ * Checks that the workspace is one a restore may take over: either
+ * unconfigured, or left behind by an interrupted restore (per the marker), in
+ * which case the restore is what recovers it.
+ */
+export function checkWorkspaceIsRestorable(
+  workspacePath: string,
+  logger: BaseLogger
+): Result<void, RestoreError> {
+  if (existsSync(getMarkerPath(workspacePath))) {
+    return ok();
+  }
+
+  using workspace = createWorkspace(workspacePath, logger);
+  const currentElectionId = workspace.store.getCurrentElectionId();
+  if (currentElectionId) {
+    return err({
+      type: 'workspace-already-configured',
+      message: `Expected workspace to be unconfigured, but it has election with ID ${currentElectionId}`,
+    });
+  }
+
+  return ok();
+}
+
+/**
+ * Checks that the workspace's volume can hold what the manifest promises to
+ * deliver, with `minAvailableStorageBytes` to spare. Refusing up front beats
+ * discovering a full disk partway through copying the database.
+ */
+export async function checkWorkspaceHasSufficientSpace({
+  workspacePath,
+  manifest,
+  minAvailableStorageBytes = DEFAULT_MIN_AVAILABLE_STORAGE_BYTES,
+}: {
+  workspacePath: string;
+  manifest: BackupManifest;
+  minAvailableStorageBytes?: number;
+}): Promise<Result<void, RestoreError>> {
+  const [workspaceDiskSpace] = await getDiskSpaceSummaries([workspacePath]);
+  const available = workspaceDiskSpace.available * 1024;
+  const required = iter(manifest.files).sum((file) => file.size);
+
+  if (available - required < minAvailableStorageBytes) {
+    return err({
+      type: 'insufficient-workspace-storage',
+      available,
+      required,
+      message: `Restoring this backup requires ${required} bytes plus ${minAvailableStorageBytes} bytes to spare, but only ${available} bytes are available`,
+    });
+  }
+
+  return ok();
+}
+
+/**
+ * Takes ownership of the workspace: empties it so the restore starts from a
+ * clean slate, and drops the in-progress marker.
+ */
+export async function claimWorkspace(workspacePath: string): Promise<void> {
+  await emptydir(workspacePath);
+  await writeFile(getMarkerPath(workspacePath), '');
+}
+
+/**
+ * Clears out a failed restore's partial work, so that nothing half-restored is
+ * left to be mistaken for data.
+ */
+export async function abandonFailedRestore(
+  workspacePath: string
+): Promise<void> {
+  await emptydir(workspacePath);
+}
+
+/**
+ * Removes the in-progress marker, declaring the restore complete.
+ */
+export async function completeRestore(workspacePath: string): Promise<void> {
+  await rm(getMarkerPath(workspacePath), { force: true });
+}

--- a/apps/admin/backend/src/backup/restore/types.ts
+++ b/apps/admin/backend/src/backup/restore/types.ts
@@ -1,0 +1,56 @@
+import { ProgressTracking } from '../progress.js';
+
+/**
+ * Possible expected errors that can occur when restoring a backup.
+ */
+export type RestoreError =
+  | { type: 'workspace-already-configured'; message: string }
+  | { type: 'backup-read-failed'; message: string }
+  | { type: 'backup-authentication-failed'; message: string }
+  | { type: 'backup-verification-failed'; message: string }
+  | { type: 'unsupported-backup-version'; message: string }
+  | { type: 'unsupported-software-version'; message: string }
+  | {
+      type: 'insufficient-workspace-storage';
+      available: number;
+      required: number;
+      message: string;
+    }
+  | { type: 'workspace-flush-failed'; message: string };
+
+/**
+ * Options for restoring a backup into a workspace.
+ */
+export interface RestoreBackupOptions extends ProgressTracking {
+  /**
+   * Path to a directory containing a valid and signed backup.
+   */
+  backup: string;
+
+  /**
+   * The workspace directory into which the backup should be restored. Its
+   * contents belong to the restore: whatever it holds is emptied before
+   * copying begins, so it must not contain anything worth keeping. A workspace
+   * whose database is already configured with an election is refused rather
+   * than cleared.
+   */
+  workspace: string;
+
+  /**
+   * How many bytes must remain available on the workspace's volume after the
+   * restored files land. Used to eagerly refuse a restore that would fill the
+   * disk.
+   *
+   * @default DEFAULT_MIN_AVAILABLE_STORAGE_BYTES
+   */
+  minAvailableStorageBytes?: number;
+
+  /**
+   * How many bytes of a single file must be copied before another progress
+   * event is emitted for it. Copying a large file emits an event roughly every
+   * this many bytes rather than once per chunk.
+   *
+   * @default DEFAULT_PROGRESS_EVENT_INTERVAL_BYTES
+   */
+  progressEventIntervalBytes?: number;
+}

--- a/apps/admin/backend/src/backup/restore/types.ts
+++ b/apps/admin/backend/src/backup/restore/types.ts
@@ -4,6 +4,7 @@ import { ProgressTracking } from '../progress.js';
  * Possible expected errors that can occur when restoring a backup.
  */
 export type RestoreError =
+  | { type: 'cancelled'; message: string }
   | { type: 'workspace-already-configured'; message: string }
   | { type: 'backup-read-failed'; message: string }
   | { type: 'backup-authentication-failed'; message: string }

--- a/apps/admin/backend/src/backup/restore/verify_step.ts
+++ b/apps/admin/backend/src/backup/restore/verify_step.ts
@@ -1,0 +1,64 @@
+import { err, ok, Result } from '@votingworks/basics';
+import { syncFilesystem } from '@votingworks/fs';
+import { BaseLogger } from '@votingworks/logging';
+import { createWorkspace } from '../../util/workspace.js';
+import { BackupManifest } from '../backup_manifest.js';
+import { RestoreError } from './types.js';
+
+/**
+ * Verifies that the restored workspace holds what the manifest promised: a
+ * database configured with the election the operator was told they were
+ * restoring.
+ */
+export function verifyRestoredWorkspace({
+  manifest,
+  workspacePath,
+  logger,
+}: {
+  manifest: BackupManifest;
+  workspacePath: string;
+  logger: BaseLogger;
+}): Result<void, RestoreError> {
+  // A manifest lists only files, so a backup carries no record of workspace
+  // directories that were empty (e.g. `ballot-images` before any CVRs are
+  // loaded). `createWorkspace` recreates whatever the copy didn't, rather than
+  // requiring the backup to have provided it. This runs before the flush, so
+  // the recreated directories are covered by it.
+  using workspace = createWorkspace(workspacePath, logger);
+  const currentElectionId = workspace.store.getCurrentElectionId();
+  const electionDefinitionId =
+    currentElectionId &&
+    workspace.store.getElectionDefinitionId(currentElectionId);
+
+  if (electionDefinitionId !== manifest.election.id) {
+    return err({
+      type: 'backup-verification-failed',
+      message: `Expected election ID ${manifest.election.id} but got ${
+        electionDefinitionId || 'none'
+      }`,
+    });
+  }
+
+  return ok();
+}
+
+/**
+ * Flushes the restored files to disk, so that declaring the restore complete
+ * means the data survives an immediate power cut. Without this the restored
+ * files may live only in the page cache.
+ */
+export async function flushRestoredWorkspace(
+  workspacePath: string
+): Promise<Result<void, RestoreError>> {
+  const flushResult = await syncFilesystem(workspacePath);
+  if (flushResult.isErr()) {
+    return err({
+      type: 'workspace-flush-failed',
+      message: `Failed to flush the restored workspace to disk: ${
+        flushResult.err().message
+      }`,
+    });
+  }
+
+  return ok();
+}

--- a/apps/admin/backend/src/util/workspace.ts
+++ b/apps/admin/backend/src/util/workspace.ts
@@ -136,7 +136,7 @@ export function resolveWorkspacePath(logger: BaseLogger): string {
   const workspacePath =
     process.env.ADMIN_WORKSPACE ??
     (getNodeEnv() === 'development'
-      ? join(import.meta.dirname, '../dev-workspace')
+      ? join(import.meta.dirname, '../../dev-workspace')
       : undefined);
   if (!workspacePath) {
     logger.log(LogEventId.WorkspaceConfigurationMessage, 'system', {

--- a/apps/admin/backend/test/backup.ts
+++ b/apps/admin/backend/test/backup.ts
@@ -1,0 +1,156 @@
+import { vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import {
+  electionFamousNames2021Fixtures,
+  makeTemporaryDirectory,
+} from '@votingworks/fixtures';
+import { assertDefined } from '@votingworks/basics';
+import { DEFAULT_SYSTEM_SETTINGS, Id } from '@votingworks/types';
+import { BaseLogger, LogSource } from '@votingworks/logging';
+import { getDiskSpaceSummaries } from '@votingworks/backend';
+import { createWorkspace, Workspace } from '../src/util/workspace.js';
+
+/**
+ * A volume with so much free space that a test using it never has to think
+ * about storage limits.
+ */
+export const GENEROUS_AVAILABLE_KB = 1_000_000_000; // 1 TB
+
+/**
+ * Mocks {@link getDiskSpaceSummaries}, reporting `availableKb` free kilobytes
+ * for each queried path. Requires the calling test file to have mocked
+ * `@votingworks/backend`.
+ */
+export function mockDiskSpace(
+  availableKb: (path: string) => number = () => GENEROUS_AVAILABLE_KB
+): void {
+  vi.mocked(getDiskSpaceSummaries).mockImplementation((paths) =>
+    Promise.resolve(
+      paths.map((path) => ({
+        path,
+        mountpoint: '/',
+        total: GENEROUS_AVAILABLE_KB,
+        used: 0,
+        available: availableKb(path),
+      }))
+    )
+  );
+}
+
+/**
+ * Creates a workspace in a temporary directory configured with the famous
+ * names election as its current election.
+ */
+export async function makeConfiguredWorkspace(): Promise<Workspace> {
+  const logger = new BaseLogger(LogSource.VxAdminService);
+  const workspace = createWorkspace(makeTemporaryDirectory(), logger);
+  const { electionPackage, readElectionDefinition } =
+    electionFamousNames2021Fixtures;
+  const electionId = await workspace.store.addElection({
+    electionData: readElectionDefinition().electionData,
+    systemSettingsData: JSON.stringify(DEFAULT_SYSTEM_SETTINGS),
+    electionPackageSourceFilePath: electionPackage.asFilePath(),
+    electionPackageHash: createHash('sha256')
+      .update(electionPackage.asBuffer())
+      .digest('hex'),
+  });
+  workspace.store.setCurrentElectionId(electionId);
+  return workspace;
+}
+
+/**
+ * What {@link addCvrWithBallotImage} added.
+ */
+export interface AddedCvrWithBallotImage {
+  cvrId: Id;
+
+  /**
+   * Where the ballot image was written within the workspace.
+   */
+  imagePath: string;
+
+  /**
+   * The ballot image's contents, unique to this `ballotId`.
+   */
+  imageData: Buffer;
+}
+
+/**
+ * Adds a single CVR with a ballot image directly via low-level store calls,
+ * bypassing the CVR export/import pipeline entirely. Each `ballotId` gets its
+ * own batch and CVR file, so this may be called repeatedly to build up a
+ * workspace with several images.
+ */
+export function addCvrWithBallotImage(
+  workspace: Workspace,
+  { ballotId = 'ballot-1' }: { ballotId?: string } = {}
+): AddedCvrWithBallotImage {
+  const { store } = workspace;
+  const electionId = store.getCurrentElectionId();
+  if (!electionId) throw new Error('workspace has no current election');
+  const electionRecord = store.getElection(electionId);
+  if (!electionRecord) throw new Error('current election not found');
+  const { election } = electionRecord.electionDefinition;
+  const batchId = `batch-for-${ballotId}`;
+  const cvrFileId = `cvr-file-for-${ballotId}`;
+
+  store.addScannerBatch({
+    batchId,
+    scannerId: 'scanner-1',
+    label: 'Batch 1',
+    electionId,
+    startedAt: new Date().toISOString(),
+  });
+  store.addCastVoteRecordFileRecord({
+    id: cvrFileId,
+    electionId,
+    isTestMode: false,
+    filename: 'cvrs.jsonl',
+    exportedTimestamp: new Date().toISOString(),
+    sha256Hash: 'hash',
+    scannerIds: new Set(['scanner-1']),
+    pollingPlaceIds: new Set(),
+    batchIds: [batchId],
+  });
+  const result = store.addCastVoteRecordFileEntry({
+    electionId,
+    cvrFileId,
+    ballotId,
+    cvr: {
+      ballotStyleGroupId: assertDefined(election.ballotStyles[0]).groupId,
+      batchId,
+      card: { type: 'bmd' },
+      precinctId: assertDefined(election.precincts[0]).id,
+      votes: {},
+      votingMethod: 'precinct',
+    },
+    adjudicationFlags: {
+      isBlank: false,
+      hasOvervote: false,
+      hasUndervote: false,
+      hasWriteIn: true,
+      hasMarginalMark: false,
+      hasCrossoverVote: false,
+    },
+  });
+  if (result.isErr()) {
+    throw new Error(`failed to add cvr: ${JSON.stringify(result.err())}`);
+  }
+  const { cvrId } = result.ok();
+
+  const imageData = Buffer.from(`fake-front-image-data-for-${ballotId}`);
+  store.addBallotImage({
+    cvrId,
+    electionDefinitionId: election.id,
+    imageData,
+    side: 'front',
+  });
+
+  return {
+    cvrId,
+    imagePath: join(store.getBallotImagesPath(), election.id, `${cvrId}-front`),
+    imageData,
+  };
+}

--- a/apps/admin/backend/test/backup.ts
+++ b/apps/admin/backend/test/backup.ts
@@ -8,9 +8,11 @@ import {
 } from '@votingworks/fixtures';
 import { assertDefined } from '@votingworks/basics';
 import { DEFAULT_SYSTEM_SETTINGS, Id } from '@votingworks/types';
-import { BaseLogger, LogSource } from '@votingworks/logging';
+import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
 import { createWorkspace, Workspace } from '../src/util/workspace.js';
+import { createBackup } from '../src/backup/create/index.js';
+import { Backup } from '../src/backup/backup.js';
 
 /**
  * A volume with so much free space that a test using it never has to think
@@ -153,4 +155,22 @@ export function addCvrWithBallotImage(
     imagePath: join(store.getBallotImagesPath(), election.id, `${cvrId}-front`),
     imageData,
   };
+}
+
+/**
+ * Creates a real, signed backup of a workspace with one CVR and ballot image.
+ * Requires the calling test to have mocked disk space, as {@link mockDiskSpace}
+ * does.
+ */
+export async function makeBackup(): Promise<Backup> {
+  using source = await makeConfiguredWorkspace();
+  addCvrWithBallotImage(source, { ballotId: 'ballot-1' });
+  const created = (
+    await createBackup({
+      workspace: source,
+      target: makeTemporaryDirectory(),
+      logger: mockBaseLogger({ fn: vi.fn }),
+    })
+  ).unsafeUnwrap();
+  return new Backup(created.path);
 }

--- a/apps/scan/backend/src/util/workspace.ts
+++ b/apps/scan/backend/src/util/workspace.ts
@@ -127,7 +127,7 @@ export function getScanWorkspace(): Optional<string> {
   return (
     process.env.SCAN_WORKSPACE ??
     (getNodeEnv() === 'development'
-      ? join(import.meta.dirname, '../dev-workspace')
+      ? join(import.meta.dirname, '../../dev-workspace')
       : undefined)
   );
 }

--- a/libs/auth/src/artifact_authentication.ts
+++ b/libs/auth/src/artifact_authentication.ts
@@ -294,7 +294,10 @@ function constructSignatureFileName(artifact: ArtifactToExport): string {
   }
 }
 
-function constructSignatureFilePath(artifact: ArtifactToImport): string {
+/**
+ * Determines the file name for the given importable artifact.
+ */
+export function constructSignatureFilePath(artifact: ArtifactToImport): string {
   switch (artifact.type) {
     case 'cast_vote_records': {
       return `${artifact.directoryPath}${SIGNATURE_FILE_EXTENSION}`;

--- a/libs/fs/src/copy_file.test.ts
+++ b/libs/fs/src/copy_file.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { err, typedAs } from '@votingworks/basics';
+import {
+  makeTemporaryDirectory,
+  makeTemporaryFile,
+} from '@votingworks/fixtures';
+import { CopyFileError, copyFile } from './copy_file';
+import * as openFile from './open_file';
+import { READ_CHUNK_SIZE } from './read_chunks';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeDestinationPath(): string {
+  return join(makeTemporaryDirectory(), 'destination');
+}
+
+test('copies a file, reporting what it actually held', async () => {
+  const content = 'the contents of the file';
+  const source = makeTemporaryFile({ content });
+  const destination = makeDestinationPath();
+
+  const result = await copyFile({
+    source,
+    destination,
+    maxSize: content.length,
+  });
+
+  expect(result.unsafeUnwrap()).toEqual({ size: content.length });
+  expect(readFileSync(destination, 'utf-8')).toEqual(content);
+});
+
+test('hashes the contents during the copy when asked', async () => {
+  const content = 'the contents of the file';
+  const source = makeTemporaryFile({ content });
+  const destination = makeDestinationPath();
+
+  const result = await copyFile({
+    source,
+    destination,
+    maxSize: content.length,
+    digest: 'sha256',
+  });
+
+  expect(result.unsafeUnwrap()).toEqual({
+    size: content.length,
+    sha256: createHash('sha256').update(content).digest('hex'),
+  });
+});
+
+test('copies a file larger than one read chunk', async () => {
+  const content = Buffer.from('a'.repeat(READ_CHUNK_SIZE * 2 + 1));
+  const source = makeTemporaryFile({ content });
+  const destination = makeDestinationPath();
+
+  const progress: number[] = [];
+  const result = await copyFile({
+    source,
+    destination,
+    maxSize: content.byteLength,
+    digest: 'sha256',
+    onProgress: (copiedBytes) => progress.push(copiedBytes),
+  });
+
+  // Progress is reported once per chunk as it lands, ending at the full size.
+  expect(progress).toEqual([
+    READ_CHUNK_SIZE,
+    READ_CHUNK_SIZE * 2,
+    READ_CHUNK_SIZE * 2 + 1,
+  ]);
+
+  expect(result.unsafeUnwrap()).toEqual({
+    size: content.byteLength,
+    sha256: createHash('sha256').update(content).digest('hex'),
+  });
+  expect(readFileSync(destination)).toEqual(content);
+});
+
+test('a file exactly at the limit is still copied', async () => {
+  const source = makeTemporaryFile({ content: 'a'.repeat(100) });
+  const destination = makeDestinationPath();
+
+  expect(
+    (await copyFile({ source, destination, maxSize: 100 })).unsafeUnwrap()
+  ).toEqual({ size: 100 });
+});
+
+test('a file that grows past the limit while being copied is abandoned', async () => {
+  const source = makeTemporaryFile({ content: '' });
+  const destination = makeDestinationPath();
+  const maxSize = 4 * 1024;
+
+  // Written after the file exists but before it is copied: nothing here
+  // consults `stat`, so the limit is enforced on what the read produces.
+  writeFileSync(source, 'a'.repeat(maxSize * 4));
+
+  expect(await copyFile({ source, destination, maxSize })).toEqual(
+    err(typedAs<CopyFileError>({ type: 'FileExceedsMaxSize', maxSize }))
+  );
+
+  // The limit is what a caller has agreed to spend, so a source that turns out
+  // to be bigger than it claimed must not leave more than that behind.
+  expect(existsSync(destination)).toEqual(false);
+});
+
+test('a source that cannot be opened is reported as such', async () => {
+  const destination = makeDestinationPath();
+
+  expect(
+    await copyFile({
+      source: join(makeTemporaryDirectory(), 'does-not-exist'),
+      destination,
+      maxSize: 100,
+    })
+  ).toEqual(
+    err(
+      typedAs<CopyFileError>({
+        type: 'OpenFileError',
+        error: expect.objectContaining({ code: 'ENOENT' }),
+      })
+    )
+  );
+  expect(existsSync(destination)).toEqual(false);
+});
+
+test('a source that opens but cannot be read is not blamed on the destination', async () => {
+  // A directory opens fine and fails the read itself, with EISDIR, standing in
+  // for the errors a failing drive raises partway through.
+  const source = makeTemporaryDirectory();
+  const destination = makeDestinationPath();
+
+  expect(
+    await copyFile({
+      source,
+      destination,
+      maxSize: 1024 * 1024,
+    })
+  ).toEqual(
+    err(
+      typedAs<CopyFileError>({
+        type: 'ReadFileError',
+        error: expect.objectContaining({
+          message: expect.stringContaining('EISDIR'),
+        }),
+      })
+    )
+  );
+  expect(existsSync(destination)).toEqual(false);
+});
+
+test('a destination that cannot be opened is not blamed on the source', async () => {
+  const source = makeTemporaryFile({ content: 'contents' });
+
+  expect(
+    await copyFile({
+      source,
+      destination: join(makeTemporaryDirectory(), 'no-such-directory', 'file'),
+      maxSize: 100,
+    })
+  ).toEqual(
+    err(
+      typedAs<CopyFileError>({
+        type: 'WriteFileError',
+        error: expect.objectContaining({ code: 'ENOENT' }),
+      })
+    )
+  );
+});
+
+test('a short write is completed rather than trusted', async () => {
+  const content = 'the contents of the file';
+  const source = makeTemporaryFile({ content });
+  const destination = makeDestinationPath();
+
+  // `write` may accept fewer bytes than offered without erroring. Wrap the
+  // destination handle so every write takes at most a few bytes, forcing the
+  // copy to notice and finish the job.
+  const realOpen = openFile.open;
+  vi.spyOn(openFile, 'open').mockImplementation(async (path, flags, mode) => {
+    const result = await realOpen(path, flags, mode);
+    if (flags === 'w' && result.isOk()) {
+      const handle = result.ok();
+      const realWrite = handle.write.bind(handle);
+      vi.spyOn(handle, 'write').mockImplementation(((
+        buffer: Buffer,
+        offset: number,
+        length: number
+      ) =>
+        realWrite(buffer, offset, Math.min(length, 7))) as typeof handle.write);
+    }
+    return result;
+  });
+
+  const result = await copyFile({
+    source,
+    destination,
+    maxSize: content.length,
+    digest: 'sha256',
+  });
+
+  expect(result.unsafeUnwrap()).toEqual({
+    size: content.length,
+    sha256: createHash('sha256').update(content).digest('hex'),
+  });
+  expect(readFileSync(destination, 'utf-8')).toEqual(content);
+});
+
+// `/dev/full` opens fine and fails every write with ENOSPC, which is what a
+// destination disk filling up mid-copy looks like. It is Linux-only, so this is
+// skipped elsewhere; CI, where coverage is enforced, runs on Linux. As a device
+// rather than a regular file, it also exercises cleanup declining to unlink a
+// destination that cannot be holding a partial copy.
+test.runIf(existsSync('/dev/full'))(
+  'a write that fails partway through is not blamed on the source',
+  async () => {
+    const source = makeTemporaryFile({ content: 'contents' });
+
+    expect(
+      await copyFile({ source, destination: '/dev/full', maxSize: 100 })
+    ).toEqual(
+      err(
+        typedAs<CopyFileError>({
+          type: 'WriteFileError',
+          error: expect.objectContaining({ code: 'ENOSPC' }),
+        })
+      )
+    );
+    expect(existsSync('/dev/full')).toEqual(true);
+  }
+);
+
+test('invalid maxSize', async () => {
+  await expect(
+    copyFile({ source: 'source', destination: 'destination', maxSize: -1 })
+  ).rejects.toThrow('maxSize must be non-negative');
+});

--- a/libs/fs/src/copy_file.test.ts
+++ b/libs/fs/src/copy_file.test.ts
@@ -108,6 +108,47 @@ test('a file that grows past the limit while being copied is abandoned', async (
   expect(existsSync(destination)).toEqual(false);
 });
 
+test('a signal already aborted stops the copy before it opens anything', async () => {
+  const source = makeTemporaryFile({ content: 'the contents of the file' });
+  const destination = makeDestinationPath();
+  const open = vi.spyOn(openFile, 'open');
+
+  expect(
+    await copyFile({
+      source,
+      destination,
+      maxSize: 1024,
+      signal: AbortSignal.abort(),
+    })
+  ).toEqual(err(typedAs<CopyFileError>({ type: 'Cancelled' })));
+
+  expect(open).not.toHaveBeenCalled();
+  expect(existsSync(destination)).toEqual(false);
+});
+
+test('aborting partway through leaves no partial destination', async () => {
+  // Big enough that the abort below lands between chunks rather than after
+  // the whole file has already been read.
+  const content = Buffer.from('a'.repeat(READ_CHUNK_SIZE * 4));
+  const source = makeTemporaryFile({ content });
+  const destination = makeDestinationPath();
+  const controller = new AbortController();
+
+  const result = await copyFile({
+    source,
+    destination,
+    maxSize: content.byteLength,
+    onProgress: () => controller.abort(),
+    signal: controller.signal,
+  });
+
+  expect(result).toEqual(err(typedAs<CopyFileError>({ type: 'Cancelled' })));
+
+  // A cancelled copy is abandoned like a failed one: what landed so far is
+  // not a file anyone should find.
+  expect(existsSync(destination)).toEqual(false);
+});
+
 test('a source that cannot be opened is reported as such', async () => {
   const destination = makeDestinationPath();
 

--- a/libs/fs/src/copy_file.ts
+++ b/libs/fs/src/copy_file.ts
@@ -1,0 +1,156 @@
+import { Result, err, ok } from '@votingworks/basics';
+import { createHash } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+import { open } from './open_file';
+import { FileExceedsMaxSizeError } from './file_exceeds_max_size_error';
+import { ReadChunkError } from './read_chunk_error';
+import { readChunksWithinLimit } from './read_chunks';
+
+/**
+ * Possible errors that can occur when copying a file.
+ */
+export type CopyFileError =
+  | { type: 'OpenFileError'; error: globalThis.Error }
+  | { type: 'FileExceedsMaxSize'; maxSize: number }
+  | { type: 'ReadFileError'; error: globalThis.Error }
+  | { type: 'WriteFileError'; error: globalThis.Error };
+
+/**
+ * What a copied file turned out to hold, measured as it was copied rather than
+ * taken on faith beforehand.
+ */
+export interface CopiedFile {
+  size: number;
+}
+
+/**
+ * A {@link CopiedFile} whose contents were also digested along the way.
+ */
+export interface DigestedCopiedFile extends CopiedFile {
+  sha256: string;
+}
+
+/**
+ * Copies a file, up to `maxSize` bytes. A file with more than that to give is
+ * an error, and no more than `maxSize` bytes of it are ever written.
+ *
+ * As with {@link readFile}, the size is counted as the bytes arrive rather than
+ * read from a `stat` beforehand: a source may live on removable media, so what
+ * it says about its own size is a claim and not a fact. Counting what actually
+ * arrives is what makes `maxSize` a limit on what a caller spends, rather than
+ * a limit on what the source admits to.
+ *
+ * Pass `digest: 'sha256'` to hash the contents during the copy, which callers
+ * who have to verify what they copied need anyway and which costs no extra
+ * read. A partial copy is removed rather than left for a caller to trip over.
+ *
+ * Pass `onProgress` to hear how many bytes have landed in the destination so
+ * far, called once per chunk written.
+ */
+export async function copyFile(options: {
+  source: string;
+  destination: string;
+  maxSize: number;
+  onProgress?: (copiedBytes: number) => void;
+}): Promise<Result<CopiedFile, CopyFileError>>;
+/**
+ * Copies a file, up to `maxSize` bytes, hashing its contents along the way.
+ */
+export async function copyFile(options: {
+  source: string;
+  destination: string;
+  maxSize: number;
+  digest: 'sha256';
+  onProgress?: (copiedBytes: number) => void;
+}): Promise<Result<DigestedCopiedFile, CopyFileError>>;
+/**
+ * Copies a file, up to `maxSize` bytes.
+ */
+export async function copyFile({
+  source,
+  destination,
+  maxSize,
+  digest,
+  onProgress,
+}: {
+  source: string;
+  destination: string;
+  maxSize: number;
+  digest?: 'sha256';
+  onProgress?: (copiedBytes: number) => void;
+}): Promise<Result<CopiedFile | DigestedCopiedFile, CopyFileError>> {
+  if (maxSize < 0) {
+    throw new Error('maxSize must be non-negative');
+  }
+
+  const openSourceResult = await open(source);
+  if (openSourceResult.isErr()) {
+    return err({ type: 'OpenFileError', error: openSourceResult.err() });
+  }
+
+  const sourceFd = openSourceResult.ok();
+  try {
+    const openDestinationResult = await open(destination, 'w');
+    if (openDestinationResult.isErr()) {
+      return err({
+        type: 'WriteFileError',
+        error: openDestinationResult.err(),
+      });
+    }
+
+    const destinationFd = openDestinationResult.ok();
+    const hash = digest ? createHash(digest) : undefined;
+    let size = 0;
+    let succeeded = false;
+
+    try {
+      // Every chunk is hashed and written before the next is asked for, so
+      // they can all share one buffer.
+      for await (const chunk of readChunksWithinLimit(sourceFd, maxSize, {
+        reuseBuffer: true,
+      })) {
+        size += chunk.byteLength;
+        hash?.update(chunk);
+
+        // `write` may accept fewer bytes than offered without erroring, so
+        // keep writing until the whole chunk has landed.
+        let written = 0;
+        while (written < chunk.byteLength) {
+          const { bytesWritten } = await destinationFd.write(
+            chunk,
+            written,
+            chunk.byteLength - written
+          );
+          written += bytesWritten;
+        }
+
+        onProgress?.(size);
+      }
+
+      succeeded = true;
+    } catch (error) {
+      // Anything the chunks themselves raise is about the source; anything
+      // raised in the loop body is this function writing.
+      if (error instanceof FileExceedsMaxSizeError) {
+        return err({ type: 'FileExceedsMaxSize', maxSize });
+      }
+
+      if (error instanceof ReadChunkError) {
+        return err({ type: 'ReadFileError', error: error.readError });
+      }
+
+      return err({ type: 'WriteFileError', error: error as Error });
+    } finally {
+      const shouldRemove = !succeeded && (await destinationFd.stat()).isFile();
+      await destinationFd.close();
+
+      if (shouldRemove) {
+        await rm(destination, { force: true });
+      }
+    }
+
+    return ok(hash ? { size, sha256: hash.digest('hex') } : { size });
+  } finally {
+    await sourceFd.close();
+  }
+}

--- a/libs/fs/src/copy_file.ts
+++ b/libs/fs/src/copy_file.ts
@@ -13,7 +13,8 @@ export type CopyFileError =
   | { type: 'OpenFileError'; error: globalThis.Error }
   | { type: 'FileExceedsMaxSize'; maxSize: number }
   | { type: 'ReadFileError'; error: globalThis.Error }
-  | { type: 'WriteFileError'; error: globalThis.Error };
+  | { type: 'WriteFileError'; error: globalThis.Error }
+  | { type: 'Cancelled' };
 
 /**
  * What a copied file turned out to hold, measured as it was copied rather than
@@ -46,12 +47,18 @@ export interface DigestedCopiedFile extends CopiedFile {
  *
  * Pass `onProgress` to hear how many bytes have landed in the destination so
  * far, called once per chunk written.
+ *
+ * Pass `signal` to be able to stop the copy partway. Aborting is checked
+ * between chunks, so a copy stops within one chunk of the signal rather than
+ * running to completion, and the partial destination is removed just as it is
+ * for a failure.
  */
 export async function copyFile(options: {
   source: string;
   destination: string;
   maxSize: number;
   onProgress?: (copiedBytes: number) => void;
+  signal?: AbortSignal;
 }): Promise<Result<CopiedFile, CopyFileError>>;
 /**
  * Copies a file, up to `maxSize` bytes, hashing its contents along the way.
@@ -62,6 +69,7 @@ export async function copyFile(options: {
   maxSize: number;
   digest: 'sha256';
   onProgress?: (copiedBytes: number) => void;
+  signal?: AbortSignal;
 }): Promise<Result<DigestedCopiedFile, CopyFileError>>;
 /**
  * Copies a file, up to `maxSize` bytes.
@@ -72,15 +80,23 @@ export async function copyFile({
   maxSize,
   digest,
   onProgress,
+  signal,
 }: {
   source: string;
   destination: string;
   maxSize: number;
   digest?: 'sha256';
   onProgress?: (copiedBytes: number) => void;
+  signal?: AbortSignal;
 }): Promise<Result<CopiedFile | DigestedCopiedFile, CopyFileError>> {
   if (maxSize < 0) {
     throw new Error('maxSize must be non-negative');
+  }
+
+  // Checked before opening anything so that a copy cancelled up front costs
+  // nothing and leaves no destination at all.
+  if (signal?.aborted) {
+    return err({ type: 'Cancelled' });
   }
 
   const openSourceResult = await open(source);
@@ -109,6 +125,10 @@ export async function copyFile({
       for await (const chunk of readChunksWithinLimit(sourceFd, maxSize, {
         reuseBuffer: true,
       })) {
+        if (signal?.aborted) {
+          return err({ type: 'Cancelled' });
+        }
+
         size += chunk.byteLength;
         hash?.update(chunk);
 

--- a/libs/fs/src/election.ts
+++ b/libs/fs/src/election.ts
@@ -7,6 +7,13 @@ import { ZodError } from 'zod/v4';
 import { ReadFileError, readFile } from './read_file';
 
 /**
+ * The largest election definition we will read. Generous relative to any real
+ * election, whose size is dominated by its translated strings, but bounded so
+ * that a file claiming to be an election cannot be read without limit.
+ */
+export const MAX_ELECTION_DEFINITION_SIZE = 100 * 1024 * 1024; // 100 MB
+
+/**
  * Possible errors that can occur when reading an election.
  */
 export type ReadElectionError =
@@ -20,6 +27,7 @@ export async function readElection(
   electionPath: string
 ): Promise<Result<ElectionDefinition, ReadElectionError>> {
   const readFileResult = await readFile(electionPath, {
+    maxSize: MAX_ELECTION_DEFINITION_SIZE,
     encoding: 'utf-8',
   });
 

--- a/libs/fs/src/file_exceeds_max_size_error.ts
+++ b/libs/fs/src/file_exceeds_max_size_error.ts
@@ -1,0 +1,10 @@
+/**
+ * Thrown once a file has produced more bytes than a caller allowed it to. The
+ * limit itself is not carried along: whoever set it already has it, and by
+ * definition we never learned how big the file actually was.
+ */
+export class FileExceedsMaxSizeError extends Error {
+  constructor(maxSize: number) {
+    super(`file is larger than the maximum of ${maxSize} bytes`);
+  }
+}

--- a/libs/fs/src/index.ts
+++ b/libs/fs/src/index.ts
@@ -1,4 +1,7 @@
 /* istanbul ignore file */
+export * from './file_exceeds_max_size_error';
+export * from './read_chunk_error';
+export * from './read_chunks';
 export * from './election';
 export * from './list_directory';
 export * from './open_file';

--- a/libs/fs/src/index.ts
+++ b/libs/fs/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+export * from './copy_file';
 export * from './file_exceeds_max_size_error';
 export * from './read_chunk_error';
 export * from './read_chunks';

--- a/libs/fs/src/read_chunk_error.ts
+++ b/libs/fs/src/read_chunk_error.ts
@@ -1,0 +1,18 @@
+/**
+ * Thrown when a file itself could not be read, e.g. EIO from a failing disk.
+ * Wrapped in its own class so that a caller doing something with each chunk can
+ * tell a failure of the source from a failure of its own, which are otherwise
+ * indistinguishable once both have been thrown out of the same loop.
+ */
+export class ReadChunkError extends Error {
+  constructor(private readonly error: globalThis.Error) {
+    super(error.message);
+  }
+
+  /**
+   * The error the file system actually raised.
+   */
+  get readError(): globalThis.Error {
+    return this.error;
+  }
+}

--- a/libs/fs/src/read_chunks.test.ts
+++ b/libs/fs/src/read_chunks.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { iter } from '@votingworks/basics';
+import { makeTemporaryFile } from '@votingworks/fixtures';
+import { open } from './open_file';
+import { READ_CHUNK_SIZE, readChunksWithinLimit } from './read_chunks';
+import { FileExceedsMaxSizeError } from './file_exceeds_max_size_error';
+
+async function collect(
+  content: string,
+  maxSize: number,
+  options?: { reuseBuffer?: boolean }
+): Promise<Buffer[]> {
+  const fd = (await open(makeTemporaryFile({ content }))).unsafeUnwrap();
+  try {
+    return await iter(readChunksWithinLimit(fd, maxSize, options)).toArray();
+  } finally {
+    await fd.close();
+  }
+}
+
+test('a file is delivered in chunks of at most the chunk size', async () => {
+  const content = 'a'.repeat(READ_CHUNK_SIZE * 2 + 1);
+  const chunks = await collect(content, content.length);
+
+  expect(chunks.map((chunk) => chunk.byteLength)).toEqual([
+    READ_CHUNK_SIZE,
+    READ_CHUNK_SIZE,
+    1,
+  ]);
+  expect(Buffer.concat(chunks).toString()).toEqual(content);
+});
+
+test('chunks are the caller`s to keep by default', async () => {
+  const content = 'a'.repeat(READ_CHUNK_SIZE + 1);
+  const [first, second] = await collect(content, content.length);
+
+  expect(first?.buffer === second?.buffer).toEqual(false);
+});
+
+test('reuseBuffer reads the whole file through one buffer', async () => {
+  const content = 'a'.repeat(READ_CHUNK_SIZE + 1);
+  const [first, second] = await collect(content, content.length, {
+    reuseBuffer: true,
+  });
+
+  // The reason this is opt-in: a caller that kept the first chunk would find it
+  // holding the second chunk's bytes.
+  expect(first?.buffer === second?.buffer).toEqual(true);
+});
+
+test('a file is cut off once it exceeds the limit', async () => {
+  await expect(
+    collect('a'.repeat(READ_CHUNK_SIZE * 2), READ_CHUNK_SIZE)
+  ).rejects.toThrow(FileExceedsMaxSizeError);
+});

--- a/libs/fs/src/read_chunks.ts
+++ b/libs/fs/src/read_chunks.ts
@@ -1,0 +1,68 @@
+import { Buffer } from 'node:buffer';
+import { FileHandle } from 'node:fs/promises';
+import { FileExceedsMaxSizeError } from './file_exceeds_max_size_error';
+import { ReadChunkError } from './read_chunk_error';
+
+/**
+ * How much is read at a time from a file whose size we do not trust in advance.
+ *
+ * Large enough that per-read overhead is not what dominates — at 64 KB it was,
+ * costing roughly a third of a copy's time and several times a read's — and
+ * small enough that a limit is overshot by at most this much before it is
+ * noticed. Note that this is what an untrusted file may briefly cost us beyond
+ * `maxSize`; nothing beyond the limit is ever written or kept.
+ */
+export const READ_CHUNK_SIZE = 1024 * 1024;
+
+/**
+ * Reads a file in chunks, stopping as soon as it has produced more than
+ * `maxSize` bytes in total.
+ *
+ * The size is counted as the bytes arrive rather than read from a `stat`
+ * beforehand. A file may live on removable media, where what it says about
+ * itself is a claim and not a fact, and where it can change between being
+ * measured and being read: trusting the claim risks both consuming more than
+ * `maxSize` and silently taking a prefix of a file that grew. Counting what
+ * actually arrives is what makes `maxSize` a limit on what a caller spends.
+ *
+ * Opening and closing `fd` is the caller's business, since what to do about a
+ * partial read differs depending on where those bytes were going. Failures are
+ * thrown rather than returned so that a caller consuming the chunks can tell
+ * them apart from its own; see {@link ReadChunkError}.
+ *
+ * Each chunk is freshly allocated, so a caller may keep the ones it is given.
+ * Pass `reuseBuffer: true` if every chunk is finished with before the next is
+ * asked for — copying it somewhere, hashing it — to read the whole file through
+ * a single buffer instead of allocating one per chunk. A retained chunk will
+ * then be overwritten in place, so this has to be opted into.
+ */
+export async function* readChunksWithinLimit(
+  fd: FileHandle,
+  maxSize: number,
+  { reuseBuffer = false }: { reuseBuffer?: boolean } = {}
+): AsyncGenerator<Buffer> {
+  const reusedBuffer = reuseBuffer
+    ? Buffer.allocUnsafe(READ_CHUNK_SIZE)
+    : undefined;
+  let size = 0;
+
+  for (;;) {
+    const chunk = reusedBuffer ?? Buffer.allocUnsafe(READ_CHUNK_SIZE);
+    let bytesRead: number;
+
+    try {
+      ({ bytesRead } = await fd.read(chunk, 0, READ_CHUNK_SIZE, null));
+    } catch (error) {
+      throw new ReadChunkError(error as globalThis.Error);
+    }
+
+    if (bytesRead === 0) return;
+
+    size += bytesRead;
+    if (size > maxSize) {
+      throw new FileExceedsMaxSizeError(maxSize);
+    }
+
+    yield chunk.subarray(0, bytesRead);
+  }
+}

--- a/libs/fs/src/read_file.test.ts
+++ b/libs/fs/src/read_file.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 import { Buffer } from 'node:buffer';
+import { writeFileSync } from 'node:fs';
 import { err, ok, typedAs } from '@votingworks/basics';
 import {
   makeTemporaryDirectory,
@@ -8,6 +9,7 @@ import {
 } from '@votingworks/fixtures';
 import fc from 'fast-check';
 import { ReadFileError, readFile } from './read_file';
+import { READ_CHUNK_SIZE } from './read_chunks';
 
 test('file open error', async () => {
   const path = makeTemporaryPath();
@@ -49,7 +51,6 @@ test('file exceeds max size', async () => {
           typedAs<ReadFileError>({
             type: 'FileExceedsMaxSize',
             maxSize,
-            fileSize: maxSize + 1,
           })
         )
       );
@@ -57,15 +58,27 @@ test('file exceeds max size', async () => {
   );
 });
 
-test('no maxSize reads any size', async () => {
-  const content = 'file contents';
+test('a file that grows past the limit while being read is refused', async () => {
+  const path = makeTemporaryFile({ content: '' });
+  const maxSize = 4 * 1024;
+
+  // Written after the file exists but before it is read, standing in for a file
+  // whose reported size and actual contents disagree. Nothing here consults
+  // `stat`, so the limit is enforced on what the read actually produces.
+  writeFileSync(path, 'a'.repeat(maxSize * 4));
+
+  expect(await readFile(path, { maxSize })).toEqual(
+    err(typedAs<ReadFileError>({ type: 'FileExceedsMaxSize', maxSize }))
+  );
+});
+
+test('a file larger than one read chunk is read whole', async () => {
+  const content = 'a'.repeat(READ_CHUNK_SIZE * 2 + 1);
   const path = makeTemporaryFile({ content });
 
-  const buffer = (await readFile(path)).unsafeUnwrap();
-  expect(buffer).toBeInstanceOf(Buffer);
-  expect(buffer.toString('utf-8')).toEqual(content);
-
-  expect(await readFile(path, { encoding: 'utf-8' })).toEqual(ok(content));
+  expect(await readFile(path, { maxSize: content.length })).toEqual(
+    ok(Buffer.from(content))
+  );
 });
 
 test('invalid maxSize', async () => {

--- a/libs/fs/src/read_file.ts
+++ b/libs/fs/src/read_file.ts
@@ -1,49 +1,53 @@
-import { Result, err, ok } from '@votingworks/basics';
+import { assert, Result, err, ok } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
 import { open } from './open_file';
+import { FileExceedsMaxSizeError } from './file_exceeds_max_size_error';
+import { ReadChunkError } from './read_chunk_error';
+import { readChunksWithinLimit } from './read_chunks';
 
 /**
  * Possible errors that can occur when reading a file.
  */
 export type ReadFileError =
   | { type: 'OpenFileError'; error: globalThis.Error }
-  | { type: 'FileExceedsMaxSize'; maxSize: number; fileSize: number }
+  | { type: 'FileExceedsMaxSize'; maxSize: number }
   | { type: 'ReadFileError'; error: globalThis.Error };
 
 /**
- * Reads the entire contents of a file. If `maxSize` is provided and the file is
- * larger than `maxSize` then an error is returned without reading the file.
+ * Reads the entire contents of a file, up to `maxSize` bytes. A file with more
+ * than that to give is an error, and no more than `maxSize` bytes of it are
+ * ever read. Note that assembling the result briefly holds both the chunks
+ * read and their concatenation, so peak memory is about twice `maxSize`. See
+ * {@link readChunksWithinLimit} for why the size is measured rather than taken
+ * on faith.
  *
  * @param path The path to the file to read.
- * @param maxSize The maximum size of the file to read in bytes.
+ * @param maxSize The maximum number of bytes to read.
  */
 export async function readFile(
   path: string,
-  options?: { maxSize?: number }
+  options: { maxSize: number }
 ): Promise<Result<Buffer, ReadFileError>>;
 /**
- * Reads the entire contents of a file. If `maxSize` is provided and the file is
- * larger than `maxSize` then an error is returned without reading the file.
+ * Reads the entire contents of a file, up to `maxSize` bytes. A file with more
+ * than that to give is an error, and no more than `maxSize` bytes of it are
+ * ever read. Peak memory is about twice `maxSize`, plus the decoded string.
  *
  * @param path The path to the file to read.
- * @param maxSize The maximum size of the file to read in bytes.
+ * @param maxSize The maximum number of bytes to read.
  */
 export async function readFile(
   path: string,
-  { maxSize, encoding }: { maxSize?: number; encoding: BufferEncoding }
+  options: { maxSize: number; encoding: BufferEncoding }
 ): Promise<Result<string, ReadFileError>>;
 /**
- * Reads the entire contents of a file. If `maxSize` is provided and the file is
- * larger than `maxSize` then an error is returned without reading the file.
- *
- * @param path The path to the file to read.
- * @param maxSize The maximum size of the file to read in bytes.
+ * Reads the entire contents of a file, up to `maxSize` bytes.
  */
 export async function readFile(
   path: string,
-  { maxSize, encoding }: { maxSize?: number; encoding?: BufferEncoding } = {}
+  { maxSize, encoding }: { maxSize: number; encoding?: BufferEncoding }
 ): Promise<Result<Buffer | string, ReadFileError>> {
-  if (maxSize !== undefined && maxSize < 0) {
+  if (maxSize < 0) {
     throw new Error('maxSize must be non-negative');
   }
 
@@ -54,36 +58,26 @@ export async function readFile(
   }
 
   const fd = openResult.ok();
+  const chunks: Buffer[] = [];
+
   try {
-    const stat = await fd.stat();
-
-    if (maxSize !== undefined && stat.size > maxSize) {
-      return err({
-        type: 'FileExceedsMaxSize',
-        maxSize,
-        fileSize: stat.size,
-      });
+    for await (const chunk of readChunksWithinLimit(fd, maxSize)) {
+      chunks.push(chunk);
     }
-
-    const buffer = Buffer.allocUnsafe(stat.size);
-    const readResult = await fd.read(buffer, 0, stat.size, 0);
-
-    /* istanbul ignore next */
-    if (readResult.bytesRead !== stat.size) {
-      return err({
-        type: 'ReadFileError',
-        error: new Error(
-          `unexpected number of bytes read: ${readResult.bytesRead} instead of ${stat.size}`
-        ),
-      });
-    }
-
-    return ok(encoding ? buffer.toString(encoding) : buffer);
   } catch (error) {
-    // e.g. EISDIR reading a directory, or EIO from a failing disk. These are
-    // read failures like any other, and must not leak the file descriptor.
-    return err({ type: 'ReadFileError', error: error as Error });
+    if (error instanceof FileExceedsMaxSizeError) {
+      return err({ type: 'FileExceedsMaxSize', maxSize });
+    }
+
+    // Nothing else in the loop can throw, so whatever this is came from the
+    // file: e.g. EISDIR reading a directory, or EIO from a failing disk.
+    assert(error instanceof ReadChunkError);
+    return err({ type: 'ReadFileError', error: error.readError });
   } finally {
+    // However this ended, the descriptor must not leak.
     await fd.close();
   }
+
+  const buffer = Buffer.concat(chunks);
+  return ok(encoding ? buffer.toString(encoding) : buffer);
 }

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -370,6 +370,26 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)
 **Description:** User updated a qualified write-in candidate.
 **Machines:** vx-admin
+### backup-create-init
+**Type:** [user-action](#user-action)
+**Description:** Creating a backup of the machine data is initiated.
+**Machines:** vx-admin
+### backup-create-complete
+**Type:** [user-action](#user-action)
+**Description:** Creating a backup completed, success or failure is indicated by the disposition.
+**Machines:** vx-admin
+### backup-restore-init
+**Type:** [user-action](#user-action)
+**Description:** Restoring the machine data from a backup is initiated.
+**Machines:** vx-admin
+### backup-restore-complete
+**Type:** [user-action](#user-action)
+**Description:** Restoring from a backup completed, success or failure is indicated by the disposition.
+**Machines:** vx-admin
+### backup-restore-machine-mismatch
+**Type:** [user-action](#user-action)
+**Description:** User is restoring a backup whose machine ID differs from the current machine's ID.
+**Machines:** vx-admin
 ### clear-ballot-data-init
 **Type:** [user-action](#user-action)
 **Description:** User has initiated clearing ballot data in the current application.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -621,6 +621,38 @@ eventType = "user-action"
 documentationMessage = "User updated a qualified write-in candidate."
 restrictInDocumentationToApps = ["vx-admin"]
 
+[Events.BackupCreateInit]
+eventId = "backup-create-init"
+eventType = "user-action"
+documentationMessage = "Creating a backup of the machine data is initiated."
+defaultMessage = "User initiated creating a backup..."
+restrictInDocumentationToApps = ["vx-admin"]
+
+[Events.BackupCreateComplete]
+eventId = "backup-create-complete"
+eventType = "user-action"
+documentationMessage = "Creating a backup completed, success or failure is indicated by the disposition."
+restrictInDocumentationToApps = ["vx-admin"]
+
+[Events.BackupRestoreInit]
+eventId = "backup-restore-init"
+eventType = "user-action"
+documentationMessage = "Restoring the machine data from a backup is initiated."
+defaultMessage = "User initiated restoring from a backup..."
+restrictInDocumentationToApps = ["vx-admin"]
+
+[Events.BackupRestoreComplete]
+eventId = "backup-restore-complete"
+eventType = "user-action"
+documentationMessage = "Restoring from a backup completed, success or failure is indicated by the disposition."
+restrictInDocumentationToApps = ["vx-admin"]
+
+[Events.BackupRestoreMachineMismatch]
+eventId = "backup-restore-machine-mismatch"
+eventType = "user-action"
+documentationMessage = "User is restoring a backup whose machine ID differs from the current machine's ID."
+restrictInDocumentationToApps = ["vx-admin"]
+
 # VxCentralScan-specific user action logs
 [Events.ClearingBallotData]
 eventId = "clear-ballot-data-init"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -155,6 +155,11 @@ export enum LogEventId {
   ElectionReportPrinted = 'election-report-printed',
   WriteInAdjudicated = 'write-in-adjudicated',
   QualifiedWriteInCandidateUpdated = 'qualified-write-in-candidate-updated',
+  BackupCreateInit = 'backup-create-init',
+  BackupCreateComplete = 'backup-create-complete',
+  BackupRestoreInit = 'backup-restore-init',
+  BackupRestoreComplete = 'backup-restore-complete',
+  BackupRestoreMachineMismatch = 'backup-restore-machine-mismatch',
   ClearingBallotData = 'clear-ballot-data-init',
   ClearedBallotData = 'clear-ballot-data-complete',
   DeleteScanBatchInit = 'delete-cvr-batch-init',
@@ -871,6 +876,47 @@ const QualifiedWriteInCandidateUpdated: LogDetails = {
   eventId: LogEventId.QualifiedWriteInCandidateUpdated,
   eventType: LogEventType.UserAction,
   documentationMessage: 'User updated a qualified write-in candidate.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const BackupCreateInit: LogDetails = {
+  eventId: LogEventId.BackupCreateInit,
+  eventType: LogEventType.UserAction,
+  documentationMessage: 'Creating a backup of the machine data is initiated.',
+  defaultMessage: 'User initiated creating a backup...',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const BackupCreateComplete: LogDetails = {
+  eventId: LogEventId.BackupCreateComplete,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Creating a backup completed, success or failure is indicated by the disposition.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const BackupRestoreInit: LogDetails = {
+  eventId: LogEventId.BackupRestoreInit,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Restoring the machine data from a backup is initiated.',
+  defaultMessage: 'User initiated restoring from a backup...',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const BackupRestoreComplete: LogDetails = {
+  eventId: LogEventId.BackupRestoreComplete,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'Restoring from a backup completed, success or failure is indicated by the disposition.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const BackupRestoreMachineMismatch: LogDetails = {
+  eventId: LogEventId.BackupRestoreMachineMismatch,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    "User is restoring a backup whose machine ID differs from the current machine's ID.",
   restrictInDocumentationToApps: [AppName.VxAdmin],
 };
 
@@ -1736,6 +1782,16 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return WriteInAdjudicated;
     case LogEventId.QualifiedWriteInCandidateUpdated:
       return QualifiedWriteInCandidateUpdated;
+    case LogEventId.BackupCreateInit:
+      return BackupCreateInit;
+    case LogEventId.BackupCreateComplete:
+      return BackupCreateComplete;
+    case LogEventId.BackupRestoreInit:
+      return BackupRestoreInit;
+    case LogEventId.BackupRestoreComplete:
+      return BackupRestoreComplete;
+    case LogEventId.BackupRestoreMachineMismatch:
+      return BackupRestoreMachineMismatch;
     case LogEventId.ClearingBallotData:
       return ClearingBallotData;
     case LogEventId.ClearedBallotData:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -293,6 +293,16 @@ pub enum EventId {
     WriteInAdjudicated,
     #[serde(rename = "qualified-write-in-candidate-updated")]
     QualifiedWriteInCandidateUpdated,
+    #[serde(rename = "backup-create-init")]
+    BackupCreateInit,
+    #[serde(rename = "backup-create-complete")]
+    BackupCreateComplete,
+    #[serde(rename = "backup-restore-init")]
+    BackupRestoreInit,
+    #[serde(rename = "backup-restore-complete")]
+    BackupRestoreComplete,
+    #[serde(rename = "backup-restore-machine-mismatch")]
+    BackupRestoreMachineMismatch,
     #[serde(rename = "clear-ballot-data-init")]
     ClearingBallotData,
     #[serde(rename = "clear-ballot-data-complete")]


### PR DESCRIPTION
## Overview

Refs #7987

_(It's kinda big—sorry. Review by commit strongly encouraged!)_

Adds the `backups restore` subcommand, taking a backup directory and a workspace as inputs. Along the way I noticed some issues with the `create` and `list` subcommands that this PR also fixes.

Some of the changes are in `libs/fs` and aim to centralize defensive file IO when dealing with an untrusted external drive. For example, we don't want to read or copy an arbitrary amount of bytes from an external drive since it might just keep sending bytes forever, filling RAM or the internal disk.

As for the restore itself, it follows a similar structure to the backup create code. It validates the backup manifest and signature, checks the internal disk has enough space, copies files over verifying their sizes/hashes match, flushes dirty pages to disk, and marks the restore a success. A fair amount of the code in the restore process—like with the create process—is error handling and integrity checking.

## Demo Video or Screenshot

```sh
# Create a backup.
$ ./bin/backups create --workspace dev-workspace/ --target /tmp
Flushing to device      [████████████████████████] 100%
● franklin-county_lincoln-municipal-general-election_dc2aa66c40
│  Election  Lincoln Municipal General Election · 2021-06-06
│  Created   8/27/2026, 1:04 PM · machine 0000 · v4.1
╰─ Files     2 (435.3 KB)

# List backups.
$ ./bin/backups list /tmp
● franklin-county_lincoln-municipal-general-election_dc2aa66c40
│  Election  Lincoln Municipal General Election · 2021-06-06
│  Created   8/27/2026, 1:04 PM · machine 0000 · v4.1
╰─ Files     2 (435.3 KB)

# Already-configured workspace cannot be restored over, as designed.
$ ./bin/backups restore --workspace dev-workspace --backup /tmp/vxadmin-backups/franklin-county_lincoln-municipal-general-election_dc2aa66c40/
Preparing               [████████████████████████] 100%

Error: Expected workspace to be unconfigured, but it has election with ID b41e84cb-73e8-4276-8c26-5b936db9ed26

# Unconfigure with a sledgehammer.
$ rm -rf dev-workspace/

# Restore from the latest backup for real.
$ ./bin/backups restore --workspace dev-workspace --backup /tmp/vxadmin-backups/franklin-county_lincoln-municipal-general-election_dc2aa66c40/
Flushing to disk        [████████████████████████] 100%
Restored /tmp/vxadmin-backups/franklin-county_lincoln-municipal-general-election_dc2aa66c40/ to dev-workspace.
```

## Testing Plan

Many new automated tests, plus manual testing as shown above.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

