### PR TITLE
libs/printing: log when rich printer status via IPP changes availability

### DIFF
--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -81,7 +81,7 @@ IDs are logged with each log to identify the log being written.
 ### printer-status-changed
 **Type:** [application-status](#application-status)
 **Description:** Application saw a change in the status of the currently connected printer.
-**Machines:** vx-scan
+**Machines:** vx-admin, vx-mark, vx-scan
 ### printer-print-request
 **Type:** [user-action](#user-action)
 **Description:** A print request was triggered.

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -366,7 +366,11 @@ const PrinterStatusChanged: LogDetails = {
   eventType: LogEventType.ApplicationStatus,
   documentationMessage:
     'Application saw a change in the status of the currently connected printer.',
-  restrictInDocumentationToApps: [AppName.VxScan],
+  restrictInDocumentationToApps: [
+    AppName.VxAdmin,
+    AppName.VxMark,
+    AppName.VxScan,
+  ],
 };
 
 const PrinterPrintRequest: LogDetails = {

--- a/libs/printing/src/printer/printer.test.ts
+++ b/libs/printing/src/printer/printer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { mockFunction } from '@votingworks/test-utils';
+import { err, ok } from '@votingworks/basics';
 import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import {
   BooleanEnvironmentVariableName,
@@ -9,6 +10,7 @@ import {
 import { PrinterRichStatus } from '@votingworks/types';
 import { isDeviceAttached } from '@votingworks/backend';
 import { detectPrinter } from './printer';
+import { ExecError } from '../utils/exec';
 import {
   CITIZEN_E351_PRINTER_CONFIG,
   HP_4201_PRINTER_CONFIG,
@@ -48,6 +50,12 @@ vi.mock(import('@votingworks/backend'), async (importActual) => ({
 }));
 
 const isDeviceAttachedMock = vi.mocked(isDeviceAttached);
+
+const IDLE_RICH_STATUS: PrinterRichStatus = {
+  state: 'idle',
+  stateReasons: ['none'],
+  markerInfos: [],
+};
 
 const mockGetPrinterRichStatus = mockFunction('mockGetPrinterRichStatus');
 vi.mock(
@@ -215,12 +223,110 @@ describe('rich status', () => {
         config,
       })
       .returns(undefined);
-    mockGetPrinterRichStatus.expectCallWith().returns(richStatus);
+    mockGetPrinterRichStatus.expectCallWith().returns(ok(richStatus));
     expect(await printer.status()).toEqual({
       connected: true,
       config,
       richStatus,
     });
+  });
+
+  test('logs only when rich status availability changes', async () => {
+    const logger = mockBaseLogger({ fn: vi.fn });
+    const printer = detectPrinter(logger);
+
+    const uri = `${HP_4001_PRINTER_CONFIG.baseDeviceUri}/serial=1234`;
+    const config = HP_4001_PRINTER_CONFIG;
+    const richStatus: PrinterRichStatus = {
+      state: 'idle',
+      stateReasons: ['none'],
+      markerInfos: [],
+    };
+    const ipptoolError: ExecError = {
+      stdout: '',
+      stderr:
+        'ipptool: Unable to connect to localhost:60000: Connection refused',
+      code: 1,
+      signal: null,
+      cmd: 'ipptool',
+    };
+
+    // printer connects, nothing serving IPP yet
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(err(ipptoolError));
+    expect(await printer.status()).toEqual({ connected: true, config });
+    expect(logger.log).toHaveBeenCalledTimes(2); // configured + unavailable
+    expect(logger.log).toHaveBeenLastCalledWith(
+      LogEventId.PrinterStatusChanged,
+      'system',
+      {
+        message:
+          'Rich printer status is unavailable via IPP; ipptool failed: ipptool: Unable to connect to localhost:60000: Connection refused',
+        disposition: 'failure',
+        ippUri: 'ipp://localhost:60000/ipp/print',
+        exitCode: 1,
+      }
+    );
+
+    // still unavailable: no additional log
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockGetPrinterRichStatus.expectCallWith().returns(err(ipptoolError));
+    expect(await printer.status()).toEqual({ connected: true, config });
+    expect(logger.log).toHaveBeenCalledTimes(2);
+
+    // becomes available
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockGetPrinterRichStatus.expectCallWith().returns(ok(richStatus));
+    expect(await printer.status()).toEqual({
+      connected: true,
+      config,
+      richStatus,
+    });
+    expect(logger.log).toHaveBeenCalledTimes(3);
+    expect(logger.log).toHaveBeenLastCalledWith(
+      LogEventId.PrinterStatusChanged,
+      'system',
+      {
+        message: 'Rich printer status is available via IPP.',
+        disposition: 'success',
+        ippUri: 'ipp://localhost:60000/ipp/print',
+      }
+    );
+
+    // still available: no additional log
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockGetPrinterRichStatus.expectCallWith().returns(ok(richStatus));
+    await printer.status();
+    expect(logger.log).toHaveBeenCalledTimes(3);
+
+    // fails without stderr: falls back to the exit code
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockGetPrinterRichStatus
+      .expectCallWith()
+      .returns(err({ ...ipptoolError, stderr: '', code: 124 }));
+    await printer.status();
+    expect(logger.log).toHaveBeenCalledTimes(4);
+    expect(logger.log).toHaveBeenLastCalledWith(
+      LogEventId.PrinterStatusChanged,
+      'system',
+      expect.objectContaining({
+        message:
+          'Rich printer status is unavailable via IPP; ipptool failed: exit code 124',
+        exitCode: 124,
+      })
+    );
+
+    // disconnect resets the state, so a reconnect logs again
+    mockGetConnectedDeviceUris.expectCallWith().returns([]);
+    isDeviceAttachedMock.mockReturnValue(false);
+    expect(await printer.status()).toEqual({ connected: false });
+    expect(logger.log).toHaveBeenCalledTimes(5); // removed
+    mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+    mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(err(ipptoolError));
+    await printer.status();
+    expect(logger.log).toHaveBeenCalledTimes(7); // configured + unavailable
   });
 });
 
@@ -232,7 +338,7 @@ describe('printer-specific print options', () => {
     const config = HP_4201_PRINTER_CONFIG;
     mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
     mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
-    mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(ok(IDLE_RICH_STATUS));
     await printer.status();
 
     mockPrintData
@@ -251,7 +357,7 @@ describe('printer-specific print options', () => {
     const config = HP_4001_PRINTER_CONFIG;
     mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
     mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
-    mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(ok(IDLE_RICH_STATUS));
     await printer.status();
 
     mockPrintData
@@ -267,7 +373,7 @@ describe('printer-specific print options', () => {
     const config = HP_M404_PRINTER_CONFIG;
     mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
     mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
-    mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(ok(IDLE_RICH_STATUS));
     await printer.status();
 
     mockPrintData
@@ -295,7 +401,7 @@ describe('printer-specific print options', () => {
     const config = HP_4201_PRINTER_CONFIG;
     mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
     mockConfigurePrinter.expectCallWith({ uri, config }).returns(undefined);
-    mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+    mockGetPrinterRichStatus.expectCallWith().returns(ok(IDLE_RICH_STATUS));
     await printer.status();
 
     mockPrintData

--- a/libs/printing/src/printer/printer.ts
+++ b/libs/printing/src/printer/printer.ts
@@ -1,11 +1,13 @@
 import { isDeviceAttached, type Device } from '@votingworks/backend';
-import { assertDefined } from '@votingworks/basics';
+import { Result, assertDefined } from '@votingworks/basics';
 import { LogEventId, BaseLogger } from '@votingworks/logging';
+import { PrinterRichStatus } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
 } from '@votingworks/utils';
 import { rootDebug } from '../utils/debug';
+import { ExecError } from '../utils/exec';
 import { getConnectedDeviceUris } from './device_uri';
 import { configurePrinter } from './configure';
 import { Printer } from './types';
@@ -19,6 +21,42 @@ const debug = rootDebug.extend('manager');
 interface PrinterDevice {
   uri?: string;
   lastPrint: number;
+  /**
+   * Whether the last IPP query for rich status succeeded. Undefined until the
+   * first query for the currently configured printer.
+   */
+  richStatusAvailable?: boolean;
+}
+
+/**
+ * Logs that rich status via IPP became available or unavailable for the
+ * configured printer. Status is polled continuously, so callers only log
+ * transitions. The error detail matters: "connection refused" means nothing is
+ * serving IPP for the printer (e.g. the IPP-over-USB daemon is missing or
+ * gave up on the device), while a timeout means it is present but stuck.
+ */
+function logRichStatusAvailability(
+  logger: BaseLogger,
+  richStatusResult: Result<PrinterRichStatus, ExecError>
+): void {
+  if (richStatusResult.isOk()) {
+    logger.log(LogEventId.PrinterStatusChanged, 'system', {
+      message: 'Rich printer status is available via IPP.',
+      disposition: 'success',
+      ippUri: CUPS_DEFAULT_IPP_URI,
+    });
+    return;
+  }
+
+  const { code, stderr } = richStatusResult.err();
+  logger.log(LogEventId.PrinterStatusChanged, 'system', {
+    message: `Rich printer status is unavailable via IPP; ipptool failed: ${
+      stderr.trim() || `exit code ${code}`
+    }`,
+    disposition: 'failure',
+    ippUri: CUPS_DEFAULT_IPP_URI,
+    exitCode: code,
+  });
 }
 
 export function detectPrinter(logger: BaseLogger): Printer {
@@ -64,6 +102,7 @@ export function detectPrinter(logger: BaseLogger): Printer {
             uri: printerDevice.uri,
           });
           printerDevice.uri = undefined;
+          printerDevice.richStatusAvailable = undefined;
         }
       }
 
@@ -92,12 +131,19 @@ export function detectPrinter(logger: BaseLogger): Printer {
       }
 
       const config = assertDefined(getPrinterConfig(printerDevice.uri));
+      if (!config.supportsIpp) {
+        return { connected: true, config };
+      }
+
+      const richStatusResult = await getPrinterRichStatus(CUPS_DEFAULT_IPP_URI);
+      if (printerDevice.richStatusAvailable !== richStatusResult.isOk()) {
+        printerDevice.richStatusAvailable = richStatusResult.isOk();
+        logRichStatusAvailability(logger, richStatusResult);
+      }
       return {
         connected: true,
         config,
-        richStatus: config.supportsIpp
-          ? await getPrinterRichStatus(CUPS_DEFAULT_IPP_URI)
-          : undefined,
+        richStatus: richStatusResult.ok(),
       };
     },
 

--- a/libs/printing/src/printer/status.test.ts
+++ b/libs/printing/src/printer/status.test.ts
@@ -85,7 +85,9 @@ test('uses ipptool to query and parse printer atttributes', async () => {
       stderr: '',
     })
   );
-  expect(await getPrinterRichStatus(CUPS_DEFAULT_IPP_URI)).toEqual({
+  expect(
+    (await getPrinterRichStatus(CUPS_DEFAULT_IPP_URI)).unsafeUnwrap()
+  ).toEqual({
     state: 'idle',
     stateReasons: ['none'],
     markerInfos: [mockMarkerInfo],
@@ -130,7 +132,7 @@ test('parses multiple marker infos', async () => {
       stderr: '',
     })
   );
-  expect(await getPrinterRichStatus()).toEqual({
+  expect((await getPrinterRichStatus()).unsafeUnwrap()).toEqual({
     state: 'idle',
     stateReasons: ['none'],
     markerInfos: [
@@ -158,7 +160,7 @@ test('parses multiple printer-state-reasons', async () => {
       stderr: '',
     })
   );
-  expect(await getPrinterRichStatus()).toEqual({
+  expect((await getPrinterRichStatus()).unsafeUnwrap()).toEqual({
     state: 'stopped',
     stateReasons: [
       'media-empty-error',
@@ -179,24 +181,29 @@ test('creates a special printer-state-reason if HP sleep mode detected', async (
       stderr: '',
     })
   );
-  expect(await getPrinterRichStatus()).toEqual({
+  expect((await getPrinterRichStatus()).unsafeUnwrap()).toEqual({
     state: 'idle',
     stateReasons: ['sleep-mode'],
     markerInfos: [mockMarkerInfo],
   });
 });
 
-test('returns undefined if ipptool fails', async () => {
+test('returns the ipptool error if ipptool fails', async () => {
   execMock.mockResolvedValueOnce(
     err({
       stdout: '',
-      stderr: 'ipptool failed',
+      stderr:
+        'ipptool: Unable to connect to localhost:60000: Connection refused',
       code: 1,
       signal: null,
       cmd: 'ipptool',
     })
   );
-  expect(await getPrinterRichStatus()).toBeUndefined();
+  const result = await getPrinterRichStatus();
+  expect(result.err()).toMatchObject({
+    code: 1,
+    stderr: 'ipptool: Unable to connect to localhost:60000: Connection refused',
+  });
 });
 
 test('throws error if ipptool output cannot be parsed', async () => {

--- a/libs/printing/src/printer/status.ts
+++ b/libs/printing/src/printer/status.ts
@@ -1,5 +1,5 @@
 import tmp from 'tmp-promise';
-import { Optional, assert } from '@votingworks/basics';
+import { Result, assert, err, ok } from '@votingworks/basics';
 import { writeFile } from 'node:fs/promises';
 import {
   IppMarkerInfo,
@@ -8,7 +8,7 @@ import {
   PrinterRichStatus,
   safeParseInt,
 } from '@votingworks/types';
-import { exec } from '../utils/exec';
+import { ExecError, exec } from '../utils/exec';
 import { rootDebug } from '../utils/debug';
 
 const debug = rootDebug.extend('status');
@@ -123,7 +123,7 @@ export const CUPS_DEFAULT_IPP_URI = 'ipp://localhost:60000/ipp/print';
  */
 async function getPrinterIppAttributes(
   printerIppUri: string
-): Promise<Optional<IppAttributes>> {
+): Promise<Result<IppAttributes, ExecError>> {
   // ipptool takes a file to specify the query to make, so we write a temporary
   // file with the query text
   const queryFile = await tmp.file();
@@ -134,11 +134,12 @@ async function getPrinterIppAttributes(
   const ipptoolResult = await exec(`ipptool`, ipptoolArgs);
   void queryFile.cleanup(); // void so we don't block status on the cleanup
 
-  // `ipptool` may fail if the printer was just connected and CUPS hasn't yet
-  // set up the IPP server for it. In this case, we just return undefined.
+  // `ipptool` fails if nothing is serving IPP for the printer yet (the
+  // IPP-over-USB daemon can take a few seconds after the printer connects) or
+  // if the printer stops responding. Callers decide how to surface that.
   if (ipptoolResult.isErr()) {
     debug('ipptool failed: %o', ipptoolResult.err().stderr);
-    return undefined;
+    return ipptoolResult;
   }
 
   const { stdout, stderr } = ipptoolResult.ok();
@@ -147,7 +148,7 @@ async function getPrinterIppAttributes(
 
   const attributes = parseIpptoolOutput(stdout);
   debug('parsed ipptool attributes: %O', attributes);
-  return attributes;
+  return ok(attributes);
 }
 
 function wrapWithArray<T>(value: T | T[]): T[] {
@@ -165,11 +166,12 @@ function zip(...arrays: Array<unknown[]>): Array<unknown[]> {
  */
 export async function getPrinterRichStatus(
   printerIppUri = CUPS_DEFAULT_IPP_URI
-): Promise<Optional<PrinterRichStatus>> {
-  const attributes = await getPrinterIppAttributes(printerIppUri);
-  if (!attributes) {
-    return undefined;
+): Promise<Result<PrinterRichStatus, ExecError>> {
+  const attributesResult = await getPrinterIppAttributes(printerIppUri);
+  if (attributesResult.isErr()) {
+    return err(attributesResult.err());
   }
+  const attributes = attributesResult.ok();
 
   const state = attributes['printer-state'] as IppPrinterState;
   let stateReasons = wrapWithArray(
@@ -206,5 +208,5 @@ export async function getPrinterRichStatus(
       }) as unknown as IppMarkerInfo
   );
 
-  return { state, stateReasons, markerInfos };
+  return ok({ state, stateReasons, markerInfos });
 }


### PR DESCRIPTION
## Overview

Part of https://github.com/votingworks/vxsuite/issues/9189 (see also #5503).

Rich printer status for HP printers comes from `ipptool` querying the IPP-over-USB daemon (`ipp-usb`) on `localhost:60000`. When that query failed we silently returned `undefined` and the UI showed a plain "Connected", so nothing in the exported logs indicated that rich status was missing — which is how the `ipp-usb` package being absent from VxMark/VxPrint images went unnoticed until a cert lab spotted it.

This PR only adds logging (the image fix is being handled separately):

- `getPrinterRichStatus` returns a `Result` carrying the `ipptool` error instead of swallowing it.
- `detectPrinter` logs `printer-status-changed` when rich status becomes **unavailable** (disposition `failure`, with `ipptool`'s stderr and exit code — "connection refused" means nothing is serving IPP, a timeout means the daemon/printer is stuck) and again when it becomes **available** (disposition `success`).
- Status is polled continuously, so only transitions are logged; the state resets when the printer disconnects so a reconnect logs again.
- `printer-status-changed` documentation widened to VxAdmin and VxMark (VxPrint has no `AppName`).

Example log line on a machine without `ipp-usb`:

```
Rich printer status is unavailable via IPP; ipptool failed: ipptool: Unable to connect to localhost:60000: Connection refused
```

## Demo Video or Screenshot

N/A (logging only).

## Testing Plan

- Unit tests cover the `Result` change and the transition logging (unavailable → unavailable → available → available → unavailable, and reset on disconnect).
- Manual (to do before undrafting): on a QA VxMark without `ipp-usb`, confirm a single `printer-status-changed` failure line at startup with "Connection refused"; after `apt-get install ipp-usb` + replugging the printer, confirm the success line.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
