### PR TITLE
docs: fix broken markdown links

### DIFF
--- a/apps/design/frontend/README.md
+++ b/apps/design/frontend/README.md
@@ -4,8 +4,8 @@ An application for designing ballots.
 
 ## Setup
 
-Follow the instructions in the [VxSuite README](../../README.md) to get set up,
-then follow the instructions below.
+Follow the instructions in the [VxSuite README](../../../README.md) to get set
+up, then follow the instructions below.
 
 ### Google Cloud Authentication
 
@@ -146,11 +146,9 @@ In `apps/design/frontend`, run the following:
 pnpm start
 ```
 
-
-The server will be available at http://localhost:3000, with the backend at
-http://localhost:3001. To use a different port, set the `FRONTEND_PORT`
+The server will be available at <http://localhost:3000>, with the backend at
+<http://localhost:3001>. To use a different port, set the `FRONTEND_PORT`
 environment variable and the backend port will use `$FRONTEND_PORT + 1`.
-
 
 ## Restoring database from snapshot
 

--- a/docs/best_practices/typescript.md
+++ b/docs/best_practices/typescript.md
@@ -180,7 +180,7 @@ function pickRandom<T>(array: readonly T[]): T {
 ```
 
 For more information on using iterables with `iter`, see the
-[iteration exercises](../../exercises/01-iteration).
+[iteration exercises](../exercises/01-iteration).
 
 ### Avoid exceptions when possible
 

--- a/libs/ballot-encoder/README.md
+++ b/libs/ballot-encoder/README.md
@@ -105,7 +105,7 @@ information as possible is encoded. Here are some of the guidelines:
 
 ### Shared Ballot Config
 
-See `BallotConfig` in [index.ts](./index.ts) for the data structure used to
+See `BallotConfig` in [index.ts](src/index.ts) for the data structure used to
 represent this data in memory and applies to both BMD ballots and HMPB ballots.
 Given `E` (an `Election`) and `C` (a `BallotConfig`) corresponding to `E`, `C`
 is encoded as follows:
@@ -136,7 +136,7 @@ is encoded as follows:
 ### Completed BMD Ballot Encoding
 
 A "completed ballot" is one that has been filled out by a voter. See
-`CompletedBallot` in [election.ts](../../types/src/election.ts) for the data
+`CompletedBallot` in [election.ts](../types/src/election.ts) for the data
 structures used to represent a completed ballot in memory. Given `ED` (an
 `ElectionDefinition`), `B` (a `CompletedBallot`) corresponding to `ED`, `B` is
 encoded as follows:
@@ -183,7 +183,7 @@ encoded as follows:
 ### HMPB Metadata Encoding
 
 HMPB metadata describes the information needed to properly scan a hand-marked
-paper ballot. See `HMPBBallotPageMetadata` in [index.ts](./index.ts). Given
+paper ballot. See `HMPBBallotPageMetadata` in [index.ts](./src/index.ts). Given
 metadata `H` and election definition `ED`, `H` is encoded as follows:
 
 - **Prelude:** This is the literal string `VP` encoded as UTF-8 bytes, followed

--- a/libs/ballot-interpreter/README.md
+++ b/libs/ballot-interpreter/README.md
@@ -122,16 +122,16 @@ Because no bubbles may appear in the timing mark area, bubble coordinates
 effectively begin at (1, 1).
 
 The implementation uses a "corners" algorithm
-([timing_marks/corners/](src/bubble-ballot-rust/timing_marks/corners/)) that
-starts by identifying the four corners of the ballot grid and then walks along
-each border to find all timing marks.
+([timing_marks/corner_finding.rs](./src/bubble-ballot-rust/timing_marks/corner_finding.rs))
+that starts by identifying the four corners of the ballot grid and then walks
+along each border to find all timing marks.
 
 #### Timing Mark Detection Algorithm
 
 The timing mark detection process consists of three main steps:
 
 1. **Shape Finding**
-   ([timing_marks/corners/shape_finding/mod.rs](src/bubble-ballot-rust/timing_marks/corners/shape_finding/mod.rs)):
+   ([shape_finding/mod.rs](./src/bubble-ballot-rust/timing_marks/shape_finding/mod.rs)):
    The algorithm scans the ballot image column by column within an inset region
    from each edge. For each column, it groups contiguous black pixels vertically
    and filters groups by height to match expected timing mark dimensions.
@@ -141,7 +141,7 @@ The timing mark detection process consists of three main steps:
    timing mark size and aspect ratio.
 
 2. **Corner Finding**
-   ([timing_marks/corners/corner_finding.rs](src/bubble-ballot-rust/timing_marks/corners/corner_finding.rs)):
+   ([corner_finding.rs](./src/bubble-ballot-rust/timing_marks/corner_finding.rs)):
    For each of the four corners (top-left, top-right, bottom-left,
    bottom-right), the algorithm identifies candidate corner groupings. Each
    grouping consists of three timing marks: the corner mark itself, plus one
