### PR TITLE
fix(types): keep all contests on a party-less ballot style

### DIFF
--- a/libs/ballot-interpreter/src/cross_language_bmd.test.ts
+++ b/libs/ballot-interpreter/src/cross_language_bmd.test.ts
@@ -21,8 +21,9 @@ import {
   arbitraryBallotId,
   arbitraryElectionDefinition,
 } from '@votingworks/test-utils';
+import { electionCombinedBallotPrimaryFixtures } from '@votingworks/fixtures';
 import { Buffer } from 'node:buffer';
-import { throwIllegalValue } from '@votingworks/basics';
+import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { napi } from './bubble-ballot-ts/napi.js';
 import type {
   BridgeDecodeBmdResult,
@@ -377,4 +378,54 @@ test('multi-page BMD ballot: Rust encode matches TS decode', async () => {
     ),
     MULTI_PAGE_FC_PARAMS
   );
+});
+
+test("combined ballot primary: TS and Rust agree on a party-less ballot style's contests", async () => {
+  const { election, ballotHash } =
+    electionCombinedBallotPrimaryFixtures.readElectionDefinition();
+
+  const partyLessStyles = election.ballotStyles.filter(
+    (ballotStyle) => ballotStyle.partyId === undefined
+  );
+  expect(partyLessStyles.length).toBeGreaterThan(0);
+
+  for (const ballotStyle of partyLessStyles) {
+    const contests = getContests({ ballotStyle, election });
+
+    // Without party-specific contests on a party-less ballot style, this
+    // fixture no longer exercises the divergence.
+    expect(
+      contests.filter(
+        (contest) => contest.type === 'candidate' && contest.partyId
+      ).length
+    ).toBeGreaterThan(0);
+
+    const precinct = assertDefined(
+      election.precincts.find((p) => ballotStyle.precincts.includes(p.id))
+    );
+    const votes = generateVotesForContests(contests, false);
+
+    const page: SummaryBallotPage = {
+      ballotHash,
+      ballotStyleId: ballotStyle.id,
+      precinctId: precinct.id,
+      isTestMode: false,
+      ballotType: BallotType.Precinct,
+      pageNumber: 1,
+      totalPages: 1,
+      ballotAuditId: 'combined-primary-audit-id',
+      contests: [...contests],
+      votes,
+    };
+
+    const decoded = await napi.decodeBmdBallotData(
+      election,
+      Buffer.from(encodeSummaryBallotPage(election, page))
+    );
+
+    expect(decoded.contestIds).toEqual(contests.map((contest) => contest.id));
+    expect(normalizeRustVotes(decoded.votes, election, ballotStyle.id)).toEqual(
+      normalizeTsVotes(votes)
+    );
+  }
 });

--- a/libs/types-rs/src/election.rs
+++ b/libs/types-rs/src/election.rs
@@ -404,14 +404,15 @@ impl Contest {
             .districts
             .iter()
             .any(|district_id| district_id == self.district_id())
-            // and has matching party or no party
-            && match self {
-                Contest::YesNo(_)
-                | Contest::StraightParty(_)
-                | Contest::Candidate(CandidateContest { party_id: None, .. }) => true,
-                Contest::Candidate(CandidateContest { party_id, .. }) => {
-                    party_id == &ballot_style.party_id
+            && match (&ballot_style.party_id, self) {
+                // Party filtering only applies to candidate contests on a ballot
+                // style that has a party of its own, as in a closed primary. A
+                // combined ballot primary uses party-less ballot styles that
+                // carry every party's contests, so we don't filter in that case.
+                (Some(style_party), Contest::Candidate(CandidateContest { party_id, .. })) => {
+                    party_id.is_none() || party_id.as_ref() == Some(style_party)
                 }
+                _ => true,
             }
     }
 }
@@ -602,7 +603,82 @@ pub struct StraightPartyContest {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use std::{fs::File, io::BufReader, path::PathBuf};
+
     use super::*;
+
+    fn read_election(name: &str) -> Election {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../fixtures/data")
+            .join(name)
+            .join("election.json");
+        serde_json::from_reader(BufReader::new(File::open(path).expect("fixture exists")))
+            .expect("fixture parses")
+    }
+
+    #[test]
+    fn test_combined_primary_ballot_style_keeps_every_party_contest() {
+        let election = read_election("electionCombinedBallotPrimary");
+        let ballot_style = election
+            .ballot_styles
+            .first()
+            .expect("election has a ballot style");
+        assert!(
+            ballot_style.party_id.is_none(),
+            "this fixture's ballot styles are party-less; the test is meaningless otherwise"
+        );
+
+        let contests = election.contests_in(ballot_style);
+        let party_specific = contests
+            .iter()
+            .filter(|contest| {
+                matches!(
+                    contest,
+                    Contest::Candidate(CandidateContest {
+                        party_id: Some(_),
+                        ..
+                    })
+                )
+            })
+            .count();
+
+        assert!(
+            party_specific > 0,
+            "party-specific contests must survive on a party-less ballot style"
+        );
+        assert_eq!(
+            contests.len(),
+            election
+                .contests
+                .iter()
+                .filter(|c| ballot_style.districts.contains(c.district_id()))
+                .count(),
+            "a party-less ballot style filters by district only"
+        );
+    }
+
+    /// A closed primary does filter by party, and contests without a party stay
+    /// on every ballot style.
+    #[test]
+    fn test_closed_primary_ballot_style_filters_by_party() {
+        let election = read_election("electionTwoPartyPrimary");
+        let ballot_style = election
+            .ballot_styles
+            .iter()
+            .find(|bs| bs.party_id.is_some())
+            .expect("fixture has a party-specific ballot style");
+        let style_party = ballot_style.party_id.as_ref().expect("checked above");
+
+        for contest in election.contests_in(ballot_style) {
+            if let Contest::Candidate(CandidateContest { party_id, .. }) = &contest {
+                assert!(
+                    party_id.is_none() || party_id.as_ref() == Some(style_party),
+                    "contest {} from another party is on this ballot style",
+                    contest.id()
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_grid_location() {


### PR DESCRIPTION
## Overview
`Election::contests_in` dropped candidate contests belonging to a party when the ballot style had no party of its own. TypeScript's `getContests` skips party filtering entirely in that case, so the two implementations disagreed about which contests are on a ballot style. This caused summary ballot encodings to be mutually incompatible between the two for such elections.

Note that the Rust version has not yet been used in production, so this was never an issue for a real election.

## Testing Plan
Adds a cross-language test that exercises this code path to ensure the implementations match up.
