### PR TITLE
VxDesign: Split translation requests into quota-compliant batches

### DIFF
--- a/libs/backend/src/language_and_audio/translator.test.ts
+++ b/libs/backend/src/language_and_audio/translator.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest';
 import { LanguageCode } from '@votingworks/types';
+import { assert } from '@votingworks/basics';
 import {
   mockCloudTranslatedText,
   makeMockGoogleCloudTranslationClient,
@@ -65,4 +66,71 @@ test('GoogleCloudTranslator strips image elements', async () => {
     })
   );
   translationClient.translateText.mockClear();
+});
+
+test('splits batches based on character limit', async () => {
+  const translationClient = makeMockGoogleCloudTranslationClient({ fn: vi.fn });
+  const translator = new GoogleCloudTranslator({ translationClient });
+
+  const text = 'Do you like apples? '.repeat(50);
+  expect(text).toHaveLength(1_000);
+  const textArray = Array.from<string>({ length: 65 }).fill(text);
+
+  const translatedTextArray = await translator.translateText(
+    textArray,
+    LanguageCode.SPANISH
+  );
+  expect(translatedTextArray).toEqual(
+    textArray.map((t) => mockCloudTranslatedText(t, LanguageCode.SPANISH))
+  );
+
+  expect(translationClient.translateText).toHaveBeenCalledTimes(3);
+  for (const [callIndex, batchSize] of [30, 30, 5].entries()) {
+    const call = translationClient.translateText.mock.calls[callIndex];
+    assert(!!call);
+
+    expect(call[0].contents).toHaveLength(batchSize);
+  }
+});
+
+test('splits batches based on item count limit', async () => {
+  const translationClient = makeMockGoogleCloudTranslationClient({ fn: vi.fn });
+  const translator = new GoogleCloudTranslator({ translationClient });
+
+  const textArray = Array.from<string>({ length: 1025 }).fill(
+    'Do you like apples?'
+  );
+
+  const translatedTextArray = await translator.translateText(
+    textArray,
+    LanguageCode.SPANISH
+  );
+  expect(translatedTextArray).toEqual(
+    textArray.map((t) => mockCloudTranslatedText(t, LanguageCode.SPANISH))
+  );
+
+  expect(translationClient.translateText).toHaveBeenCalledTimes(2);
+  for (const [callIndex, batchSize] of [1024, 1].entries()) {
+    const call = translationClient.translateText.mock.calls[callIndex];
+    assert(!!call);
+    expect(call[0].contents).toHaveLength(batchSize);
+  }
+});
+
+test('makes no requests for an empty text array', async () => {
+  const translationClient = makeMockGoogleCloudTranslationClient({ fn: vi.fn });
+  const translator = new GoogleCloudTranslator({ translationClient });
+
+  expect(await translator.translateText([], LanguageCode.SPANISH)).toEqual([]);
+  expect(translationClient.translateText).not.toHaveBeenCalled();
+});
+
+test('throws if translations are missing', async () => {
+  const translationClient = makeMockGoogleCloudTranslationClient({ fn: vi.fn });
+  translationClient.translateText.mockResolvedValue([{}, undefined, undefined]);
+  const translator = new GoogleCloudTranslator({ translationClient });
+
+  await expect(
+    translator.translateText(['Do you like apples?'], LanguageCode.SPANISH)
+  ).rejects.toThrow('Expected 1 translation(s), got 0');
 });

