### PR TITLE
Update ballot interpreter to support optional prefix in QR metadata

### DIFF
--- a/libs/ballot-interpreter/README.md
+++ b/libs/ballot-interpreter/README.md
@@ -191,15 +191,14 @@ misinterpreting votes. Key aspects of error handling include:
 
 ### Decode Metadata
 
-The metadata can be encoded either using a QR code in the bottom-left corner or
-by using the presence/absence of timing marks in the bottom row. The metadata
+The metadata is encoded using a QR code in the bottom-left corner. The metadata
 includes the ballot style, precinct, and other information that may be useful
-for interpreting the ballot. When using timing mark based encoding, we use the
-same encoding as the AccuVote system. There is an additional check to ensure
-that we found the timing marks correctly where we check that the areas we
-believe the timing marks to be are sufficiently dark. This mitigates potential
-issues with the timing mark detection algorithm due to smudges, stray marks,
-etc.
+for interpreting the ballot.
+
+The QR code payload is base64-encoded, optionally prefixed with
+`https://ballot.page/vx/` so that scanning the QR code with a phone opens an
+informational page. The interpreter strips that prefix and accepts either
+standard base64 or URL-safe base64.
 
 ### Score Bubble Marks
 

--- a/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
+++ b/libs/ballot-interpreter/src/bubble-ballot-rust/qr_code/detect.rs
@@ -1,6 +1,9 @@
 use std::cell::OnceCell;
 
-use base64::{Engine as _, engine::general_purpose::STANDARD};
+use base64::{
+    Engine as _,
+    engine::general_purpose::{GeneralPurpose, STANDARD, URL_SAFE_NO_PAD},
+};
 use image::GrayImage;
 use serde::Serialize;
 use types_rs::{
@@ -298,8 +301,13 @@ impl Error {
 
 pub type Result = std::result::Result<Detected, Error>;
 
-/// Unwraps a base64-wrapped QR code payload to raw ballot bytes.
-///
+/// The QR code payload is optionally prefixed so that scanning the QR code
+/// with a phone opens an informational page.
+const BALLOT_URL_PREFIX: &[u8] = b"https://ballot.page/vx/";
+
+/// Accept standard base64 or URL-safe base64.
+const PAYLOAD_ENGINES: [GeneralPurpose; 2] = [STANDARD, URL_SAFE_NO_PAD];
+
 /// The decode is kept only if it produced something with a ballot prelude. A
 /// successful decode on its own proves nothing: the base64 alphabet is a
 /// superset of the alphabets a QR payload can be drawn from, so a payload that
@@ -307,10 +315,12 @@ pub type Result = std::result::Result<Detected, Error>;
 /// recognize is passed through unchanged so that the prelude check downstream
 /// reports the error.
 fn unwrap_qr_payload(detected: &Detected) -> Detected {
-    let bytes = match STANDARD.decode(detected.bytes()) {
-        Ok(decoded) if is_vx_payload(&decoded) => decoded,
-        _ => detected.bytes().to_vec(),
-    };
+    let payload = detected.bytes();
+    let stripped = payload.strip_prefix(BALLOT_URL_PREFIX).unwrap_or(payload);
+    let bytes = PAYLOAD_ENGINES
+        .iter()
+        .find_map(|engine| engine.decode(stripped).ok().filter(|d| is_vx_payload(d)))
+        .unwrap_or_else(|| payload.to_vec());
 
     Detected::new(
         detected.detector(),
@@ -485,6 +495,23 @@ mod test {
             assert!(
                 is_vx_payload(unwrapped.bytes()) || unwrapped.bytes() == payload.as_bytes()
             );
+        }
+    }
+
+    /// Test every form that the payload may take
+    #[test]
+    fn test_unwrap_accepted_base64_forms() {
+        let raw = [0x56, 0x42, 0x01, 0xfb, 0xff];
+        assert_eq!(STANDARD.encode(raw), "VkIB+/8=");
+
+        for encoded in [STANDARD.encode(raw), URL_SAFE_NO_PAD.encode(raw)] {
+            for payload in [encoded.clone(), format!("https://ballot.page/vx/{encoded}")] {
+                let expected: &[u8] = &raw;
+                assert_eq!(
+                    unwrap_qr_payload(&detected(payload.as_bytes())).bytes(),
+                    expected,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/9201

We're considering prefixing our bubble ballot metadata QR code payloads with a URL so that, when scanned by a phone, they direct you to an explanatory page. This PR updates the interpreter to optionally support that. It also updates the interpreter to support URL-safe base64-encoded payloads in addition to standard base64-encoded payloads.

The PR doesn't actually update our bubble ballots. We can handle that later (should we actually choose to pursue this idea) since that logic lives outside the certified system.

## Testing Plan

- [x] Updated automated tests

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~