### PR TITLE
fix(types): ensure election districts are coherent

### DIFF
--- a/libs/test-utils/src/arbitraries.ts
+++ b/libs/test-utils/src/arbitraries.ts
@@ -337,9 +337,11 @@ function arbitraryStraightPartyContest({
 }
 
 export function arbitraryContests({
+  districtId,
   electionType,
   partyIds,
 }: {
+  districtId?: fc.Arbitrary<District['id']>;
   electionType?: ElectionType;
   partyIds?: fc.Arbitrary<Array<Party['id']>>;
 } = {}): fc.Arbitrary<readonly Contest[]> {
@@ -349,7 +351,7 @@ export function arbitraryContests({
     electionType === 'general' && ids.length === 0
       ? fc.constant([])
       : fc
-          .option(arbitraryStraightPartyContest({ partyIds }))
+          .option(arbitraryStraightPartyContest({ districtId, partyIds }))
           .map((contest) => (contest ? [contest] : []))
   );
   return fc
@@ -357,11 +359,12 @@ export function arbitraryContests({
       arbitraryStraightPartyContests,
       fc.array(
         arbitraryCandidateContest({
+          districtId,
           partyIds,
           allowWriteIns: fc.constant(true),
         })
       ),
-      fc.array(arbitraryYesNoContest())
+      fc.array(arbitraryYesNoContest({ districtId }))
     )
     .map(([straightPartyContests, candidateContests, otherContests]) => [
       ...straightPartyContests,
@@ -531,6 +534,9 @@ export function arbitraryElection(): fc.Arbitrary<Election> {
           seal: fc.string({ minLength: 1, maxLength: 200 }),
           parties: fc.constant(parties),
           contests: arbitraryContests({
+            // Contests must sit in districts the election actually has, or
+            // `getContests` finds nothing for any ballot style.
+            districtId: fc.constantFrom(...districts.map(({ id }) => id)),
             electionType: type,
             partyIds: fc.constant(parties.map(({ id }) => id)),
           }),

--- a/libs/types/src/__snapshots__/schema.test.ts.snap
+++ b/libs/types/src/__snapshots__/schema.test.ts.snap
@@ -166,6 +166,24 @@ exports[`parsing validates district references 1`] = `
   {
     "code": "custom",
     "path": [
+      "contests",
+      0,
+      "districtId"
+    ],
+    "message": "Contest 'CC' has district 'D', but no such district is defined. Districts defined: [DIS]."
+  },
+  {
+    "code": "custom",
+    "path": [
+      "contests",
+      1,
+      "districtId"
+    ],
+    "message": "Contest 'YNC' has district 'D', but no such district is defined. Districts defined: [DIS]."
+  },
+  {
+    "code": "custom",
+    "path": [
       "ballotStyles",
       0,
       "districts",

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -833,6 +833,21 @@ export const ElectionSchema = z
   })
   .check((ctx) => {
     const election = ctx.value;
+    for (const [contestIndex, contest] of election.contests.entries()) {
+      if (!election.districts.some((d) => d.id === contest.districtId)) {
+        ctx.issues.push({
+          code: 'custom',
+          path: ['contests', contestIndex, 'districtId'],
+          message: `Contest '${contest.id}' has district '${
+            contest.districtId
+          }', but no such district is defined. Districts defined: [${election.districts
+            .map((d) => d.id)
+            .join(', ')}].`,
+          input: election,
+        });
+      }
+    }
+
     for (const [
       ballotStyleIndex,
       { id, districts, precincts },

--- a/libs/types/src/schema.test.ts
+++ b/libs/types/src/schema.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { err } from '@votingworks/basics';
+import { assertDefined, err } from '@votingworks/basics';
 import { election as electionGeneral, electionData } from '../test/election';
 import * as t from '.';
 import { safeParse, safeParseJson, unsafeParse } from './generic';
@@ -120,6 +120,20 @@ test('parsing validates district references', () => {
       })
       .unsafeUnwrapErr()
   ).toMatchSnapshot();
+});
+
+test('parsing validates contest district references', () => {
+  const [contest, ...restContests] = electionGeneral.contests;
+  const result = t.safeParseVxfElection({
+    ...electionGeneral,
+    contests: [
+      { ...assertDefined(contest), districtId: 'not-a-real-district' },
+      ...restContests,
+    ],
+  });
+  expect(result.unsafeUnwrapErr().message).toContain(
+    `Contest '${assertDefined(contest).id}' has district 'not-a-real-district', but no such district is defined.`
+  );
 });
 
 test('parsing validates precinct references', () => {


### PR DESCRIPTION
## Overview

`ElectionSchema` accepted contests whose `districtId` matched no district in `election.districts`. Such an election parses fine but `getContests` then finds nothing for any ballot style. This PR adds a schema check rejecting it.

`arbitraryElection` was generating exactly those incoherent elections. This PR fixes it by ensuring contest districts come from the election's own districts.

## Testing Plan

New unit test; manually checked all in-repo `election.json` files.