--- a/libs/backend/src/language_and_audio/translator.ts
+++ b/libs/backend/src/language_and_audio/translator.ts
@@ -164,25 +164,25 @@ const MAX_BATCH_ITEMS = 1024;
 function* translationBatches(stringsToTranslate: string[]): Iterable<string[]> {
   let batch: string[] = [];
   let nBytes = 0;
-  let nCodePoints = 0;
+  let nCodeUnits = 0;
 
   for (const item of stringsToTranslate) {
     const itemCodeUnits = item.length;
     const itemBytes = Buffer.byteLength(item, 'utf8');
 
     if (
-      nCodePoints + itemCodeUnits > MAX_BATCH_CODE_UNITS ||
+      nCodeUnits + itemCodeUnits > MAX_BATCH_CODE_UNITS ||
       nBytes + itemBytes > MAX_BATCH_BYTES ||
       batch.length === MAX_BATCH_ITEMS
     ) {
       yield batch;
       batch = [];
-      nCodePoints = 0;
+      nCodeUnits = 0;
       nBytes = 0;
     }
 
     batch.push(item);
-    nCodePoints += itemCodeUnits;
+    nCodeUnits += itemCodeUnits;
     nBytes += itemBytes;
   }
 

--- a/libs/backend/src/language_and_audio/translator.ts
+++ b/libs/backend/src/language_and_audio/translator.ts
@@ -1,8 +1,9 @@
+import { Buffer } from 'node:buffer';
 import {
   TranslationServiceClient as GoogleCloudTranslationClient,
   protos,
 } from '@google-cloud/translate';
-import { assertDefined, iter } from '@votingworks/basics';
+import { assert, assertDefined, iter } from '@votingworks/basics';
 
 import { NonEnglishLanguageCode, LanguageCode } from '@votingworks/types';
 import { GOOGLE_CLOUD_PROJECT_ID } from './google_cloud_config';
@@ -105,21 +106,85 @@ export class GoogleCloudTranslator implements Translator {
     // We strip them out in order and replace them after translating.
     const textArrayWithoutImages = textArray.map(stripImagesFromRichText);
 
-    const [response] = await this.translationClient.translateText({
-      contents: textArrayWithoutImages,
-      mimeType: 'text/plain',
-      parent: `projects/${GOOGLE_CLOUD_PROJECT_ID}`,
-      sourceLanguageCode: LanguageCode.ENGLISH,
-      targetLanguageCode,
-    });
+    const translations = [];
+    for (const contents of translationBatches(textArrayWithoutImages)) {
+      const [response] = await this.translationClient.translateText({
+        contents,
+        mimeType: 'text/plain',
+        parent: `projects/${GOOGLE_CLOUD_PROJECT_ID}`,
+        sourceLanguageCode: LanguageCode.ENGLISH,
+        targetLanguageCode,
+      });
+      translations.push(...(response.translations ?? []));
+    }
 
-    const translatedTextArrayWithImages = iter(response.translations)
+    assert(
+      translations.length === textArray.length,
+      `Expected ${textArray.length} translation(s), got ${translations.length}`
+    );
+
+    return iter(translations)
       .zip(textArray)
       .map(([{ translatedText }, originalText]) =>
         restoreImagesInTranslation(originalText, assertDefined(translatedText))
       )
       .toArray();
-
-    return translatedTextArrayWithImages;
   }
+}
+
+/**
+ * Actual limit is 30,000 unicode code points. `String.length` wouldn't be an
+ * accurate measurement for that, since it counts UTF-16 code units, so this is
+ * a rough estimate for code point count, with some wiggle room built in.
+ *
+ * https://docs.cloud.google.com/translate/quotas#content-limit
+ */
+const MAX_BATCH_CODE_UNITS = 30_000;
+
+/**
+ * Actual limit here is 100 KiB, but leaving some wiggle room for the request
+ * metadata. Shouldn't be possible to hit this limit in practice, given the
+ * code unit limit, but it's here for completeness.
+ *
+ * https://docs.cloud.google.com/translate/quotas#content-limit
+ */
+const MAX_BATCH_BYTES = 96 * 1024;
+
+/**
+ * Limit on the number of items in the `contents` array in translate requests.
+ *
+ * https://docs.cloud.google.com/php/docs/reference/cloud-translate/latest/V3.TranslateTextRequest
+ */
+const MAX_BATCH_ITEMS = 1024;
+
+/**
+ * Splits the given translation request items into batches within the limits of
+ * the Google Cloud Translate API.
+ */
+function* translationBatches(stringsToTranslate: string[]): Iterable<string[]> {
+  let batch: string[] = [];
+  let nBytes = 0;
+  let nCodePoints = 0;
+
+  for (const item of stringsToTranslate) {
+    const itemCodeUnits = item.length;
+    const itemBytes = Buffer.byteLength(item, 'utf8');
+
+    if (
+      nCodePoints + itemCodeUnits > MAX_BATCH_CODE_UNITS ||
+      nBytes + itemBytes > MAX_BATCH_BYTES ||
+      batch.length === MAX_BATCH_ITEMS
+    ) {
+      yield batch;
+      batch = [];
+      nCodePoints = 0;
+      nBytes = 0;
+    }
+
+    batch.push(item);
+    nCodePoints += itemCodeUnits;
+    nBytes += itemBytes;
+  }
+
+  if (batch.length > 0) yield batch;
 }


### PR DESCRIPTION
## Overview

Issue: https://github.com/votingworks/vxsuite/issues/9217
Builds on: https://github.com/votingworks/vxsuite/pull/8966

For large elections with lots of ballot strings, our batched translation requests start to hit Google Cloud API limits. This splits up requests into smaller batches that stay under the limits, the main ones being a limit on the total number of code points being translated and a limit on the number of individual strings requested. There's an additional request byte limit that we don't expect to hit with the code point limit in place, but added it in anyway.

## Demo Video or Screenshot
N/A

## Testing Plan
- New unit tests for the split-batch paths
- Manual testing with large election as part of CA scale testing work

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
