### PR TITLE
Printer job tracking spec

### DIFF
--- a/specs/0008-print-job-tracking.md
+++ b/specs/0008-print-job-tracking.md
@@ -1,0 +1,221 @@
+# Print Job Status Tracking
+
+**Author:** @kshen0
+
+## Existing Discussion
+
+- https://github.com/votingworks/vxsuite/issues/9186
+- [VxSuite Print Tracking Limitations](https://docs.google.com/document/d/1_4kJRrqcMXAerx8-M6kkqe4Wj-9yJsjyL6JOIAMp0Ks/edit?tab=t.0#heading=h.l932348m6v4m)
+
+## Problem
+
+VxSuite currently has a very limited understanding of the status of print jobs.
+Currently, the application
+
+- submits a print job to CUPS
+- waits for the job to be accepted
+- reports success in logging and UI
+
+Downstream failures like jams, insufficient paper, or pulling the printer cable
+out are clear failures that are represented as success in the logs, user-facing
+messages, and ballots printed count. We want VxMark and VxPrint to instead
+accurately track and represent print job status.
+
+## Proposal
+
+### Prerequisites
+
+**`lp` migration**
+
+Migrate `Printer` abstraction to use `lp` instead of `lpr`. The former reports
+print job ID that can be used to query job status. This was done in
+https://github.com/votingworks/vxsuite/issues/9186.
+
+**Concatenate VxPrint's "Print All Ballot Styles" into a single job**
+
+This feature currently enqueues 1 job for each ballot style. We should
+concatenate the ballots into a single long job for easier job tracking.
+
+### Extend `libs/printing`
+
+**Extend `PrinterDevice`**
+
+`PrinterDevice` tracks the necessary state for a caller to maintain a connection
+to a supported printer. The state is isolated to `libs/printing` and not exposed
+to the caller. An instance of `Printer` is exposed to the caller by
+`detectPrinter` (production) or `MockFilePrinter`.
+
+```
+interface PrinterDevice {
+  uri?: string;
+  lastPrint: number;
+}
+
+export interface Printer {
+  status: () => Promise<PrinterStatus>;
+  print: PrintFunction;
+}
+```
+
+We'll extend `PrinterDevice` to track jobs:
+
+```
+type JobId = number;
+
+export type JobState =
+   // `ipptool` states
+  | 'pending'
+  | 'pending-held'
+  | 'processing'
+  | 'processing-stopped'
+  | 'canceled'
+  | 'aborted'
+  | 'completed'
+  // Additional states
+  | 'stalled' ;
+
+export interface JobStatus {
+   state: JobState;
+   sheetsCompleted: number;
+   lastProgressAt: Date;
+   reason?: string;
+}
+
+interface PrinterDevice {
+  uri?: string;
+  lastPrint: number;
+  // New state
+  jobs: Map<JobId, JobStatus>;
+}
+export interface Printer {
+  status: () => Promise<PrinterStatus>;
+  print: PrintFunction;
+  // New methods
+  getJobStatus: (jobId: JobId) => Result<JobStatus, Error>;
+  clearJobQueue: () => Promise<void>;
+}
+```
+
+**IPP Endpoints**
+
+TODO
+
+**`Printer.print()`**
+
+When a print job is initiated by `print()`, kick off a monitor responsible for
+
+- polling `ipptool` for the job's status
+- storing updated status in `PrinterDevice.jobs`
+- logging for print job success and failure
+
+Logging redundant with the above logging cases will be removed from VxSuite
+apps. Polling ceases when the job reaches a terminal state.
+
+The monitor is necessary because VxMark and VxPrint will read the status from 2
+different places (more on these later):
+
+1. The API endpoint polled by the frontend to read and display print job status
+2. The backend monitor responsible for deciding what to log and when to clear
+   the print queue
+
+Having one monitor per job to poll `ipptool` rather than update in
+`Printer.getJobStatus()` allows us to have multiple callers of that function
+without unnecessary or overlapping `ipptool` calls.
+
+The monitor will be implemented like `libs/backend`'s `startCpuMetricsLogging`:
+
+```
+export function startCpuMetricsLogging(
+  logger: BaseLogger,
+  { interval = 60_000, topProcessCount = 5 } = {}
+): { stop(): void }
+```
+
+In more detail, the monitor
+
+1. Gets updated job status from `ipptool`.
+2. Decides when a job is stalled and marks it as such.
+   - On each call to `ipptool` to update status, it checks `sheetsCompleted` and
+     `lastProgressAt` of every job.
+   - The job is marked as `stalled` if `sheetsCompleted` hasn't changed and
+     `lastProgressAt` was before some constant `JOB_STALLED_TIMEOUT` time ago.
+     `stalled` status takes priority over native CUPS job state and is not
+     overwritten (see 3, below).
+   - `stalled` status detection for the first sheet printed should be longer
+     than subsequent sheets. This is because enqueuing a long print job (long
+     reports, test decks, all ballot styles, etc) may take several seconds to
+     begin printing. A ~5 second delay for printing the first sheet isn't
+     unreasonable, but a 5 second delay between sheets 1 and 2 is more likely to
+     indicate a stall.
+3. Stores the following in `PrinterDevice.JobStatus`
+   - job state (with priority to `stalled`)
+   - number of sheets completed
+   - reason for job state from `ipptool` output `printer-state-reasons` and
+     possibly `job-state-reasons`
+   - timestamp
+
+**`Printer.getJobStatus(jobId): Result<JobStatus, Error>`**
+
+Looks up the specified job in `PrinterDevice.jobs` and returns its status.
+Returns an error if the job does not exist in the map.
+
+**`Printer.clearJobQueue()`**
+
+Runs `Cancel-Jobs` to clear CUPS queue. Does not change status in
+`PrinterDevice.jobs`.
+
+**Mocks**
+
+`createMockPrinterHandler` and `MockFilePrinter` need to support new status
+tracking behavior.
+
+### Update VxMark and VxPrint
+
+VxSuite apps currently show a "Printing ..." message for a hardcoded n seconds
+then assume the job is done. The answer to the question "is the print job done?"
+should be isolated to the backend.
+
+To that end we will make the following API changes in VxMark and VxPrint:
+
+1. `print()` endpoints start a monitor whose job is to
+   - poll `Printer.getJobStatus(jobId)`
+   - increment ballot print count on success
+   - call `clearJobQueue()` on failure or stall
+   - emit app-specific logs not covered by `libs/printing`
+   - terminate when a job reaches a terminal state and cleanup is done
+2. Add `getJobStatus(jobId): Result<JobStatus, Error>` endpoint to app backends.
+   This endpoint wraps `getJobStatus(jobId)`.
+
+The new end to end VxMark and VxPrint app flows:
+
+- Frontend initiates print request to backend
+- Backend initiates the print job and receives a job ID
+- Backend starts the monitor. The monitor polls the print job's status and
+  executes app-specific logic: maintaining ballot print count and clearing the
+  print queue on failure
+- Backend returns the job ID to the frontend
+- Frontend polls `getJobStatus(jobId)` and displays the status
+  - If a job is reported as failed or stalled, display an error message and the
+    reason why
+  - After a constant delay shared by the backend monitor automatically navigate
+    to the previous page
+
+### Logging
+
+In `libs/printing`:
+
+1. `Printer.print()` emits `PrinterPrintRequest`
+2. `Printer`'s monitor emits `PrinterPrintComplete` with failure/success
+   dispotiion on state transition to a terminal state
+
+In `VxMark` and `VxPrint`:
+
+1. TODO
+
+## Alternatives Considered
+
+TODO
+
+## Open Questions
+
+TODO

--- a/specs/0008-print-job-tracking.md
+++ b/specs/0008-print-job-tracking.md
@@ -13,29 +13,31 @@ VxSuite currently has a limited understanding of the status of print jobs.
 Currently, the application
 
 - submits a print job to CUPS
-- waits for the job to be accepted
-- reports success in logging and UI
+- reports success in logging and UI regardless of job status
 
-Downstream failures like jams, insufficient paper, or pulling the printer cable
-out are failures that are represented as success in the logs, user-facing
-messages, and ballots printed count. We want VxMark and VxPrint to instead
-accurately track and represent print job status.
+Jams, insufficient paper, or pulling the printer cable out are failures that are
+downstream of the app handing the job to CUPS. Such failures are incorrectly
+represented as success in the logs, user-facing messages, and "Ballots Printed"
+count. Rather than report a false success, we want VxMark and VxPrint to instead
+accurately track print job status and report when CUPS fails to send the job to
+the printer.
 
 ## Proposal
 
 ### Context: Existing printer state tracking
 
-`PrinterDevice` tracks the necessary state for a caller to maintain a connection
-to a printer. The state is isolated to `libs/printing` and not exposed to the
-caller. An instance of `Printer` is exposed to the caller by `detectPrinter`
-(production) or `MockFilePrinter`.
+An instance of `Printer` is provided to the caller by `detectPrinter`
+(production) or `MockFilePrinter`. `Printer` closes over `PrinterDevice`, which
+tracks the necessary state for a caller to maintain a connection to a printer.
 
 ```
+// Private to libs/printing
 interface PrinterDevice {
   uri?: string;
   lastPrint: number;
 }
 
+// Exposed to VxSuite
 export interface Printer {
   status: () => Promise<PrinterStatus>;
   print: PrintFunction;
@@ -121,23 +123,6 @@ export interface Printer {
 }
 ```
 
-Additionally, extend `Printer.status()` to `clearJobQueue()` when it detects the
-printer is disconnected (it already knows when this happens).
-
-**IPP Endpoints**
-
-Additional scheduler status added in this spec is accessible by querying CUPS at
-ipp://localhost:631/printers/VxPrinter.
-
-Query a single job with the `Get-Job-Attributes` operation and an explicit
-`job-id`.
-
-Per Claude: Do not use `Get-Jobs` with a `which-jobs` filter: IPP classifies
-jobs as `not-completed` or `completed`, where "completed" means finished —
-including aborted and canceled. A monitor polling `which-jobs=not-completed`
-would watch failed jobs disappear from its results rather than observe them
-fail.
-
 **`Printer.print()`**
 
 When a print job is initiated by `print()`, kick off a monitor responsible for
@@ -146,20 +131,33 @@ polling CUPS for job status. CUPS reports 2 bits of information we care about:
 - `job-state`, 1 of 7 states for a job encoded by `IppJobState`
 - `job-printer-state-message`: diagnostic text about the job's state
 
+Example real output from querying CUPS via `ipptool`:
+
+```
+RECEIVED: 152 bytes in response
+status-code = successful-ok (successful-ok)
+attributes-charset (charset) = utf-8
+attributes-natural-language (naturalLanguage) = en
+job-state (enum) = aborted
+job-printer-state-message (textWithoutLanguage) = Unable to send data to printer.
+```
+
 The monitor's flow is roughly:
 
-- polling `ipptool` for the job's state
-- classifying `job-state` into abstracted `JobOutcome`
-- storing updated `JobOutcome` in `PrinterDevice.jobs.outcome`
-- storing `job-printer-state-message` in `PrinterDevice.jobs.reason`
-- logging for print job success and failure
-- storing a `failure` `JobOutcome` if a job runs for longer than `JOB_TIMEOUT`
-  from monitor start. The latter is likely unnecessary because failures should
-  report as `aborted`, but protects us from hanging indefinitely.
+- poll `ipptool` for the job's state
+- classify `job-state` into abstracted `JobOutcome`
+- store updated `JobOutcome` in `PrinterDevice.jobs.outcome`
+- store `job-printer-state-message` in `PrinterDevice.jobs.reason`
+- log when print job succeeds or fails
+- store a `failure` `JobOutcome` if a job runs for longer than `JOB_TIMEOUT`
+  from monitor start. Likely unnecessary because failures should report as
+  `aborted`, but protects us from hanging indefinitely.
+- schedule deletion of the job from `PrinterDevice.jobs` upon job reaching
+  terminal state
 
 Logging that's redundant with the above logging cases will be removed from
 VxSuite apps. Polling ceases when the job reaches a terminal `JobOutcome` i.e.
-`outcome !== 'in-progress'.
+`outcome !== 'in-progress'`.
 
 The monitor is necessary because VxMark and VxPrint will read the status from 2
 different places (more on these later):
@@ -191,6 +189,62 @@ Returns an error if the job does not exist in the map.
 Runs `Cancel-Jobs` to clear CUPS queue. Does not change status in
 `PrinterDevice.jobs`.
 
+**`Printer.status()`**
+
+Update `Printer.status()` to `clearJobQueue()` when it detects the printer is
+disconnected (it already knows when this happens).
+
+**Tooling**
+
+We'll query CUPS via `ipptool`, sketched out below.
+
+1. Define query file
+
+```
+// 'get-job-attributes.ipp'
+{
+  OPERATION Get-Job-Attributes
+  GROUP operation-attributes-tag
+  ATTR charset attributes-charset utf-8
+  ATTR language attributes-natural-language en
+  ATTR uri printer-uri $uri
+  ATTR integer job-id $job-id
+  ATTR keyword requested-attributes job-state,job-printer-state-message
+}
+```
+
+2. Shell out to `ipptool`
+
+```
+  // :631 is CUPS's IPP endpoint
+  // Don't use CUPS_DEFAULT_IPP_URI because that addresses printer via ipp-usb
+  const CUPS_SCHEDULER_IPP_URI = `ipp://localhost:631/printers/${DEFAULT_MANAGED_PRINTER_NAME}`;
+
+  const GET_JOB_ATTRIBUTES_QUERY = join(
+    __dirname,
+    RELATIVE_PATH_TO_IPP_QUERIES,
+    'get-job-attributes.ipp'
+  );
+
+  const ipptoolArgs = [
+    // Specify timeout
+    '-T',
+    IPPTOOL_TIMEOUT_SECONDS,
+    // -t: "Specifies that CUPS test report output is desired instead of the
+    //     plain text output."
+    // -v: "Specifies that all request and response attributes should be output
+    //     in CUPS test mode (-t)."
+    // Combined, these format the output to the expectation of existing `parseIpptoolOutput`
+    '-tv',
+    //  -d name=value: "Defines the named variable"; in this case, job-id
+    '-d',
+    `job-id=${jobId}`,
+    CUPS_SCHEDULER_IPP_URI,
+    // File containing query args in step 1
+    GET_JOB_ATTRIBUTES_QUERY,
+  ];
+```
+
 **Mocks**
 
 `createMockPrinterHandler` and `MockFilePrinter` need to support new status
@@ -213,14 +267,12 @@ should be isolated to the backend.
 
 To that end we will make the following API changes in VxMark and VxPrint:
 
-1. `print()` endpoints start a monitor whose responsibility is to
+1. `print()` endpoints start an app-side (not lib-side) monitor whose
+   responsibility is to
    - poll `Printer.getJobStatus(jobId)`
    - increment ballot print count on transition to `sent-to-printer` status
    - call `clearJobQueue()` on failure
    - emit app-specific logs not covered by `libs/printing`
-   - determine when a job reaches a terminal `JobOutcome` and
-   - schedule cleanup of the job entry in the map after `JOB_STATUS_RETENTION`
-     duration
    - terminate itself
 2. Add `getJobStatus(jobId): Result<JobStatus, Error>` endpoint to app backends.
    This endpoint wraps `getJobStatus(jobId)`.
@@ -249,8 +301,14 @@ In `VxMark` and `VxPrint`:
 
 ## Alternatives Considered
 
-TODO
+**`lpstat` instead of `ipptool`**
+
+`lpstat` has cleaner ergonomics than `ipptool` for querying CUPS. But it never
+reports `job-state`. Completed and aborted jobs render identically apart from a
+free-text `Status:` line, so success and failure cannot be reliably
+distinguished. It's also more brittle to parse its human-readable output, and
+completed and incomplete jobs must be queried separately.
 
 ## Open Questions
 
-TODO
+None at the moment.

--- a/specs/0008-print-job-tracking.md
+++ b/specs/0008-print-job-tracking.md
@@ -9,7 +9,7 @@
 
 ## Problem
 
-VxSuite currently has a very limited understanding of the status of print jobs.
+VxSuite currently has a limited understanding of the status of print jobs.
 Currently, the application
 
 - submits a print job to CUPS
@@ -17,11 +17,37 @@ Currently, the application
 - reports success in logging and UI
 
 Downstream failures like jams, insufficient paper, or pulling the printer cable
-out are clear failures that are represented as success in the logs, user-facing
+out are failures that are represented as success in the logs, user-facing
 messages, and ballots printed count. We want VxMark and VxPrint to instead
 accurately track and represent print job status.
 
 ## Proposal
+
+### Context: Existing printer state tracking
+
+`PrinterDevice` tracks the necessary state for a caller to maintain a connection
+to a printer. The state is isolated to `libs/printing` and not exposed to the
+caller. An instance of `Printer` is exposed to the caller by `detectPrinter`
+(production) or `MockFilePrinter`.
+
+```
+interface PrinterDevice {
+  uri?: string;
+  lastPrint: number;
+}
+
+export interface Printer {
+  status: () => Promise<PrinterStatus>;
+  print: PrintFunction;
+}
+```
+
+### Proposal
+
+Per the product spec we'll report when a job has been successfully submitted to
+the CUPS scheduler and CUPS has successfully transferred the job to the printer.
+Downstream issues like jams mid-print will be displayed and handled on printer
+hardware.
 
 ### Prerequisites
 
@@ -40,44 +66,42 @@ concatenate the ballots into a single long job for easier job tracking.
 
 **Extend `PrinterDevice`**
 
-`PrinterDevice` tracks the necessary state for a caller to maintain a connection
-to a supported printer. The state is isolated to `libs/printing` and not exposed
-to the caller. An instance of `Printer` is exposed to the caller by
-`detectPrinter` (production) or `MockFilePrinter`.
-
-```
-interface PrinterDevice {
-  uri?: string;
-  lastPrint: number;
-}
-
-export interface Printer {
-  status: () => Promise<PrinterStatus>;
-  print: PrintFunction;
-}
-```
-
 We'll extend `PrinterDevice` to track jobs:
 
 ```
 type JobId = number;
 
-export type JobState =
-   // `ipptool` states
+// IPP `job-state`, as reported by `ipptool` when querying CUPS.
+type IppJobState =
   | 'pending'
   | 'pending-held'
   | 'processing'
-  | 'processing-stopped'
+  | 'processing-stopped' // Not observed during testing but included for completeness
   | 'canceled'
   | 'aborted'
-  | 'completed'
-  // Additional states
-  | 'stalled' ;
+  | 'completed';
+
+export type JobOutcome = 'in-progress' | 'sent-to-printer' | 'failed';
+
+function classify(state: IppJobState): JobOutcome {
+  switch (state) {
+    case 'completed':
+      return 'sent-to-printer';
+    case 'canceled':
+    case 'aborted':
+      return 'failed';
+    case 'pending':
+    case 'pending-held':
+    case 'processing':
+    case 'processing-stopped':
+      return 'in-progress';
+    default:
+      throwIllegalValue(state);
+  }
+}
 
 export interface JobStatus {
-   state: JobState;
-   sheetsCompleted: number;
-   lastProgressAt: Date;
+   outcome: JobOutcome;
    reason?: string;
 }
 
@@ -87,6 +111,7 @@ interface PrinterDevice {
   // New state
   jobs: Map<JobId, JobStatus>;
 }
+
 export interface Printer {
   status: () => Promise<PrinterStatus>;
   print: PrintFunction;
@@ -96,20 +121,45 @@ export interface Printer {
 }
 ```
 
+Additionally, extend `Printer.status()` to `clearJobQueue()` when it detects the
+printer is disconnected (it already knows when this happens).
+
 **IPP Endpoints**
 
-TODO
+Additional scheduler status added in this spec is accessible by querying CUPS at
+ipp://localhost:631/printers/VxPrinter.
+
+Query a single job with the `Get-Job-Attributes` operation and an explicit
+`job-id`.
+
+Per Claude: Do not use `Get-Jobs` with a `which-jobs` filter: IPP classifies
+jobs as `not-completed` or `completed`, where "completed" means finished —
+including aborted and canceled. A monitor polling `which-jobs=not-completed`
+would watch failed jobs disappear from its results rather than observe them
+fail.
 
 **`Printer.print()`**
 
 When a print job is initiated by `print()`, kick off a monitor responsible for
+polling CUPS for job status. CUPS reports 2 bits of information we care about:
 
-- polling `ipptool` for the job's status
-- storing updated status in `PrinterDevice.jobs`
+- `job-state`, 1 of 7 states for a job encoded by `IppJobState`
+- `job-printer-state-message`: diagnostic text about the job's state
+
+The monitor's flow is roughly:
+
+- polling `ipptool` for the job's state
+- classifying `job-state` into abstracted `JobOutcome`
+- storing updated `JobOutcome` in `PrinterDevice.jobs.outcome`
+- storing `job-printer-state-message` in `PrinterDevice.jobs.reason`
 - logging for print job success and failure
+- storing a `failure` `JobOutcome` if a job runs for longer than `JOB_TIMEOUT`
+  from monitor start. The latter is likely unnecessary because failures should
+  report as `aborted`, but protects us from hanging indefinitely.
 
-Logging redundant with the above logging cases will be removed from VxSuite
-apps. Polling ceases when the job reaches a terminal state.
+Logging that's redundant with the above logging cases will be removed from
+VxSuite apps. Polling ceases when the job reaches a terminal `JobOutcome` i.e.
+`outcome !== 'in-progress'.
 
 The monitor is necessary because VxMark and VxPrint will read the status from 2
 different places (more on these later):
@@ -131,29 +181,6 @@ export function startCpuMetricsLogging(
 ): { stop(): void }
 ```
 
-In more detail, the monitor
-
-1. Gets updated job status from `ipptool`.
-2. Decides when a job is stalled and marks it as such.
-   - On each call to `ipptool` to update status, it checks `sheetsCompleted` and
-     `lastProgressAt` of every job.
-   - The job is marked as `stalled` if `sheetsCompleted` hasn't changed and
-     `lastProgressAt` was before some constant `JOB_STALLED_TIMEOUT` time ago.
-     `stalled` status takes priority over native CUPS job state and is not
-     overwritten (see 3, below).
-   - `stalled` status detection for the first sheet printed should be longer
-     than subsequent sheets. This is because enqueuing a long print job (long
-     reports, test decks, all ballot styles, etc) may take several seconds to
-     begin printing. A ~5 second delay for printing the first sheet isn't
-     unreasonable, but a 5 second delay between sheets 1 and 2 is more likely to
-     indicate a stall.
-3. Stores the following in `PrinterDevice.JobStatus`
-   - job state (with priority to `stalled`)
-   - number of sheets completed
-   - reason for job state from `ipptool` output `printer-state-reasons` and
-     possibly `job-state-reasons`
-   - timestamp
-
 **`Printer.getJobStatus(jobId): Result<JobStatus, Error>`**
 
 Looks up the specified job in `PrinterDevice.jobs` and returns its status.
@@ -169,6 +196,15 @@ Runs `Cancel-Jobs` to clear CUPS queue. Does not change status in
 `createMockPrinterHandler` and `MockFilePrinter` need to support new status
 tracking behavior.
 
+**Update printer config**
+
+Set the error policy to abort failed jobs to avoid the "5 minute delayed print"
+problem:
+
+```
+lpadmin -p VxPrinter ... -o printer-error-policy=abort-job
+```
+
 ### Update VxMark and VxPrint
 
 VxSuite apps currently show a "Printing ..." message for a hardcoded n seconds
@@ -177,12 +213,15 @@ should be isolated to the backend.
 
 To that end we will make the following API changes in VxMark and VxPrint:
 
-1. `print()` endpoints start a monitor whose job is to
+1. `print()` endpoints start a monitor whose responsibility is to
    - poll `Printer.getJobStatus(jobId)`
-   - increment ballot print count on success
-   - call `clearJobQueue()` on failure or stall
+   - increment ballot print count on transition to `sent-to-printer` status
+   - call `clearJobQueue()` on failure
    - emit app-specific logs not covered by `libs/printing`
-   - terminate when a job reaches a terminal state and cleanup is done
+   - determine when a job reaches a terminal `JobOutcome` and
+   - schedule cleanup of the job entry in the map after `JOB_STATUS_RETENTION`
+     duration
+   - terminate itself
 2. Add `getJobStatus(jobId): Result<JobStatus, Error>` endpoint to app backends.
    This endpoint wraps `getJobStatus(jobId)`.
 
@@ -195,10 +234,6 @@ The new end to end VxMark and VxPrint app flows:
   print queue on failure
 - Backend returns the job ID to the frontend
 - Frontend polls `getJobStatus(jobId)` and displays the status
-  - If a job is reported as failed or stalled, display an error message and the
-    reason why
-  - After a constant delay shared by the backend monitor automatically navigate
-    to the previous page
 
 ### Logging
 
@@ -206,7 +241,7 @@ In `libs/printing`:
 
 1. `Printer.print()` emits `PrinterPrintRequest`
 2. `Printer`'s monitor emits `PrinterPrintComplete` with failure/success
-   dispotiion on state transition to a terminal state
+   disposition on state transition to a terminal `JobOutcome`
 
 In `VxMark` and `VxPrint`:
 


### PR DESCRIPTION
## Overview

Spec for improved print job status. Currently we fire-and-forget print jobs, which entails

* logging success as soon as the job is handed to the CUPS print scheduler
* showing success in the UI with a hardcoded timeout

If CUPS fails to send the job to the printer (for example, if printer connection is lost immediately after the job is sent from app to CUPS) we'll still represent success in those 2 ways.

This spec introduces a way to accurately track a more detailed level of success. It doesn't track the ink-on-paper job because that solution is significantly more complicated.

See:
https://github.com/votingworks/vxsuite/issues/9186
[Product/engineering exploration](https://docs.google.com/document/d/1_4kJRrqcMXAerx8-M6kkqe4Wj-9yJsjyL6JOIAMp0Ks/edit?tab=t.0#heading=h.l932348m6v4m)

## Demo Video or Screenshot

N/A; spec

## Testing Plan

N/A; spec
