### PR TITLE
Turn Turborepo on by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1608,23 +1608,6 @@ jobs:
           command: |
             ./script/validate-monorepo
 
-  # TEMPORARY: Turborepo is opt-in (via VX_USE_TURBO); every other CI job runs
-  # the pre-Turbo pnpm path. This job exercises the Turbo build path end-to-end
-  # so it can't silently rot while opt-in. Remove it once VX_USE_TURBO is the
-  # default and the rest of CI runs through Turbo.
-  build-with-turbo:
-    executor: nodejs
-    resource_class: xlarge
-    environment:
-      VX_USE_TURBO: '1'
-    steps:
-      - checkout-and-install:
-          is_node_package: true
-      - run:
-          name: Build all packages with Turbo
-          command: |
-            pnpm build
-
   notify-gallery:
     executor: nodejs
     resource_class: small
@@ -1824,9 +1807,6 @@ workflows:
           context:
             - screenshots-publishing
       - validate-monorepo:
-          context:
-            - screenshots-publishing
-      - build-with-turbo:
           context:
             - screenshots-publishing
       - test-rust-crates:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,22 +66,22 @@ pnpm install
 
 ### Building
 
-> **Turborepo is opt-in.** By default, `pnpm build`/`lint`/`test:run`/`clean`
-> and `pnpm start` run the pre-Turbo pnpm behavior (recursive `--filter` builds,
-> `run-dev` dev servers) — exactly as on `main`. Set the environment variable
-> **`VX_USE_TURBO=1`** to route the same commands through
-> [Turborepo](https://turborepo.com) instead (dependency-ordered, cached builds;
-> `turbo watch` dev servers). See the `## Turborepo` section for how the switch
+> **Turborepo is the default.** `pnpm build`/`lint`/`test:run`/`clean` and
+> `pnpm start` route through [Turborepo](https://turborepo.com)
+> (dependency-ordered, cached builds; `turbo watch` dev servers). Set the
+> environment variable **`VX_USE_TURBO=0`** (or `false`/`no`/`off`) to opt out
+> and get the pre-Turbo pnpm behavior instead (recursive `--filter` builds,
+> `run-dev` dev servers). See the `## Turborepo` section for how the switch
 > works. The examples below work identically in both modes unless noted.
 
 ```sh
-# Build everything (from repo root — always uses Turbo; see below)
+# Build everything (from repo root)
 pnpm build
 
 # Build a specific package and its dependencies
 pnpm --filter @votingworks/<package-name> build
-# ...opt into Turbo for the same build:
-VX_USE_TURBO=1 pnpm --filter @votingworks/<package-name> build
+# ...opt out of Turbo for the same build:
+VX_USE_TURBO=0 pnpm --filter @votingworks/<package-name> build
 
 # Build the package only, without (re)building its dependencies
 pnpm --filter @votingworks/<package-name> build:self
@@ -89,11 +89,11 @@ pnpm --filter @votingworks/<package-name> build:self
 
 A package's public `build`/`lint`/`test:run`/`test:ci`/`clean` scripts delegate
 to the `script/vx-task` orchestrator (via
-`pnpm -w vx-task <task> $npm_package_name`), which picks pnpm or Turbo based on
+`pnpm -w vx-task <task> $npm_package_name`), which picks Turbo or pnpm based on
 `VX_USE_TURBO`. The actual per-package work always lives in the `:self` scripts
 (e.g. `build:self`). The repo-root
-`pnpm build`/`test`/`lint`/`type-check`/`clean` scripts did not exist on `main`,
-so they are Turbo-only regardless of `VX_USE_TURBO`.
+`pnpm build`/`test`/`lint`/`type-check`/`clean` scripts have no pre-Turbo
+equivalent, so they are Turbo-only regardless of `VX_USE_TURBO`.
 
 ### Running Tests
 
@@ -173,15 +173,14 @@ pnpm --filter @votingworks/<app-frontend> start
 pnpm start
 ```
 
-Each app frontend's `start` script delegates to `script/vx-dev`. By default (no
-`VX_USE_TURBO`) it runs the pre-Turbo `run-dev`, which uses `concurrently` to
-run Vite, a `tsc --watch` build, and a nodemon-reloaded backend. With
-`VX_USE_TURBO=1` it runs `turbo watch` over the frontend's Vite dev server
-(`dev:server`) and its backend service (`dev`); because `turbo watch` re-runs a
-task when the package **or any of its dependencies** change, editing a shared
-library rebuilds it and restarts the backend automatically, including transitive
-dependency changes. In both modes Vite keeps running across library changes and
-handles its own HMR.
+Each app frontend's `start` script delegates to `script/vx-dev`. By default it
+runs `turbo watch` over the frontend's Vite dev server (`dev:server`) and its
+backend service (`dev`); with `VX_USE_TURBO=0` it runs the pre-Turbo `run-dev`,
+which uses `concurrently` to run Vite, a `tsc --watch` build, and a
+nodemon-reloaded backend. Because `turbo watch` re-runs a task when the package
+**or any of its dependencies** change, editing a shared library rebuilds it and
+restarts the backend automatically, including transitive dependency changes. In
+both modes Vite keeps running across library changes and handles its own HMR.
 
 **Stopping dev servers.** Pressing **Ctrl-C** in the terminal running
 `pnpm start` stops everything cleanly in both modes. But `kill`ing the