@@ -151,7 +151,7 @@ The timing mark detection process consists of three main steps:
    no such grouping is found, an error is returned.
 
 3. **Border Finding**
-   ([timing_marks/corners/border_finding.rs](src/bubble-ballot-rust/timing_marks/corners/border_finding.rs)):
+   ([border_finding.rs](./src/bubble-ballot-rust/timing_marks/border_finding.rs)):
    After corners are identified, the algorithm finds timing marks along each
    border by "walking" from one corner to the other. Starting at a corner mark,
    it computes a unit vector pointing toward the opposite corner with length

--- a/libs/fixture-generators/README.md
+++ b/libs/fixture-generators/README.md
@@ -35,7 +35,7 @@ Optional flags:
 
 ### Saved Fixtures
 
-To regenerate the saved fixtures in [libs/fixtures](../libs/fixtures), run:
+To regenerate the saved fixtures in [libs/fixtures](../fixtures), run:
 
 ```bash
 pnpm generate-cvr-fixtures
@@ -86,8 +86,7 @@ are optional and have default values.
 
 A command-line tool for generating election packages and elections with grid
 layouts and translations. Follow the instructions to setup Google Cloud account
-authentication [here](/../backend/src/language_and_audio/README.md) before
-using.
+authentication [here](../backend/src/language_and_audio/README.md) before using.
 
 ```bash
 ./bin/generate-election-package -e path/to/base-election-definition.json -o path/to/output-directory

--- a/libs/logging/README.md
+++ b/libs/logging/README.md
@@ -28,8 +28,8 @@ failure. If not specified the disposition will be n/a.
 
 Each log has its own entry in the `LogEventId` enum and corresponding
 `LogDetails`. These types are specified in
-[`config/log_event_details.toml`](config/log_event_details.toml). Resulting
-TypeScript types and Rust enums are found in the generated files
+[`log_event_details.toml`](log_event_details.toml). Resulting TypeScript types
+and Rust enums are found in the generated files
 [log_event_enums.ts](src/log_event_enums.ts) and
 [log_event_enums.rs](types-rust/src/log_event_enums.rs) respectively.
 
@@ -44,8 +44,8 @@ disposition.
 You can optionally provide a `defaultMessage` for a log which will be the
 message included on the log line if one is not specified in the call to `log`.
 
-Adding a log event type is similar to adding a log event, but there are different
-fields to add.
+Adding a log event type is similar to adding a log event, but there are
+different fields to add.
 
 ## Generating TypeScript and Rust types
 

--- a/script/src/validate-monorepo/cli.ts
+++ b/script/src/validate-monorepo/cli.ts
@@ -4,6 +4,7 @@ import { IO } from '../types';
 import { validateMonorepo, ValidationIssue } from './validation';
 import * as cargo from './validation/cargo';
 import * as circleci from './validation/circleci';
+import * as markdownLinks from './validation/markdown_links';
 import * as pkgs from './validation/packages';
 import * as tsconfig from './validation/tsconfig';
 import * as turbo from './validation/turbo';
