### PR TITLE
Stop leaking timers past test teardown

### DIFF
--- a/apps/admin/frontend/src/setupTests.ts
+++ b/apps/admin/frontend/src/setupTests.ts
@@ -37,3 +37,7 @@ afterAll(clearTemporaryRootDir);
 
 // Not implemented in jsdom:
 HTMLElement.prototype.scrollIntoView = vi.fn();
+
+afterAll(() => {
+  vi.useRealTimers();
+});

--- a/apps/central-scan/frontend/src/screens/settings_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/settings_screen.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import { MIN_TIME_TO_UNCONFIGURE_MACHINE_MS } from '@votingworks/ui';
 import { screen, within } from '../../test/react_testing_library.js';
 import { renderInAppContext } from '../../test/render_in_app_context.js';
 import { SettingsScreenProps, SettingsScreen } from './settings_screen.js';
@@ -21,6 +22,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   apiMock.assertComplete();
 });
 
@@ -64,6 +66,15 @@ test('clicking "Unconfigure Machine" calls backend', async () => {
 
   // we are redirected to the dashboard
   expect(history.location.pathname).toEqual('/');
+
+  // Without this, UnconfigureMachineButton's delayed close lands after this
+  // file's jsdom environment is torn down.
+  await vi.waitFor(
+    () => {
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    },
+    { timeout: MIN_TIME_TO_UNCONFIGURE_MACHINE_MS * 2 }
+  );
 });
 
 test('clicking "Update Date and Time" shows modal to set clock', async () => {
@@ -97,8 +108,6 @@ test('clicking "Update Date and Time" shows modal to set clock', async () => {
   await vi.waitFor(() => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
-
-  vi.useRealTimers();
 });
 
 test('shows a polling place picker when the election has polling places', async () => {

--- a/apps/mark-scan/frontend/src/setupTests.tsx
+++ b/apps/mark-scan/frontend/src/setupTests.tsx
@@ -1,6 +1,6 @@
 // https://til.hashrocket.com/posts/hzqwty5ykx-create-react-app-has-a-default-test-setup-file
 
-import { afterEach, beforeEach, expect, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, expect, vi } from 'vitest';
 import matchers from '@testing-library/jest-dom/matchers';
 import fetchMock from 'fetch-mock';
 import { TextDecoder, TextEncoder } from 'node:util';
@@ -33,3 +33,7 @@ globalThis.TextEncoder = TextEncoder;
 if (typeof globalThis.PointerEvent === 'undefined') {
   globalThis.PointerEvent = MouseEvent as typeof PointerEvent;
 }
+
+afterAll(() => {
+  vi.useRealTimers();
+});

--- a/apps/mark/frontend/src/setupTests.tsx
+++ b/apps/mark/frontend/src/setupTests.tsx
@@ -39,3 +39,7 @@ if (typeof globalThis.PointerEvent === 'undefined') {
 
 beforeAll(setupTemporaryRootDir);
 afterAll(clearTemporaryRootDir);
+
+afterAll(() => {
+  vi.useRealTimers();
+});

--- a/apps/pollbook/frontend/src/setupTests.ts
+++ b/apps/pollbook/frontend/src/setupTests.ts
@@ -1,4 +1,8 @@
 import matchers from '@testing-library/jest-dom/matchers';
-import { expect } from 'vitest';
+import { afterAll, expect, vi } from 'vitest';
 
 expect.extend(matchers);
+
+afterAll(() => {
+  vi.useRealTimers();
+});

--- a/apps/scan/frontend/src/setupTests.ts
+++ b/apps/scan/frontend/src/setupTests.ts
@@ -2,7 +2,7 @@ import {
   clearTemporaryRootDir,
   setupTemporaryRootDir,
 } from '@votingworks/fixtures';
-import { afterAll, beforeAll, expect } from 'vitest';
+import { afterAll, beforeAll, expect, vi } from 'vitest';
 import matchers from '@testing-library/jest-dom/matchers';
 import { TextDecoder, TextEncoder } from 'node:util';
 import { configure } from '../test/react_testing_library.js';
@@ -16,3 +16,7 @@ globalThis.TextEncoder = TextEncoder;
 
 beforeAll(setupTemporaryRootDir);
 afterAll(clearTemporaryRootDir);
+
+afterAll(() => {
+  vi.useRealTimers();
+});

--- a/libs/ui/src/setupTests.ts
+++ b/libs/ui/src/setupTests.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { afterAll, beforeAll, beforeEach, expect } from 'vitest';
+import { afterAll, beforeAll, beforeEach, expect, vi } from 'vitest';
 import matchers from '@testing-library/jest-dom/matchers';
 import { cleanup, configure } from '@testing-library/react';
 import {
@@ -56,3 +56,7 @@ configure({ asyncUtilTimeout: 5_000 });
 
 beforeAll(setupTemporaryRootDir);
 afterAll(clearTemporaryRootDir);
+
+afterAll(() => {
+  vi.useRealTimers();
+});


### PR DESCRIPTION
## Overview

`test-apps-central-scan-frontend` intermittently goes red on an unhandled `ReferenceError: window is not defined` with every test passing: a timer outlives its test file, and its React state update reaches `getCurrentEventPriority`, which reads `window.event`, after jsdom is torn down.

Two variants, one commit each:

- **central-scan** — a real timer. `settings_screen.test.tsx` clicks "Delete All Election Data" but never waits for the modal close that `MIN_TIME_TO_UNCONFIGURE_MACHINE_MS` delays by 1s, while the whole file takes ~950ms. Fixed by awaiting it, plus moving `vi.useRealTimers()` into `afterEach` so a mid-test failure stops leaking fake timers into the rest of the file.
- **ui, scan, admin, pollbook, mark, mark-scan** — an advancing fake clock, i.e. 48a239e3390e verbatim. None of these packages ever called `vi.useRealTimers()`. Fixed with the same global `afterAll` guard that landed for VxDesign.

## Testing Plan

- A temporary `afterAll` probe reporting `vi.isFakeTimers()` / `vi.getTimerCount()` per file found 88 files across 6 packages ending with an installed clock and queued callbacks — worst is scan's `election_manager_screen.test.tsx` at 266 pending. Re-probed after the fix: 0 leaks (31/31 scan files, 171/171 libs/ui files).
- Probing all 24 `UnconfigureMachineButton` click sites confirmed central-scan's `settings_screen.test.tsx` was the only one whose continuation never ran before its own teardown.
- Every affected package's full suite passes; CI green (63/63).

Two residuals, both benign and called out for reviewers: scan's `election_manager_screen.test.tsx` still queues its modal close past the test (the guard now contains it), and the real-timer sweep was scoped to `UnconfigureMachineButton` call sites rather than the whole repo — no `setupTests` guard can catch a leaked *real* timer.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.