@@ -195,26 +194,25 @@ the `run-dev` and `turbo watch` modes).
 ## Turborepo
 
 Task orchestration and caching are handled by [Turborepo](https://turborepo.com)
-(`turbo.json` at the repo root), **when opted in via `VX_USE_TURBO`**.
+(`turbo.json` at the repo root).
 
-**Opt-in switch.** Turbo is off by default so this branch can land on `main`
-without forcing the whole team onto it at once. Each package's public
+**Opt-out switch.** Turbo is on by default. Each package's public
 `build`/`lint`/`test:run`/`test:ci`/`clean` script delegates to
 `script/vx-task`, and each frontend's `start` delegates to `script/vx-dev`.
-These orchestrators read `VX_USE_TURBO`:
+These orchestrators read `VX_USE_TURBO` (parsed by `script/lib/turbo.sh`, and
+mirrored in TypeScript by `script/src/prod-build/utils/use_turbo.ts`):
 
-- **unset (default):** reproduce the pre-Turbo behavior from `main` — pnpm's
+- **unset (default), or any other value:** run the matching Turbo task /
+  `turbo watch`.
+- **`0`, `false`, `no` or `off`:** reproduce the pre-Turbo behavior — pnpm's
   recursive `--filter` for dependency-ordered builds, the package's own `:self`
   script for lint/test, and `run-dev` for dev servers.
-- **set (e.g. `VX_USE_TURBO=1`):** run the matching Turbo task / `turbo watch`.
 
 The real per-package work always lives in the `:self` scripts; only the
-orchestration around them differs between the two modes. CI runs the pre-Turbo
-path (no `VX_USE_TURBO` in the CircleCI env) except for one temporary
-`build-with-turbo` job that builds everything with `VX_USE_TURBO=1` so the Turbo
-path can't silently rot; remove that job once Turbo becomes the default.
+orchestration around them differs between the two modes. CI sets no
+`VX_USE_TURBO`, so it runs everything through Turbo.
 
-Tasks and their wiring (`turbo.json`, used when `VX_USE_TURBO` is set):
+Tasks and their wiring (`turbo.json`):
 
 | Task            | Depends on    | Cached outputs                                     |
 | --------------- | ------------- | -------------------------------------------------- |
@@ -229,8 +227,8 @@ Tasks and their wiring (`turbo.json`, used when `VX_USE_TURBO` is set):
 
 Run any task directly with `turbo run <task> [--filter=<pkg>]`. Root scripts
 (`pnpm build`, `pnpm lint`, `pnpm test`, `pnpm type-check`, `pnpm clean`) wrap
-the corresponding Turbo task across all packages (Turbo-only; they had no
-pre-Turbo equivalent on `main`).
+the corresponding Turbo task across all packages (Turbo-only; they have no
+pre-Turbo equivalent).
 
 **The `:self` split and `vx-task` delegation:** each package's public
 `build`/`clean`/`lint`/`test:run`/`test:ci` script is a thin delegation of the
@@ -238,12 +236,12 @@ form `pnpm -w vx-task <task> $npm_package_name`; the `:self` task does the
 actual work (tsc/eslint/vitest). In Turbo mode `vx-task` runs
 `turbo run <task>:self --filter=$npm_package_name --` (building
 `build:self`/`^build:self` first, so the task never runs against unbuilt deps);
-in the default mode it runs the pnpm equivalent. Extra args pass straight
-through, so `pnpm test:run <file>` and `pnpm test:run -t "pattern"` still work
-in both modes. `validate-monorepo` enforces that any package defining a `:self`
-task delegates its public task to `vx-task`. The dev-time watcher `pnpm test` is
-not a delegated task (it's persistent and interactive); it prefixes
-`pnpm -w vx-task build $npm_package_name` (which builds deps via pnpm or Turbo
+when opted out it runs the pnpm equivalent. Extra args pass straight through, so
+`pnpm test:run <file>` and `pnpm test:run -t "pattern"` still work in both
+modes. `validate-monorepo` enforces that any package defining a `:self` task
+delegates its public task to `vx-task`. The dev-time watcher `pnpm test` is not
+a delegated task (it's persistent and interactive); it prefixes
+`pnpm -w vx-task build $npm_package_name` (which builds deps via Turbo or pnpm
 per the switch) and then execs `vitest` directly, so deps are built once up
 front while the watcher keeps its native UI.
 

--- a/docs/turborepo.md
+++ b/docs/turborepo.md
@@ -5,21 +5,22 @@ Task orchestration and caching in this monorepo are handled by
 derives task order from the pnpm workspace dependency graph, runs independent
 tasks in parallel, and caches results so unchanged work is never repeated.
 
-> **Turbo is opt-in.** Set **`VX_USE_TURBO=1`** in your environment to route
-> `pnpm build`/`lint`/`test:run`/`clean` and `pnpm start` through Turbo. Without
-> it, those commands run the pre-Turbo pnpm path (recursive `--filter` builds,
-> `run-dev` dev servers) exactly as before. Export it in your shell profile to
-> make Turbo your default:
+> **Turbo is the default.** `pnpm build`/`lint`/`test:run`/`clean` and
+> `pnpm start` all run through Turbo with no configuration. To opt out for a
+> single command — or for a whole shell, if you hit a Turbo-specific problem —
+> set **`VX_USE_TURBO=0`** (`false`, `no` and `off` work too):
 >
 > ```sh
-> export VX_USE_TURBO=1
+> VX_USE_TURBO=0 pnpm build     # one command
+> export VX_USE_TURBO=0         # this shell
 > ```
 >
-> The per-package public scripts delegate to `script/vx-task` (and frontends'
-> `start` to `script/vx-dev`), which read this variable and pick pnpm or Turbo.
-> The repo-root `pnpm build`/`test`/`lint`/`type-check`/`clean` scripts are
-> always Turbo (they had no pre-Turbo equivalent). The commands below assume
-> `VX_USE_TURBO` is set.
+> That falls back to the pre-Turbo pnpm path (recursive `--filter` builds,
+> `run-dev` dev servers). The per-package public scripts delegate to
+> `script/vx-task` (and frontends' `start` to `script/vx-dev`), which read this
+> variable and pick Turbo or pnpm. The repo-root
+> `pnpm build`/`test`/`lint`/`type-check`/`clean` scripts are always Turbo (they
+> have no pre-Turbo equivalent). The commands below assume the default.
 
 This is the practical guide. The task wiring and caching rules are also
 summarized in [CLAUDE.md](../CLAUDE.md#turborepo).
@@ -58,8 +59,8 @@ rebuilds it and restarts the backend automatically.
 
 ### Stopping dev servers
 
-`pnpm start` runs dev servers via `run-dev` (default) or `turbo watch` (with
-`VX_USE_TURBO`). Pressing **Ctrl-C** in the `pnpm start` terminal is clean in
+`pnpm start` runs dev servers via `turbo watch` (default) or `run-dev` (with
+`VX_USE_TURBO=0`). Pressing **Ctrl-C** in the `pnpm start` terminal is clean in
 both modes. Other ways of stopping are not: `kill`ing the `pnpm start` process
 (it doesn't forward the signal), a `SIGKILL` or editor "stop" button, or a
 `pkill` that lands on a wrapper rather than the runner can leave the servers

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -406,8 +406,6 @@ export function generateAllConfigs(
     // hardcoded jobs
     'shellcheck',
     'validate-monorepo',
-    // TEMPORARY: remove once Turborepo is the default (see the job definition).
-    'build-with-turbo',
     RUST_CRATES_JOB_ID,
   ];
 
@@ -488,23 +486,6 @@ ${rustJobLines.map((line) => `  ${line}\n`).join('')}
           name: Validate
           command: |
             ./script/validate-monorepo
-
-  # TEMPORARY: Turborepo is opt-in (via VX_USE_TURBO); every other CI job runs
-  # the pre-Turbo pnpm path. This job exercises the Turbo build path end-to-end
-  # so it can't silently rot while opt-in. Remove it once VX_USE_TURBO is the
-  # default and the rest of CI runs through Turbo.
-  build-with-turbo:
-    executor: nodejs
-    resource_class: xlarge
-    environment:
-      VX_USE_TURBO: '1'
-    steps:
-      - checkout-and-install:
-          is_node_package: true
-      - run:
-          name: Build all packages with Turbo
-          command: |
-            pnpm build
 
 ${generateNotifyGalleryJob()
   .map((line) => `  ${line}`)

--- a/script/lib/turbo.sh
+++ b/script/lib/turbo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Shared opt-out switch for the Turborepo-backed orchestration.
+#
+# Turbo is the default. Set `VX_USE_TURBO` to a falsy value (`0`, `false`, `no`
+# or `off`, case-insensitively) to fall back to the pre-Turbo pnpm scripts.
+
+use_turbo() {
+  case "$(printf '%s' "${VX_USE_TURBO:-1}" | tr '[:upper:]' '[:lower:]')" in
+    0 | false | no | off) return 1 ;;
+    *) return 0 ;;
+  esac
+}

--- a/script/src/prod-build/index.ts
+++ b/script/src/prod-build/index.ts
@@ -14,6 +14,7 @@ import { execSync } from './utils/exec_sync';
 import { existsSync } from './utils/exists_sync';
 import { mkdirp } from './utils/mkdirp';
 import { rmrf } from './utils/rmrf';
+import { useTurbo } from './utils/use_turbo';
 
 export function main({ stdout }: IO): void {
   assertExpectedPnpmVersion();
@@ -32,10 +33,10 @@ export function main({ stdout }: IO): void {
   );
   const prodPackages = getProductionPackages(root);
 
-  if (process.env['VX_USE_TURBO']) {
-    // Opt-in: build the app packages via turbo, which orders and caches the
-    // whole dependency graph. `pnpm exec` resolves turbo from the workspace
-    // without relying on it being on PATH.
+  if (useTurbo()) {
+    // Build the app packages via turbo, which orders and caches the whole
+    // dependency graph. `pnpm exec` resolves turbo from the workspace without
+    // relying on it being on PATH.
     const buildFilters = appPackages.map((pkg) => `--filter=${pkg.name}`);
     stdout.write(
       `🔨 Building ${appPackages.map((pkg) => pkg.name).join(', ')}\n`
@@ -44,7 +45,7 @@ export function main({ stdout }: IO): void {
       cwd: WORKSPACE_ROOT,
     });
   } else {
-    // Default (pre-Turbo): build each app package in turn via `make build`,
+    // Opted out of Turbo: build each app package in turn via `make build`,
     // which delegates to the package's own dependency-ordered `pnpm build`.
     for (const { path } of appPackages) {
       stdout.write(`🔨 ${path}\n`);

--- a/script/src/prod-build/utils/use_turbo.ts
+++ b/script/src/prod-build/utils/use_turbo.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether to orchestrate builds with Turborepo. Turbo is the default; set
+ * `VX_USE_TURBO` to a falsy value (`0`, `false`, `no` or `off`) to opt out and
+ * use the pre-Turbo pnpm scripts. Mirrors `script/lib/turbo.sh`.
+ */
+export function useTurbo(): boolean {
+  const value = process.env['VX_USE_TURBO'];
+  if (value === undefined || value === '') {
+    return true;
+  }
+  return !['0', 'false', 'no', 'off'].includes(value.toLowerCase());
+}

--- a/script/src/validate-monorepo/validation/packages.ts
+++ b/script/src/validate-monorepo/validation/packages.ts
@@ -46,7 +46,8 @@ export type ValidationIssue =
 
 /**
  * Public tasks that delegate to the `vx-task` orchestrator, which picks between
- * Turborepo (opt-in via `VX_USE_TURBO`) and the pre-Turbo pnpm behavior. The
+ * Turborepo (the default) and the pre-Turbo pnpm behavior (`VX_USE_TURBO=0`).
+ * The
  * real per-package work lives in the `:self` counterpart. Any package that
  * defines the `:self` task must delegate its public task to `vx-task`, so the
  * orchestration choice stays centralized in `script/vx-task`.

--- a/script/vx-dev
+++ b/script/vx-dev
@@ -1,20 +1,23 @@
 #!/usr/bin/env bash
 
-# Dev-server launcher with a Turborepo opt-in.
+# Dev-server launcher, backed by Turborepo.
 #
 # Each app frontend's `start` script delegates here (via
 # `pnpm -w vx-dev <app>`) so the choice of dev orchestration lives in one place:
 #
-#   * VX_USE_TURBO set  -> `turbo watch` the frontend's Vite dev server and the
-#                          backend service, rebuilding/restarting on dependency
-#                          changes. This is opt-in.
-#   * VX_USE_TURBO unset -> the pre-Turbo `run-dev`, which uses `concurrently`
-#                           to run Vite, a `tsc --watch` build, and a
-#                           nodemon-reloaded backend.
+#   * default             -> `turbo watch` the frontend's Vite dev server and
+#                            the backend service, rebuilding/restarting on
+#                            dependency changes.
+#   * VX_USE_TURBO=0      -> opt out and use the pre-Turbo `run-dev`, which uses
+#     (or false/no/off)      `concurrently` to run Vite, a `tsc --watch` build,
+#                            and a nodemon-reloaded backend.
 #
 # Run from the workspace root (via `pnpm -w`), so relative paths resolve there.
 
 set -euo pipefail
+
+# shellcheck source=script/lib/turbo.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/turbo.sh"
 
 core_only=false
 app=""
@@ -34,14 +37,14 @@ if [[ -z "${app}" ]]; then
   exit 1
 fi
 
-if [[ -z "${VX_USE_TURBO:-}" ]]; then
+if ! use_turbo; then
   if [[ "${core_only}" == true ]]; then
     exec script/run-dev "${app}" --core-only
   fi
   exec script/run-dev "${app}"
 fi
 
-# Turbo mode. Derive the machine type from the frontend package's `vx.env`, the
+# Derive the machine type from the frontend package's `vx.env`, the
 # same source `run-dev` reads, so both modes behave identically.
 fe_pkg_json="apps/${app}/frontend/package.json"
 if [[ ! -f "${fe_pkg_json}" ]]; then

--- a/script/vx-task
+++ b/script/vx-task
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
 
-# Per-package task orchestrator with a Turborepo opt-in.
+# Per-package task orchestrator, backed by Turborepo.
 #
 # Each package's public `build`/`lint`/`test:run`/`test:ci`/`clean` scripts
 # delegate here (via `pnpm -w vx-task <task> $npm_package_name [args...]`) so the
 # choice of orchestration lives in one place:
 #
-#   * VX_USE_TURBO set  -> run the matching Turbo task (dependency-ordered and
-#                          cached). This is opt-in.
-#   * VX_USE_TURBO unset -> reproduce the pre-Turbo behavior from `main`: pnpm's
-#                           recursive `--filter` for dependency-ordered builds,
-#                           and the package's own `:self` script for lint/test
-#                           (dependencies are assumed already built, as they were
-#                           on `main`, where CI's separate Build step ran first).
+#   * default             -> run the matching Turbo task (dependency-ordered and
+#                            cached).
+#   * VX_USE_TURBO=0      -> opt out and use the pre-Turbo behavior: pnpm's
+#     (or false/no/off)      recursive `--filter` for dependency-ordered builds,
+#                            and the package's own `:self` script for lint/test
+#                            (dependencies are assumed already built, as CI's
+#                            separate Build step ran first).
 #
 # The real per-package work always lives in the `:self` scripts; only the
 # orchestration around them differs between the two modes.
 
 set -euo pipefail
+
+# shellcheck source=script/lib/turbo.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/turbo.sh"
 
 task="${1:?vx-task: task name required}"
 pkg="${2:?vx-task: package name required (pass \$npm_package_name)}"
@@ -30,7 +33,7 @@ if [[ -n "${CI:-}" ]]; then
   seq=(--sequential)
 fi
 
-if [[ -n "${VX_USE_TURBO:-}" ]]; then
+if use_turbo; then
   case "${task}" in
     build) exec turbo run build:self --filter="${pkg}" ;;
     clean) exec turbo run clean:self --filter="${pkg}..." ;;


### PR DESCRIPTION
## Overview

Turbo has been opt-in via `VX_USE_TURBO` since it landed. This flips the default: `build`/`lint`/`test:run`/`test:ci`/`clean` and `pnpm start` now go through Turbo unless `VX_USE_TURBO` is set to `0`, `false`, `no` or `off`. The switch is parsed in one place per language (`script/lib/turbo.sh`, `use_turbo.ts`), and the temporary `build-with-turbo` CI job is gone since all of CI now runs through Turbo. Docs updated.

## Testing Plan

- `pnpm --filter @votingworks/basics build` hits Turbo; `VX_USE_TURBO=0 …` runs the pre-Turbo pnpm path.
- `pnpm shellcheck`, `./script/validate-monorepo`, and `libs/monorepo-utils` tests pass.
- CI is the real test of the default: every job now builds/lints/tests via Turbo.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.