@@ -139,6 +140,14 @@ export async function main({ stderr }: IO): Promise<number> {
       case turbo.ValidationIssueKind.MissingCargoBinaryOutput:
         stderr.write(
           `${issue.packageDir}: Cargo binary "${issue.binaryName}" is not a turbo output. Add it to build:self outputs in ${issue.packageDir}/turbo.json, e.g. "outputs": ["build/**", "${issue.expectedOutput}"]\n`
+        );
+        break;
+
+      case markdownLinks.ValidationIssueKind.BrokenLink:
+        stderr.write(
+          `${relative(cwd, issue.markdownPath)}:${issue.line}: broken link to ${
+            issue.link
+          }\n`
         );
         break;
 

--- a/script/src/validate-monorepo/validation/index.ts
+++ b/script/src/validate-monorepo/validation/index.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { getWorkspacePackageInfo } from '@votingworks/monorepo-utils';
 import * as cargo from './cargo';
 import * as circleci from './circleci';
+import * as markdownLinks from './markdown_links';
 import * as pkgs from './packages';
 import * as tsconfig from './tsconfig';
 import * as turbo from './turbo';
@@ -12,7 +13,8 @@ export type ValidationIssue =
   | tsconfig.ValidationIssue
   | circleci.ValidationIssue
   | cargo.ValidationIssue
-  | turbo.ValidationIssue;
+  | turbo.ValidationIssue
+  | markdownLinks.ValidationIssue;
 
 export async function* validateMonorepo(): AsyncGenerator<ValidationIssue> {
   const root = join(__dirname, '../../../..');
@@ -48,4 +50,5 @@ export async function* validateMonorepo(): AsyncGenerator<ValidationIssue> {
   yield* circleci.checkConfig(workspacePackages);
   yield* cargo.checkConfig(root);
   yield* turbo.checkConfig(root, workspacePackages);
+  yield* markdownLinks.checkLinks(root);
 }

--- a/script/src/validate-monorepo/validation/markdown_links.ts
+++ b/script/src/validate-monorepo/validation/markdown_links.ts
@@ -1,0 +1,165 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/**
+ * Any kind of validation issue with links in markdown files.
+ */
+export type ValidationIssue = BrokenLink;
+
+/**
+ * All the kinds of validation issues for links in markdown files.
+ */
+export enum ValidationIssueKind {
+  BrokenLink = 'BrokenLink',
+}
+
+/**
+ * A relative link in a markdown file points at a path that does not exist.
+ */
+export interface BrokenLink {
+  kind: ValidationIssueKind.BrokenLink;
+  markdownPath: string;
+  line: number;
+  link: string;
+}
+
+/**
+ * Directories that never hold checked-in markdown: dependencies, build output,
+ * and git internals.
+ */
+const IGNORED_DIRECTORIES: ReadonlySet<string> = new Set([
+  '.git',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'target',
+]);
+
+/**
+ * Inline links, i.e. `](target)` or `](target "title")`. Matching only the
+ * destination means image links (`![alt](target)`) are covered too.
+ */
+const INLINE_LINK_PATTERN = /\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g;
+
+/**
+ * Reference-style link definitions, i.e. a line of the form `[id]: target`.
+ */
+const REFERENCE_DEFINITION_PATTERN = /^\[[^\]]+\]:\s*(\S+)/;
+
+/**
+ * A fenced code block delimiter, i.e. ``` or ~~~ with optional indentation and
+ * an info string.
+ */
+const CODE_FENCE_PATTERN = /^\s{0,3}(```|~~~)/;
+
+/**
+ * Finds markdown files, skipping dependency and build directories.
+ *
+ * Symlinks are skipped: a symlinked markdown file's relative links resolve
+ * against the real file's directory rather than the link's, so checking it
+ * where the symlink sits reports breakage that does not exist.
+ * `.github/copilot-instructions.md` -> `../CLAUDE.md` is the case in point. The
+ * real file is checked at its own path anyway.
+ */
+function* findMarkdownFiles(directory: string): Generator<string> {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+
+    const entryPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRECTORIES.has(entry.name)) {
+        yield* findMarkdownFiles(entryPath);
+      }
+    } else if (entry.name.endsWith('.md')) {
+      yield entryPath;
+    }
+  }
+}
+
+/**
+ * Extracts every link destination on a single line of markdown.
+ */
+function* findLinkTargets(line: string): Generator<string> {
+  const definition = REFERENCE_DEFINITION_PATTERN.exec(line);
+  if (definition) {
+    yield definition[1] as string;
+    return;
+  }
+
+  for (const match of line.matchAll(INLINE_LINK_PATTERN)) {
+    yield match[1] as string;
+  }
+}
+
+/**
+ * Resolves a link destination to a path on disk, or `undefined` if the
+ * destination is not a path this check can verify: a URL (`https:`, `mailto:`,
+ * …) or a fragment pointing within the same document.
+ */
+function resolveLinkTarget(
+  root: string,
+  markdownPath: string,
+  target: string
+): string | undefined {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target) || target.startsWith('#')) {
+    return undefined;
+  }
+
+  const path = target.replace(/#.*$/, '');
+  if (!path) {
+    return undefined;
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(path);
+  } catch {
+    // Not valid percent-encoding, so take the destination literally.
+    decoded = path;
+  }
+
+  // A leading slash is repo-root-relative, the way GitHub renders it.
+  return decoded.startsWith('/')
+    ? join(root, decoded)
+    : resolve(dirname(markdownPath), decoded);
+}
+
+/**
+ * Validates that relative links in markdown files point at paths that exist.
+ */
+export function* checkLinks(root: string): Generator<ValidationIssue> {
+  for (const markdownPath of findMarkdownFiles(root)) {
+    const lines = readFileSync(markdownPath, 'utf-8').split('\n');
+    let inCodeFence = false;
+
+    for (const [index, line] of lines.entries()) {
+      if (CODE_FENCE_PATTERN.test(line)) {
+        inCodeFence = !inCodeFence;
+        continue;
+      }
+
+      // Link-shaped text in an example is not a link.
+      if (inCodeFence) {
+        continue;
+      }
+
+      for (const target of findLinkTargets(line)) {
+        const resolved = resolveLinkTarget(root, markdownPath, target);
+
+        if (resolved && !existsSync(resolved)) {
+          yield {
+            kind: ValidationIssueKind.BrokenLink,
+            markdownPath,
+            line: index + 1,
+            link: target,
+          };
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes broken in-repo links within markdown files and adds a checker in `validate-markdown` to flag future broken links.

## Demo Video or Screenshot
```
$ ./script/validate-monorepo
libs/fixture-generators/README.md:78: broken link to ./generate-election/config.ts
```

## Testing Plan
Tested manually locally, runs in CI.
