### PR TITLE
Address Grout Luxon DateTime serialization bug due to CommonJS-ESM mix

### DIFF
--- a/libs/grout/src/serialization.test.ts
+++ b/libs/grout/src/serialization.test.ts
@@ -76,7 +76,7 @@ test('JSON serialization/deserialization', () => {
   // DateWithoutTimes
   expectToBePreservedExactly(new DateWithoutTime('2020-01-01'));
   expectToBePreservedExactly({ a: new DateWithoutTime('2020-01-01') });
-  // luxon DateTimes
+  // Luxon DateTimes
   expectToBePreservedExactly(
     DateTime.fromISO('2020-01-01T00:00:00.000Z', { setZone: true })
   );
@@ -138,4 +138,27 @@ test('deserialize errors with invalid JSON', () => {
   expect(() =>
     deserialize('{"__grout_type": "not a real type","__grout_value": 1}')
   ).toThrow('Unknown tag: not a real type');
+});
+
+/**
+ * Luxon ships both an ESM and a CommonJS build, and a DateTime created by one
+ * of them is not `instanceof` the other's class. Grout is CommonJS and
+ * uses the CommonJS build while some packages that import Grout and Luxon use
+ * the ESM build. Copying a DateTime onto a duplicate of its class simulates
+ * one arriving from the other build.
+ */
+test('Luxon DateTimes from another copy of Luxon', () => {
+  const duplicateClassPrototype = Object.create(
+    Object.prototype,
+    Object.getOwnPropertyDescriptors(DateTime.prototype)
+  );
+  const dateTime: DateTime = Object.create(
+    duplicateClassPrototype,
+    Object.getOwnPropertyDescriptors(DateTime.utc())
+  );
+  expect(dateTime instanceof DateTime).toEqual(false);
+
+  expect(deserialize(serialize(dateTime))).toStrictEqual(
+    DateTime.fromISO(dateTime.toISO(), { setZone: true })
+  );
 });

--- a/libs/grout/src/serialization.ts
+++ b/libs/grout/src/serialization.ts
@@ -97,7 +97,7 @@ const dateWithoutTimeTagger: Tagger<DateWithoutTime, string> = {
 
 const luxonDateTimeTagger: Tagger<DateTime, string> = {
   tag: 'DateTime',
-  shouldTag: (value): value is DateTime => value instanceof DateTime,
+  shouldTag: DateTime.isDateTime,
   serialize: (value) => {
     assert(value.zoneName === 'UTC', 'Only UTC DateTimes are serializable');
     return value.toISO();


### PR DESCRIPTION
## Overview

Ran into the following error when running the HWTA on main.

```
[backend:run] Error: Cannot serialize value to JSON: "2026-08-29T02:59:16.000Z"
[backend:run]     at unserializableError (/home/vx/code/vxsuite/libs/grout/build/serialization.js:132:12)
[backend:run]     at throwIfUnserializable (/home/vx/code/vxsuite/libs/grout/build/serialization.js:139:15)
[backend:run]     at Object.replacer (/home/vx/code/vxsuite/libs/grout/build/serialization.js:162:9)
[backend:run]     at JSON.stringify (<anonymous>)
[backend:run]     at serialize (/home/vx/code/vxsuite/libs/grout/build/serialization.js:165:17)
[backend:run]     at /home/vx/code/vxsuite/libs/grout/build/server.js:155:66
[backend:run]     at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

Did some digging with Claude and wow what an interesting issue. Details in the code comments. This is an example of our mix of CommonJS and ESM causing a problem.

## Testing Plan

- [x] Added a regression test that I confirmed fails when I undo the fix
- [x] Tested manually on my HWTA-imaged machine

## Checklist

- [ ] ~I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.~
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~
