### PR TITLE
VxAdmin: backup & restore follow-up fixes

### DIFF
--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -13,7 +13,7 @@ import {
   mockWritable,
 } from '@votingworks/test-utils';
 import { Client } from '@votingworks/db';
-import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
+import { BaseLogger, LogSource, mockLogger } from '@votingworks/logging';
 import { DateWithoutTime } from '@votingworks/basics';
 import {
   DEFAULT_SYSTEM_SETTINGS,
@@ -56,7 +56,7 @@ async function run(
   // interleaved with the command's own output.
   const code = await main(['node', 'backups', ...args], {
     ...streams,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system' }),
     signal,
   });
   return {
@@ -163,6 +163,34 @@ test('a logger is optional, since the real entry point does not have one', async
   expect(stderr.toString()).toContain('Usage: backups <command> [options]');
 });
 
+test('without a logger, what the CLI does is attributed to the system', async () => {
+  const source = await makeWorkspace(new BaseLogger(LogSource.VxAdminService));
+  // The default logger writes JSON lines with `console.log`, which is where
+  // the attribution being tested shows up.
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  await main(
+    [
+      'node',
+      'backups',
+      'create',
+      '--workspace',
+      source.path,
+      '--target',
+      makeTemporaryDirectory(),
+    ],
+    { stdin: mockReadable(), stdout: mockWritable(), stderr: mockWritable() }
+  );
+
+  // Nobody is signed in to a command run from a shell, unlike the same
+  // operation run from VxAdmin itself.
+  expect(
+    log.mock.calls.map(([line]) => JSON.parse(line as string))
+  ).toContainEqual(
+    expect.objectContaining({ eventId: 'backup-create-init', user: 'system' })
+  );
+});
+
 test('create requires a target', async () => {
   const { code, stderr } = await run([
     'create',
@@ -235,7 +263,7 @@ test('create copies the database into a directory within the target', async () =
   expect(backupWorkspaceNames).toContain('data.db');
   const client = Client.fileClient(
     join(backupWorkspace, 'data.db'),
-    mockBaseLogger({ fn: vi.fn })
+    mockLogger({ fn: vi.fn, role: 'system' })
   );
   const { count } = client.one('select count(*) as count from elections') as {
     count: number;
@@ -427,7 +455,7 @@ test('restore copies a backup into the workspace', async () => {
 
   const client = Client.fileClient(
     join(workspace, 'data.db'),
-    mockBaseLogger({ fn: vi.fn })
+    mockLogger({ fn: vi.fn, role: 'system' })
   );
   const { count } = client.one('select count(*) as count from elections') as {
     count: number;

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -495,7 +495,7 @@ test('create reports a cancelled backup rather than a failed one', async () => {
   expect(readdirSync(target)).toEqual([]);
 });
 
-test('restore cancelled before it starts leaves the workspace as it was', async () => {
+test('restore cancelled before it starts destroys nothing in the workspace', async () => {
   const logger = new BaseLogger(LogSource.VxAdminService);
   const source = await makeWorkspace(logger);
   const target = makeTemporaryDirectory();
@@ -519,5 +519,7 @@ test('restore cancelled before it starts leaves the workspace as it was', async 
   expect(code).toEqual(CANCELLED_EXIT_CODE);
   expect(stderr).toContain('Cancelled. No backup was restored.');
   expect(stdout).toEqual('');
-  expect(readdirSync(workspace)).toEqual(['already-here']);
+  // Opening the workspace creates the directories a workspace has, but
+  // nothing that was already there is touched.
+  expect(readdirSync(workspace)).toContain('already-here');
 });

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -11,7 +11,11 @@ import { DisplayProgress, ProgressDisplay } from './progress_display.js';
 import * as views from './views.js';
 import { ProgressEvent } from '../progress.js';
 import { createBackup } from '../create/index.js';
-import { openWorkspace, Workspace } from '../../util/workspace.js';
+import {
+  createWorkspace,
+  openWorkspace,
+  Workspace,
+} from '../../util/workspace.js';
 import { restoreBackup } from '../restore/index.js';
 
 /**
@@ -382,9 +386,13 @@ async function restore(
     Boolean((stderr as NodeJS.WriteStream).isTTY)
   );
 
+  // Not `using`: `restoreBackup` closes the store itself, and the workspace is
+  // not usable afterwards.
+  const workspace = createWorkspace(args.workspace, logger);
+
   const restoreBackupResult = await restoreBackup({
     backup: args.backup,
-    workspace: args.workspace,
+    workspace,
     logger,
     signal,
     onProgressEvent: (event) => display.update(displayProgress(event)),

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -3,7 +3,7 @@ import { relative } from 'node:path';
 import yargs from 'yargs';
 import { isNonExistentFileOrDirectoryError } from '@votingworks/basics';
 import { FileSystemEntryType, listDirectoryRecursive } from '@votingworks/fs';
-import { BaseLogger, LogSource } from '@votingworks/logging';
+import { BaseLogger, Logger, LogSource } from '@votingworks/logging';
 import { getNodeEnv } from '@votingworks/backend';
 import { BackupRoot } from '../backup_root.js';
 import { StyledPrinter } from './styled_printer.js';
@@ -30,11 +30,11 @@ export interface Streams {
 /**
  * Everything the CLI needs from its caller: the IO streams, and optionally
  * where to send log messages. Without a logger, log messages go to a real
- * {@link BaseLogger}, i.e. to stdout as JSON lines — tests pass a mock so log
+ * {@link Logger}, i.e. to stdout as JSON lines — tests pass a mock so log
  * output doesn't interleave with the command's own.
  */
 export interface MainContext extends Streams {
-  logger?: BaseLogger;
+  logger?: Logger;
 
   /**
    * When given, aborting this signal cancels a `create` or `restore` in
@@ -66,7 +66,13 @@ export async function main(
   argv: readonly string[],
   { stdin, stdout, stderr, logger: providedLogger, signal }: MainContext
 ): Promise<number> {
-  const logger = providedLogger ?? new BaseLogger(LogSource.VxAdminService);
+  // Nobody is signed in to a command run from a shell, so what it does is the
+  // system's doing, unlike the same operations run from VxAdmin itself.
+  const logger =
+    providedLogger ??
+    Logger.from(new BaseLogger(LogSource.VxAdminService), () =>
+      Promise.resolve('system')
+    );
   const parser = yargs()
     .scriptName('backups')
     .usage('Usage: $0 <command> [options]')
@@ -211,7 +217,7 @@ function displayProgress(event: ProgressEvent): DisplayProgress {
  */
 function openWorkspaceIfPresent(
   path: string,
-  logger: BaseLogger
+  logger: Logger
 ): Workspace | undefined {
   try {
     return openWorkspace(path, logger);
@@ -234,7 +240,7 @@ async function create(
     stderr,
     logger,
     signal,
-  }: Streams & { logger: BaseLogger; signal?: AbortSignal }
+  }: Streams & { logger: Logger; signal?: AbortSignal }
 ): Promise<number> {
   assert(typeof args.workspace === 'string');
   assert(typeof args.target === 'string');
@@ -374,7 +380,7 @@ async function restore(
     stderr,
     logger,
     signal,
-  }: Streams & { logger: BaseLogger; signal?: AbortSignal }
+  }: Streams & { logger: Logger; signal?: AbortSignal }
 ): Promise<number> {
   assert(typeof args.workspace === 'string');
   assert(typeof args.backup === 'string');

--- a/apps/admin/backend/src/backup/create/copy_step.test.ts
+++ b/apps/admin/backend/src/backup/create/copy_step.test.ts
@@ -6,7 +6,7 @@ import { rmSync } from 'node:fs';
 import { assertDefined } from '@votingworks/basics';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { DEV_MACHINE_ID, LATEST_SOFTWARE_VERSION } from '@votingworks/types';
-import { mockBaseLogger } from '@votingworks/logging';
+import { mockLogger } from '@votingworks/logging';
 import {
   addCvrWithBallotImage,
   makeConfiguredWorkspace,
@@ -42,7 +42,7 @@ test('copies staged files to the backup directory and builds a manifest', async 
   const prepareResult = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
   const { electionId, source, snapshotStore } = prepareResult.unsafeUnwrap();
 
@@ -58,7 +58,7 @@ test('copies staged files to the backup directory and builds a manifest', async 
       source,
       store: snapshotStore,
       backup: backupPath,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       onProgressEvent: (event) => progressEvents.push(event),
     })
   ).unsafeUnwrap();
@@ -129,7 +129,7 @@ async function copyWithProgress(
   const prepareResult = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
   const {
     electionId,
@@ -144,7 +144,7 @@ async function copyWithProgress(
       source,
       store,
       backup: join(makeTemporaryDirectory(), 'backup'),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       progressEventIntervalBytes,
       onProgressEvent: (event) => events.push(event),
     })
@@ -220,7 +220,7 @@ test('reports a staged file that cannot be read', async () => {
   const prepareResult = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
   const { electionId, source, snapshotStore } = prepareResult.unsafeUnwrap();
 
@@ -233,7 +233,7 @@ test('reports a staged file that cannot be read', async () => {
     source,
     store: snapshotStore,
     backup: join(makeTemporaryDirectory(), 'backup'),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({ type: 'OpenFileError' });
@@ -248,7 +248,7 @@ test('stops copying when cancelled between files', async () => {
   const prepareResult = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
   const { electionId, source, snapshotStore } = prepareResult.unsafeUnwrap();
   const backup = join(makeTemporaryDirectory(), 'backup');
@@ -259,7 +259,7 @@ test('stops copying when cancelled between files', async () => {
     source,
     store: snapshotStore,
     backup,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     signal: controller.signal,
     onProgressEvent(event) {
       // Abort once the first file has landed, so the copy stops with files

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -4,7 +4,7 @@ import { dirname, join, relative } from 'node:path';
 import { readdirSync, readFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
-import { LogEventId, mockBaseLogger } from '@votingworks/logging';
+import { LogEventId, mockLogger } from '@votingworks/logging';
 import { generateElectionBasedSubfolderName } from '@votingworks/utils';
 import {
   authenticateArtifactUsingSignatureFile,
@@ -80,7 +80,7 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
   addCvrWithBallotImage(workspace, { ballotId: 'ballot-1' });
 
   const target = makeTemporaryDirectory();
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
 
   // Installed after the workspace exists so the last store built is the
   // snapshot's.
@@ -97,12 +97,12 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
   // and its outcome belong in the audit log.
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupCreateInit,
-    'system',
+    'system_administrator',
     expect.objectContaining({ message: expect.stringContaining(target) })
   );
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupCreateComplete,
-    'system',
+    'system_administrator',
     expect.objectContaining({
       disposition: 'success',
       message: expect.stringContaining(firstCreated.path),
@@ -200,7 +200,7 @@ test('resolves a relative target path', async () => {
   const result = await createBackup({
     workspace,
     target: relative(process.cwd(), target),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // The backup landed in the target, reported at its absolute path.
@@ -228,7 +228,7 @@ test('reports an error when copying the backup fails', async () => {
   const target = makeTemporaryDirectory();
   vi.mocked(copy).mockRejectedValueOnce(outOfSpaceError());
 
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   const result = await createBackup({
     workspace,
     target,
@@ -241,7 +241,7 @@ test('reports an error when copying the backup fails', async () => {
   });
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupCreateComplete,
-    'system',
+    'system_administrator',
     expect.objectContaining({
       disposition: 'failure',
       errorType: 'backup-write-failed',
@@ -259,7 +259,7 @@ test('reports a backup file that could not be copied, leaving no partial backup'
   const result = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -279,7 +279,7 @@ test('reports a staged file that outgrew the size it was measured at', async () 
   const result = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // A staged file is copied under the size staging measured for it, so this
@@ -299,7 +299,7 @@ test('reports an error when writing the manifest fails, leaving no partial backu
   const result = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -319,7 +319,7 @@ test('fails fast when writing the backup fails unexpectedly', async () => {
     createBackup({
       workspace,
       target,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).rejects.toThrow('kaboom');
 });
@@ -347,7 +347,7 @@ test('reports an error when clearing a leftover in-progress backup fails', async
   const result = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -372,7 +372,7 @@ test('reports a failed swap rather than a created backup', async () => {
   const result = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -388,7 +388,7 @@ test('a cancelled copy leaves no partial backup behind', async () => {
 
   // No signal here: what is under test is how the orchestration handles a
   // copy that reports it was cancelled, not where the cancel came from.
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   const result = await createBackup({
     workspace,
     target,
@@ -402,7 +402,7 @@ test('a cancelled copy leaves no partial backup behind', async () => {
   expect(readdirSync(new BackupRoot(target).pathFor('.'))).toEqual([]);
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupCreateComplete,
-    'system',
+    'system_administrator',
     expect.objectContaining({ disposition: 'failure', errorType: 'cancelled' })
   );
 });
@@ -416,7 +416,7 @@ test('cancelling after the copy finishes stops before the manifest is written', 
   const result = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     signal: controller.signal,
     onProgressEvent(event) {
       // The event announcing the last file copied: everything is written but
@@ -449,7 +449,7 @@ test('a backup already in place survives a cancelled attempt to replace it', asy
   const firstResult = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
   const backupPath = firstResult.unsafeUnwrap().path;
   const backupContentsBefore = readdirSync(backupPath).sort();
@@ -458,7 +458,7 @@ test('a backup already in place survives a cancelled attempt to replace it', asy
   const secondResult = await createBackup({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     signal: controller.signal,
     onProgressEvent(event) {
       if (event.type === 'db_snapshot') {

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -78,20 +78,20 @@ export async function createBackup(
     target: resolve(rawOptions.target),
   };
   const { logger } = options;
-  logger.log(LogEventId.BackupCreateInit, 'system', {
+  await logger.logAsCurrentRole(LogEventId.BackupCreateInit, {
     message: `Creating a backup at ${options.target}...`,
   });
 
   const result = await tryCreateBackup(options);
 
   if (result.isOk()) {
-    logger.log(LogEventId.BackupCreateComplete, 'system', {
+    await logger.logAsCurrentRole(LogEventId.BackupCreateComplete, {
       disposition: 'success',
       message: `Backup created successfully at ${result.ok().path}.`,
     });
   } else {
     const error = result.err();
-    logger.log(LogEventId.BackupCreateComplete, 'system', {
+    await logger.logAsCurrentRole(LogEventId.BackupCreateComplete, {
       disposition: 'failure',
       errorType: error.type,
       message: `Failed to create backup: ${error.message}`,

--- a/apps/admin/backend/src/backup/create/manifest_step.test.ts
+++ b/apps/admin/backend/src/backup/create/manifest_step.test.ts
@@ -6,7 +6,7 @@ import {
   makeTemporaryDirectory,
 } from '@votingworks/fixtures';
 import { DEV_MACHINE_ID, LATEST_SOFTWARE_VERSION } from '@votingworks/types';
-import { mockBaseLogger } from '@votingworks/logging';
+import { mockLogger } from '@votingworks/logging';
 import { ok } from '@votingworks/basics';
 import {
   authenticateArtifactUsingSignatureFile,
@@ -52,7 +52,7 @@ test('writes a manifest alongside a signature that authenticates it', async () =
   await writeManifest({
     manifest,
     backup: backupPath,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     onProgressEvent: (event) => progressEvents.push(event),
   });
 
@@ -85,7 +85,7 @@ test('the signature does not authenticate a tampered-with manifest', async () =>
   await writeManifest({
     manifest: makeManifest(),
     backup: backupPath,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   const manifestPath = join(backupPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME);

--- a/apps/admin/backend/src/backup/create/prepare_step.test.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.test.ts
@@ -20,6 +20,7 @@ import {
   GENEROUS_AVAILABLE_KB,
   makeConfiguredWorkspace,
   mockDiskSpace,
+  whileWriting,
 } from '../../../test/backup.js';
 import { createWorkspace } from '../../util/workspace.js';
 import { Store } from '../../store.js';
@@ -117,38 +118,29 @@ test('reclaims a killed run’s staging area before measuring free space', async
 test('refuses while a write transaction is open on the workspace', async () => {
   const workspace = await makeConfiguredWorkspace();
 
-  // What a CVR import looks like from here: it holds its transaction open
-  // across awaits for the whole import.
-  workspace.store['client'].run('begin transaction');
-
-  const result = await prepare({
-    workspace,
-    target: makeTemporaryDirectory(),
-    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-  });
+  const result = await whileWriting(workspace, () =>
+    prepare({
+      workspace,
+      target: makeTemporaryDirectory(),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+    })
+  );
 
   expect(result.err()).toEqual({
     type: 'write-in-progress',
     message:
       'Cannot back up while another operation is writing to the database',
   });
-
-  workspace.store['client'].run('rollback');
 });
 
-test('refuses when a write begins after the snapshot is cleared to start', async () => {
+test('reports a write that began after the snapshot was cleared to start', async () => {
   const workspace = await makeConfiguredWorkspace();
-  const dbClient = workspace.store['client'];
 
-  // Slip the write in after `prepare` checks, to stand in for the window
-  // between the check and the snapshot actually starting. It takes a real
-  // write, not just an open transaction, for SQLite to hold the write lock
-  // that makes the snapshot a no-op.
-  vi.spyOn(dbClient, 'isInTransaction').mockImplementationOnce(() => {
-    dbClient.run('begin transaction');
-    dbClient.run('update elections set election_data = election_data');
-    return false;
-  });
+  // A write that slips into the window between the check and the snapshot
+  // starting is caught by the snapshot itself, which reports it this way.
+  vi.spyOn(workspace.store, 'backupTo').mockResolvedValueOnce(
+    err({ type: 'write-in-progress' })
+  );
 
   const result = await prepare({
     workspace,
@@ -161,8 +153,6 @@ test('refuses when a write begins after the snapshot is cleared to start', async
     message:
       'Cannot back up while another operation is writing to the database',
   });
-
-  dbClient.run('rollback');
 });
 
 test('refuses when a backup of the workspace is already running', async () => {

--- a/apps/admin/backend/src/backup/create/prepare_step.test.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   unlinkSync,
@@ -10,7 +11,10 @@ import {
 } from 'node:fs';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
+import { mkdtemp } from 'node:fs/promises';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
+import { err } from '@votingworks/basics';
+import { exchangePaths } from '@votingworks/fs';
 import {
   addCvrWithBallotImage,
   GENEROUS_AVAILABLE_KB,
@@ -22,6 +26,25 @@ import { Store } from '../../store.js';
 import { BackupStagingArea } from '../staging_area.js';
 import { FileBackedMachineModeController } from '../../machine_mode.js';
 import { prepare } from './prepare_step.js';
+
+vi.mock(
+  import('node:fs/promises'),
+  async (importActual): Promise<typeof import('node:fs/promises')> => {
+    const actual = await importActual();
+    return {
+      ...actual,
+      mkdtemp: vi.fn(actual.mkdtemp) as unknown as typeof mkdtemp,
+    };
+  }
+);
+
+vi.mock(
+  import('@votingworks/fs'),
+  async (importActual): Promise<typeof import('@votingworks/fs')> => {
+    const actual = await importActual();
+    return { ...actual, exchangePaths: vi.fn(actual.exchangePaths) };
+  }
+);
 
 vi.mock(
   import('@votingworks/backend'),
@@ -487,4 +510,72 @@ test('refuses to back up a workspace belonging to a client machine', async () =>
       'Only a VxAdmin in host mode can be backed up or restored, but this one is in client mode',
   });
   expect(existsSync(BackupStagingArea.pathIn(workspace.path))).toEqual(false);
+});
+
+test('refuses a target whose filesystem cannot swap a backup into place', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+
+  // What FAT32 does: `renameat2(2)` with `RENAME_EXCHANGE` is refused, which
+  // only the *second* backup to a drive would otherwise discover.
+  vi.mocked(exchangePaths).mockReturnValueOnce(
+    err({ code: 'EINVAL', message: 'EINVAL: invalid argument, renameexchange' })
+  );
+
+  const result = await prepare({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toEqual({
+    type: 'target-cannot-swap',
+    path: target,
+    message: expect.stringContaining('cannot hold backups'),
+  });
+
+  // Refused before the database was snapshotted, which is the point.
+  expect(existsSync(BackupStagingArea.pathIn(workspace.path))).toEqual(false);
+});
+
+test('refuses a target that cannot be written to at all', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+
+  // A read-only drive, or one removed between being checked and being written
+  // to: the directories the check would exchange cannot even be created. The
+  // failure has to be mocked because permissions cannot produce it — CI runs
+  // as root, for whom a directory with no write bit is still writable.
+  vi.mocked(mkdtemp).mockRejectedValueOnce(
+    Object.assign(new Error('EROFS: read-only file system, mkdtemp'), {
+      code: 'EROFS',
+    })
+  );
+
+  const result = await prepare({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  expect(result.err()).toMatchObject({ type: 'target-cannot-swap' });
+});
+
+test('leaves nothing behind after checking that the target can swap', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+
+  const result = await prepare({
+    workspace,
+    target,
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+  const { source, snapshotStore } = result.unsafeUnwrap();
+
+  // The directories the check exchanged are gone, so a drive that has never
+  // been backed up to still looks that way.
+  expect(readdirSync(target)).toEqual([]);
+
+  snapshotStore.close();
+  await source.cleanup();
 });

--- a/apps/admin/backend/src/backup/create/prepare_step.test.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.test.ts
@@ -20,6 +20,7 @@ import {
 import { createWorkspace } from '../../util/workspace.js';
 import { Store } from '../../store.js';
 import { BackupStagingArea } from '../staging_area.js';
+import { FileBackedMachineModeController } from '../../machine_mode.js';
 import { prepare } from './prepare_step.js';
 
 vi.mock(
@@ -465,5 +466,25 @@ test('cancels after staging files, before measuring the target', async () => {
     message: 'Backup cancelled',
   });
 
+  expect(existsSync(BackupStagingArea.pathIn(workspace.path))).toEqual(false);
+});
+
+test('refuses to back up a workspace belonging to a client machine', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  FileBackedMachineModeController.forWorkspace(workspace.path).set('client');
+
+  const result = await prepare({
+    workspace,
+    target: makeTemporaryDirectory(),
+    logger: mockBaseLogger({ fn: vi.fn }),
+  });
+
+  // A client machine keeps whatever database it had before it was switched, so
+  // backing one up would capture data the machine is no longer using.
+  expect(result.err()).toEqual({
+    type: 'not-host-mode',
+    message:
+      'Only a VxAdmin in host mode can be backed up or restored, but this one is in client mode',
+  });
   expect(existsSync(BackupStagingArea.pathIn(workspace.path))).toEqual(false);
 });

--- a/apps/admin/backend/src/backup/create/prepare_step.test.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.test.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
-import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
+import { BaseLogger, LogSource, mockLogger } from '@votingworks/logging';
 import { mkdtemp } from 'node:fs/promises';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
 import { err } from '@votingworks/basics';
@@ -98,7 +98,7 @@ test('reclaims a killed run’s staging area before measuring free space', async
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
   const { source, snapshotStore: store } = result.unsafeUnwrap();
 
@@ -124,7 +124,7 @@ test('refuses while a write transaction is open on the workspace', async () => {
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -153,7 +153,7 @@ test('refuses when a write begins after the snapshot is cleared to start', async
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -174,7 +174,7 @@ test('refuses when a backup of the workspace is already running', async () => {
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -192,7 +192,7 @@ test('fails when no election is configured', async () => {
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -208,7 +208,7 @@ test('fails when the backup target directory does not exist', async () => {
   const result = await prepare({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -226,7 +226,7 @@ test('fails when the backup target is not a directory', async () => {
   const result = await prepare({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -262,7 +262,7 @@ test('fails when the backup target goes away while staging', async () => {
   const result = await prepare({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -293,7 +293,7 @@ test('fails fast when the target disk space check fails for another reason', asy
     prepare({
       workspace,
       target,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).rejects.toThrow('df is broken');
 });
@@ -307,7 +307,7 @@ test('fails with insufficient-workspace-storage when the workspace volume is too
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({
@@ -328,7 +328,7 @@ test('fails with insufficient-target-storage when the target volume is too full'
   const result = await prepare({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({ type: 'insufficient-target-storage' });
@@ -347,7 +347,7 @@ test('stages a database snapshot, election package, and ballot images', async ()
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     onProgressEvent: (event) => progressEvents.push(event),
   });
 
@@ -381,7 +381,7 @@ test('fails loudly when a referenced ballot image is missing from disk', async (
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({
@@ -396,7 +396,7 @@ test('cancels before doing any work when the signal is already aborted', async (
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     signal: AbortSignal.abort(),
   });
 
@@ -431,7 +431,7 @@ test('cancels before snapshotting the database', async () => {
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     signal: controller.signal,
   });
 
@@ -449,7 +449,7 @@ test('cancels partway through snapshotting the database', async () => {
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     signal: controller.signal,
     onProgressEvent: (event) => {
       if (event.type === 'db_snapshot') {
@@ -475,7 +475,7 @@ test('cancels after staging files, before measuring the target', async () => {
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     signal: controller.signal,
     onProgressEvent: (event) => {
       if (event.type === 'staging_files') {
@@ -499,7 +499,7 @@ test('refuses to back up a workspace belonging to a client machine', async () =>
   const result = await prepare({
     workspace,
     target: makeTemporaryDirectory(),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // A client machine keeps whatever database it had before it was switched, so
@@ -525,7 +525,7 @@ test('refuses a target whose filesystem cannot swap a backup into place', async 
   const result = await prepare({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toEqual({
@@ -555,7 +555,7 @@ test('refuses a target that cannot be written to at all', async () => {
   const result = await prepare({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({ type: 'target-cannot-swap' });
@@ -568,7 +568,7 @@ test('leaves nothing behind after checking that the target can swap', async () =
   const result = await prepare({
     workspace,
     target,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
   const { source, snapshotStore } = result.unsafeUnwrap();
 

--- a/apps/admin/backend/src/backup/create/prepare_step.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.ts
@@ -89,13 +89,6 @@ const CANCELLED_ERROR: PrepareError = {
 };
 
 /**
- * Thrown from the database snapshot's progress callback to abort it, which is
- * the only way to stop a snapshot partway: `better-sqlite3` closes the backup
- * and rejects when its progress callback throws.
- */
-class CancelledError extends Error {}
-
-/**
  * Reported when the database cannot be snapshotted because something else is
  * partway through writing to it.
  */
@@ -286,45 +279,19 @@ export async function prepare(
       workspace.store.getDbPath()
     );
 
-    // SQLite refuses to copy a page while a write transaction is open on the
-    // connection running the backup, and `better-sqlite3` reports that refusal
-    // as a backup that finished with nothing left to do, deleting the
-    // destination on its way out. Catch the case we can see coming — a CVR
-    // import holds its transaction open across awaits for the whole import —
-    // rather than letting it look like a successful snapshot.
-    if (dbClient.isInTransaction()) {
-      return err(WRITE_IN_PROGRESS_ERROR);
-    }
-
-    // So that a backup cancelled before the snapshot starts never copies a
-    // page of it.
-    if (signal?.aborted) {
-      return err(CANCELLED_ERROR);
-    }
-
-    await dbClient.backup(dbSnapshotPath, {
-      progress(info) {
-        if (signal?.aborted) {
-          throw new CancelledError();
-        }
-
-        onProgressEvent?.({
-          type: 'db_snapshot',
-          progress: (info.totalPages - info.remainingPages) / info.totalPages,
-        });
-        // NOTE: `better-sqlite3`'s types say the return type has to be a number,
-        // but that's only if we want to control the next chunk of the backup's
-        // page size. Returning `undefined` lets the caller pick.
-        return undefined as unknown as number;
-      },
+    const snapshotResult = await dbClient.backup(dbSnapshotPath, {
+      signal,
+      onProgress: (progress) =>
+        onProgressEvent?.({ type: 'db_snapshot', progress }),
     });
-    if (!(await statOrUndefined(dbSnapshotPath))) {
-      // A write that began after the check above lands here: the backup
-      // resolved without copying anything and unlinked the snapshot.
-      return err(WRITE_IN_PROGRESS_ERROR);
+    if (snapshotResult.isErr()) {
+      return err(
+        snapshotResult.err().type === 'cancelled'
+          ? CANCELLED_ERROR
+          : WRITE_IN_PROGRESS_ERROR
+      );
     }
 
-    onProgressEvent?.({ type: 'db_snapshot', progress: 1 });
     await stagingArea.markStagingPathReady(dbSnapshotPath);
 
     // Enumerate ballot images from the snapshot we just took, not the live
@@ -405,10 +372,6 @@ export async function prepare(
       snapshotStore,
     });
   } catch (error) {
-    if (error instanceof CancelledError) {
-      return err(CANCELLED_ERROR);
-    }
-
     if (isNonExistentFileOrDirectoryError(error)) {
       return err({
         type: 'file-not-found',

--- a/apps/admin/backend/src/backup/create/prepare_step.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.ts
@@ -236,9 +236,6 @@ export async function prepare(
     });
   }
   const stagingArea = stagingAreaResult.ok();
-  // The workspace's own connection, so that writes made through it update the
-  // snapshot in place instead of restarting it.
-  const dbClient = workspace.store['client'];
   let snapshotStore: Store | undefined;
   let shouldPurgeStagingArea = true;
 
@@ -279,7 +276,7 @@ export async function prepare(
       workspace.store.getDbPath()
     );
 
-    const snapshotResult = await dbClient.backup(dbSnapshotPath, {
+    const snapshotResult = await workspace.store.backupTo(dbSnapshotPath, {
       signal,
       onProgress: (progress) =>
         onProgressEvent?.({ type: 'db_snapshot', progress }),

--- a/apps/admin/backend/src/backup/create/prepare_step.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.ts
@@ -1,5 +1,6 @@
 import { Stats } from 'node:fs';
-import { stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import {
   assertDefined,
   err,
@@ -10,6 +11,7 @@ import {
   Result,
 } from '@votingworks/basics';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
+import { exchangePaths } from '@votingworks/fs';
 import { Id } from '@votingworks/types';
 import { Store } from '../../store.js';
 import { checkWorkspaceIsHostMode } from '../host_mode.js';
@@ -45,6 +47,11 @@ export type PrepareError =
     }
   | {
       type: 'not-directory';
+      path: string;
+      message: string;
+    }
+  | {
+      type: 'target-cannot-swap';
       path: string;
       message: string;
     }
@@ -119,6 +126,64 @@ export interface PreparedBackup {
 }
 
 /**
+ * Prefix for the throwaway directory {@link checkTargetCanSwap} works in. Its
+ * leading dot keeps it out of the way of anything listing the drive, and
+ * `mkdtemp` completes it with enough randomness that two runs never collide.
+ */
+const SWAP_CHECK_PREFIX = '.vx-swap-check-';
+
+/**
+ * Checks that the target can have a finished backup swapped into place, which
+ * is how the last backup is replaced without either one ever being missing.
+ * `renameat2(2)` with `RENAME_EXCHANGE` is not supported on every filesystem —
+ * FAT32 refuses it — and only a target that already holds a backup would
+ * exercise it, so the first backup to a drive would succeed and every one
+ * after it would fail. Two throwaway directories answer the question outright,
+ * rather than a copy of the whole database finding out at the end.
+ */
+async function checkTargetCanSwap(
+  target: string
+): Promise<Result<void, PrepareError>> {
+  // A directory of its own, so that whatever a killed run left behind is never
+  // mistaken for a target that cannot hold backups. `target` has just been
+  // confirmed to be a directory, so the two inside it need no parents created.
+  let checkPath: string | undefined;
+
+  try {
+    checkPath = await mkdtemp(join(target, SWAP_CHECK_PREFIX));
+    const a = join(checkPath, 'a');
+    const b = join(checkPath, 'b');
+    await mkdir(a);
+    await mkdir(b);
+
+    const exchangeResult = exchangePaths(a, b);
+    if (exchangeResult.isErr()) {
+      return err({
+        type: 'target-cannot-swap',
+        path: target,
+        message: `${target} cannot hold backups: ${
+          exchangeResult.err().message
+        }`,
+      });
+    }
+
+    return ok();
+  } catch (error) {
+    // A target that cannot even be written to is one no backup can be swapped
+    // into, so it fails here rather than after the copy.
+    return err({
+      type: 'target-cannot-swap',
+      path: target,
+      message: `${target} cannot hold backups: ${extractErrorMessage(error)}`,
+    });
+  } finally {
+    if (checkPath) {
+      await rm(checkPath, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
  * Prepares the backup creation to take place by ensuring the source workspace
  * and target locations are known and able to fit the data to be copied. Stages
  * the data to be copied, including a database snapshot, returning a reference
@@ -160,6 +225,11 @@ export async function prepare(
       path: target,
       message: `${target} is not a directory`,
     });
+  }
+
+  const swapResult = await checkTargetCanSwap(target);
+  if (swapResult.isErr()) {
+    return swapResult;
   }
 
   // Claim the staging area first. It reclaims what a killed run left behind,

--- a/apps/admin/backend/src/backup/create/prepare_step.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.ts
@@ -12,6 +12,7 @@ import {
 import { getDiskSpaceSummaries } from '@votingworks/backend';
 import { Id } from '@votingworks/types';
 import { Store } from '../../store.js';
+import { checkWorkspaceIsHostMode } from '../host_mode.js';
 import { PrepareBackupOptions } from './types.js';
 import { BackupStagingArea } from '../staging_area.js';
 
@@ -31,6 +32,10 @@ async function statOrUndefined(path: string): Promise<Stats | undefined> {
 export type PrepareError =
   | {
       type: 'cancelled';
+      message: string;
+    }
+  | {
+      type: 'not-host-mode';
       message: string;
     }
   | {
@@ -129,6 +134,11 @@ export async function prepare(
 
   if (signal?.aborted) {
     return err(CANCELLED_ERROR);
+  }
+
+  const hostModeResult = checkWorkspaceIsHostMode(workspace);
+  if (hostModeResult.isErr()) {
+    return hostModeResult;
   }
 
   // Check the target up front: an unmounted backup drive is the likeliest

--- a/apps/admin/backend/src/backup/create/swap_step.test.ts
+++ b/apps/admin/backend/src/backup/create/swap_step.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { err, ok, Result } from '@votingworks/basics';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
-import { mockBaseLogger } from '@votingworks/logging';
+import { mockLogger } from '@votingworks/logging';
 import { exchangePaths, syncFilesystem, SyscallError } from '@votingworks/fs';
 import { swap } from './swap_step.js';
 import { ProgressEvent } from '../progress.js';
@@ -40,7 +40,7 @@ test('renames the in-progress backup into place when there is none yet', async (
       inProgressBackup,
       target,
       backup,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       onProgressEvent: (event) => progressEvents.push(event),
     })
   ).toEqual(ok());
@@ -67,7 +67,7 @@ test('exchanges an existing backup for the in-progress one and discards it', asy
       inProgressBackup,
       target,
       backup,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(ok());
 
@@ -85,7 +85,7 @@ test('returns an error when the exchange fails', async () => {
     inProgressBackup: join(target, 'election-in-progress'),
     target,
     backup,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(swapResult.err()).toEqual({
@@ -124,7 +124,7 @@ test('flushes the backup to the device before and after swapping it in', async (
       inProgressBackup,
       target,
       backup,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(ok());
 
@@ -149,7 +149,7 @@ test('returns an error when the flush before the swap fails', async () => {
     inProgressBackup,
     target,
     backup,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(swapResult.err()).toEqual({
@@ -180,7 +180,7 @@ test('returns an error when the flush after the swap fails', async () => {
     inProgressBackup,
     target,
     backup,
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(swapResult.err()).toEqual({

--- a/apps/admin/backend/src/backup/host_mode.ts
+++ b/apps/admin/backend/src/backup/host_mode.ts
@@ -1,0 +1,29 @@
+import { err, ok, Result } from '@votingworks/basics';
+import { FileBackedMachineModeController } from '../machine_mode.js';
+import { BaseWorkspace } from '../util/workspace.js';
+
+/**
+ * Checks that a workspace belongs to a VxAdmin in host mode, which is the only
+ * mode whose workspace holds the election database a backup is made of. A
+ * client machine keeps whatever database it had before it was switched, so
+ * backing one up would capture data the machine is no longer using, and
+ * restoring into one would replace the machine's mode along with its data.
+ *
+ * Read from the workspace rather than from the running process, so that the
+ * answer is what the machine will be when it next starts — which for a restore
+ * is the machine that has to read what was restored.
+ */
+export function checkWorkspaceIsHostMode(
+  workspace: BaseWorkspace
+): Result<void, { type: 'not-host-mode'; message: string }> {
+  const mode = FileBackedMachineModeController.forWorkspace(
+    workspace.path
+  ).get();
+
+  return mode === 'host'
+    ? ok()
+    : err({
+        type: 'not-host-mode',
+        message: `Only a VxAdmin in host mode can be backed up or restored, but this one is in ${mode} mode`,
+      });
+}

--- a/apps/admin/backend/src/backup/progress.ts
+++ b/apps/admin/backend/src/backup/progress.ts
@@ -1,4 +1,4 @@
-import { BaseLogger } from '@votingworks/logging';
+import { Logger } from '@votingworks/logging';
 
 /**
  * Basic options for all backup and restore steps.
@@ -13,7 +13,7 @@ export interface ProgressTracking {
   /**
    * Where to send log messages during the operation.
    */
-  logger: BaseLogger;
+  logger: Logger;
 
   /**
    * When given, aborting this signal stops the operation at the next point it

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -8,7 +8,7 @@ import {
   makeTemporaryDirectory,
 } from '@votingworks/fixtures';
 import { assertDefined, err, iter, ok } from '@votingworks/basics';
-import { LogEventId, mockBaseLogger } from '@votingworks/logging';
+import { LogEventId, mockLogger } from '@votingworks/logging';
 import {
   authenticateArtifactUsingSignatureFile,
   prepareSignatureFile,
@@ -79,7 +79,10 @@ beforeEach(() => {
  */
 function makeUnconfiguredWorkspacePath(): string {
   const path = makeTemporaryDirectory();
-  using workspace = createWorkspace(path, mockBaseLogger({ fn: vi.fn }));
+  using workspace = createWorkspace(
+    path,
+    mockLogger({ fn: vi.fn, role: 'system_administrator' })
+  );
   expect(workspace.store.getCurrentElectionId()).toBeUndefined();
   return path;
 }
@@ -99,7 +102,10 @@ async function makeConfiguredWorkspacePath(): Promise<string> {
  * open. `restoreBackup` closes it, so nothing here has to.
  */
 function restorable(workspacePath: string): Workspace {
-  return createWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  return createWorkspace(
+    workspacePath,
+    mockLogger({ fn: vi.fn, role: 'system_administrator' })
+  );
 }
 
 /**
@@ -197,7 +203,7 @@ async function replaceBackupFile(
 }
 
 test('restore copies the database, ballot images, and election packages', async () => {
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   using source = await makeConfiguredWorkspace();
   addCvrWithBallotImage(source, { ballotId: 'ballot-1' });
   addCvrWithBallotImage(source, { ballotId: 'ballot-2' });
@@ -249,12 +255,12 @@ test('restore copies the database, ballot images, and election packages', async 
   // and its outcome belong in the audit log.
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupRestoreInit,
-    'system',
+    'system_administrator',
     expect.objectContaining({ message: expect.stringContaining(created.path) })
   );
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupRestoreComplete,
-    'system',
+    'system_administrator',
     expect.objectContaining({ disposition: 'success' })
   );
 
@@ -293,7 +299,7 @@ test('restore copies the database, ballot images, and election packages', async 
 });
 
 test('restore recreates workspace directories the backup has no files in', async () => {
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
 
   // A workspace that is configured but has no CVRs loaded holds an empty
   // `ballot-images` directory, which a backup — a manifest of files — cannot
@@ -325,7 +331,7 @@ test('restore recreates workspace directories the backup has no files in', async
 test('restore resolves a relative backup path', async () => {
   const backup = await makeBackup();
   const workspacePath = makeUnconfiguredWorkspacePath();
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
 
   expect(
     await restoreBackup({
@@ -338,7 +344,7 @@ test('restore resolves a relative backup path', async () => {
   // The audit log records the resolved absolute path.
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupRestoreInit,
-    'system',
+    'system_administrator',
     expect.objectContaining({ message: expect.stringContaining(backup.path) })
   );
 });
@@ -351,7 +357,7 @@ test('restore fails if there is no backup manifest', async () => {
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // The CLI renders a failed restore as `Error: ${err().message}`, the same as
@@ -381,7 +387,7 @@ test('restore fails if the backup manifest is not readable', async () => {
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({ type: 'backup-read-failed' });
@@ -407,7 +413,7 @@ test('restore fails if the backup manifest version does not match', async () => 
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // A version field exists to explain *why* a backup can't be read, so this
@@ -442,7 +448,7 @@ test('restore fails if the backup manifest software version does not match', asy
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({
@@ -470,7 +476,7 @@ test('restore warns but does not fail if the machine ID does not match', async (
   }));
 
   const workspacePath = makeUnconfiguredWorkspacePath();
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
@@ -480,7 +486,10 @@ test('restore warns but does not fail if the machine ID does not match', async (
   // Moving a backup between machines is a legitimate thing to do — replacing
   // failed hardware — so this is worth recording, not refusing.
   expect(result).toEqual(ok());
-  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  using workspace = openWorkspace(
+    workspacePath,
+    mockLogger({ fn: vi.fn, role: 'system_administrator' })
+  );
   expect(workspace.store.getCurrentElectionId()).toBeDefined();
 
   // The event id is left to the implementation, but the log has to say which
@@ -532,7 +541,7 @@ test.each<{ description: string; tamper: (backup: Backup) => Promise<void> }>([
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // Every hash in the manifest is only as trustworthy as the manifest itself,
@@ -567,7 +576,7 @@ test('restore fails if a backup file cannot be read', async () => {
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // Any failure to copy has to be reported. Reporting success here hands the
@@ -596,7 +605,7 @@ test('restore fails on missing files from the backup manifest', async () => {
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({
@@ -621,7 +630,7 @@ test('restore fails if any backup files are an unexpected size', async () => {
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // The file is present and readable, so existence is not enough — the size the
@@ -653,7 +662,7 @@ test('restore fails if any backup files have unexpected content (by hash)', asyn
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   expect(result.err()).toMatchObject({
@@ -698,7 +707,7 @@ test.each<{ description: string; makePath: (escapeTarget: string) => string }>([
     const result = await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     });
 
     // A backup comes off a USB drive an operator was handed, so its manifest is
@@ -733,7 +742,7 @@ test('restore refuses a manifest entry it does not know how to restore', async (
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // The manifest is the signed statement of what the backup holds, so an entry
@@ -768,7 +777,7 @@ test('restore fails if there is no current election in the backup', async () => 
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // Restoring this would report success and leave the machine unconfigured,
@@ -800,7 +809,7 @@ test('restore clears whatever an unconfigured workspace already holds', async ()
     await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       onProgressEvent: (event) => events.push(event),
       // Low enough that even these small files report mid-copy progress.
       progressEventIntervalBytes: 1,
@@ -824,7 +833,10 @@ test('restore clears whatever an unconfigured workspace already holds', async ()
   await expect(
     exists(join(workspacePath, 'stray-directory'))
   ).resolves.toBeFalsy();
-  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  using workspace = openWorkspace(
+    workspacePath,
+    mockLogger({ fn: vi.fn, role: 'system_administrator' })
+  );
   expect(workspace.store.getCurrentElectionId()).toBeDefined();
 });
 
@@ -835,7 +847,7 @@ test('an interrupted restore can be recovered by restoring again', async () => {
     await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(ok());
 
@@ -851,12 +863,15 @@ test('an interrupted restore can be recovered by restoring again', async () => {
     await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(ok());
 
   await expect(exists(markerPath)).resolves.toBeFalsy();
-  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  using workspace = openWorkspace(
+    workspacePath,
+    mockLogger({ fn: vi.fn, role: 'system_administrator' })
+  );
   expect(workspace.store.getCurrentElectionId()).toBeDefined();
 });
 
@@ -868,7 +883,7 @@ test('restore refuses a backup the workspace volume cannot hold', async () => {
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     minAvailableStorageBytes: 1024,
   });
 
@@ -895,7 +910,7 @@ test('restore fails if the restored files cannot be flushed to disk', async () =
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
-    logger: mockBaseLogger({ fn: vi.fn }),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
   // Success is declared by removing the marker, which must not happen while
@@ -912,7 +927,7 @@ test('restoring into a configured workspace fails', async () => {
   const workspacePath = await makeConfiguredWorkspacePath();
 
   const before = listWorkspace(workspacePath);
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   const result = await restoreBackup({
     backup: backup.path,
     workspace: restorable(workspacePath),
@@ -925,7 +940,7 @@ test('restoring into a configured workspace fails', async () => {
   // and its reason belong in the audit log.
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupRestoreComplete,
-    'system',
+    'system_administrator',
     expect.objectContaining({
       disposition: 'failure',
       errorType: 'workspace-already-configured',
@@ -936,7 +951,10 @@ test('restoring into a configured workspace fails', async () => {
   // restore that wipes the election already on the machine and then reports
   // failure has destroyed the very data it declined to replace.
   expect(listWorkspace(workspacePath)).toEqual(before);
-  using workspace = openWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
+  using workspace = openWorkspace(
+    workspacePath,
+    mockLogger({ fn: vi.fn, role: 'system_administrator' })
+  );
   const electionId = assertDefined(workspace.store.getCurrentElectionId());
   expect(workspace.store.getAllBallotImagePaths(electionId)).toHaveLength(1);
 });
@@ -947,7 +965,7 @@ test('a restore cancelled before it starts leaves the workspace alone', async ()
   await writeFile(join(workspacePath, 'stray-file'), 'left over from before');
   const contentsBefore = listWorkspace(workspacePath);
 
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   expect(
     await restoreBackup({
       backup: backup.path,
@@ -960,7 +978,7 @@ test('a restore cancelled before it starts leaves the workspace alone', async ()
   expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
   expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
     LogEventId.BackupRestoreComplete,
-    'system',
+    'system_administrator',
     expect.objectContaining({ disposition: 'failure', errorType: 'cancelled' })
   );
 });
@@ -983,7 +1001,7 @@ test('a restore cancelled while vetting the backup leaves the workspace alone', 
     await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       signal: controller.signal,
     })
   ).toEqual(err({ type: 'cancelled', message: 'Restore cancelled' }));
@@ -1001,7 +1019,7 @@ test('a restore cancelled between files empties the workspace it had claimed', a
     await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       signal: controller.signal,
       onProgressEvent(event) {
         // Abort once one file has landed, so files remain to be copied.
@@ -1027,7 +1045,7 @@ test('a restore cancelled partway through a file empties the workspace', async (
     await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       signal: controller.signal,
       // Low enough that even these small files report mid-copy progress.
       progressEventIntervalBytes: 1,
@@ -1054,7 +1072,7 @@ test('restore closes the workspace store instead of leaving it on a deleted data
   const backup = await makeBackup();
   const workspacePath = makeUnconfiguredWorkspacePath();
   const workspace = restorable(workspacePath);
-  const logger = mockBaseLogger({ fn: vi.fn });
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
 
   expect(
     await restoreBackup({ backup: backup.path, workspace, logger })
@@ -1083,7 +1101,7 @@ test('restore closes the workspace store even when it fails after claiming it', 
       await restoreBackup({
         backup: backup.path,
         workspace,
-        logger: mockBaseLogger({ fn: vi.fn }),
+        logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       })
     ).err()
   ).toMatchObject({ type: 'backup-verification-failed' });
@@ -1110,7 +1128,7 @@ test('restore refuses while a write transaction is open on the workspace', async
     await restoreBackup({
       backup: backup.path,
       workspace,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(
     err({
@@ -1139,7 +1157,7 @@ test('restore refuses a write in progress even in a workspace an interrupted res
       await restoreBackup({
         backup: backup.path,
         workspace,
-        logger: mockBaseLogger({ fn: vi.fn }),
+        logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       })
     ).err()
   ).toMatchObject({ type: 'write-in-progress' });
@@ -1158,7 +1176,7 @@ test('restore refuses a workspace belonging to a client machine', async () => {
     await restoreBackup({
       backup: backup.path,
       workspace,
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(
     err({

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -33,6 +33,7 @@ import {
   ADMIN_WORKSPACE_DATABASE_NAME,
   createWorkspace,
   openWorkspace,
+  Workspace,
 } from '../../util/workspace.js';
 import { createBackup } from '../create/index.js';
 import { Backup } from '../backup.js';
@@ -90,6 +91,14 @@ async function makeConfiguredWorkspacePath(): Promise<string> {
   using workspace = await makeConfiguredWorkspace();
   addCvrWithBallotImage(workspace, { ballotId: 'existing-ballot' });
   return workspace.path;
+}
+
+/**
+ * Opens a workspace for a restore to take over, as a running backend holds one
+ * open. `restoreBackup` closes it, so nothing here has to.
+ */
+function restorable(workspacePath: string): Workspace {
+  return createWorkspace(workspacePath, mockBaseLogger({ fn: vi.fn }));
 }
 
 /**
@@ -213,7 +222,7 @@ test('restore copies the database, ballot images, and election packages', async 
   expect(
     await restoreBackup({
       backup: created.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger,
       onProgressEvent: (event) => events.push(event),
     })
@@ -301,7 +310,7 @@ test('restore recreates workspace directories the backup has no files in', async
   expect(
     await restoreBackup({
       backup: created.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger,
     })
   ).toEqual(ok());
@@ -312,7 +321,7 @@ test('restore recreates workspace directories the backup has no files in', async
   );
 });
 
-test('restore resolves relative workspace and backup paths', async () => {
+test('restore resolves a relative backup path', async () => {
   const backup = await makeBackup();
   const workspacePath = makeUnconfiguredWorkspacePath();
   const logger = mockBaseLogger({ fn: vi.fn });
@@ -320,7 +329,7 @@ test('restore resolves relative workspace and backup paths', async () => {
   expect(
     await restoreBackup({
       backup: relative(process.cwd(), backup.path),
-      workspace: relative(process.cwd(), workspacePath),
+      workspace: restorable(workspacePath),
       logger,
     })
   ).toEqual(ok());
@@ -340,7 +349,7 @@ test('restore fails if there is no backup manifest', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -370,7 +379,7 @@ test('restore fails if the backup manifest is not readable', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -396,7 +405,7 @@ test('restore fails if the backup manifest version does not match', async () => 
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -431,7 +440,7 @@ test('restore fails if the backup manifest software version does not match', asy
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -463,7 +472,7 @@ test('restore warns but does not fail if the machine ID does not match', async (
   const logger = mockBaseLogger({ fn: vi.fn });
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger,
   });
 
@@ -521,7 +530,7 @@ test.each<{ description: string; tamper: (backup: Backup) => Promise<void> }>([
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -556,7 +565,7 @@ test('restore fails if a backup file cannot be read', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -585,7 +594,7 @@ test('restore fails on missing files from the backup manifest', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -610,7 +619,7 @@ test('restore fails if any backup files are an unexpected size', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -642,7 +651,7 @@ test('restore fails if any backup files have unexpected content (by hash)', asyn
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -687,7 +696,7 @@ test.each<{ description: string; makePath: (escapeTarget: string) => string }>([
     const workspacePath = makeUnconfiguredWorkspacePath();
     const result = await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger: mockBaseLogger({ fn: vi.fn }),
     });
 
@@ -722,7 +731,7 @@ test('restore refuses a manifest entry it does not know how to restore', async (
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -757,7 +766,7 @@ test('restore fails if there is no current election in the backup', async () => 
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -789,7 +798,7 @@ test('restore clears whatever an unconfigured workspace already holds', async ()
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger: mockBaseLogger({ fn: vi.fn }),
       onProgressEvent: (event) => events.push(event),
       // Low enough that even these small files report mid-copy progress.
@@ -824,7 +833,7 @@ test('an interrupted restore can be recovered by restoring again', async () => {
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger: mockBaseLogger({ fn: vi.fn }),
     })
   ).toEqual(ok());
@@ -840,7 +849,7 @@ test('an interrupted restore can be recovered by restoring again', async () => {
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger: mockBaseLogger({ fn: vi.fn }),
     })
   ).toEqual(ok());
@@ -857,7 +866,7 @@ test('restore refuses a backup the workspace volume cannot hold', async () => {
 
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
     minAvailableStorageBytes: 1024,
   });
@@ -884,7 +893,7 @@ test('restore fails if the restored files cannot be flushed to disk', async () =
 
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger: mockBaseLogger({ fn: vi.fn }),
   });
 
@@ -905,7 +914,7 @@ test('restoring into a configured workspace fails', async () => {
   const logger = mockBaseLogger({ fn: vi.fn });
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: workspacePath,
+    workspace: restorable(workspacePath),
     logger,
   });
 
@@ -941,7 +950,7 @@ test('a restore cancelled before it starts leaves the workspace alone', async ()
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger,
       signal: AbortSignal.abort(),
     })
@@ -972,7 +981,7 @@ test('a restore cancelled while vetting the backup leaves the workspace alone', 
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger: mockBaseLogger({ fn: vi.fn }),
       signal: controller.signal,
     })
@@ -990,7 +999,7 @@ test('a restore cancelled between files empties the workspace it had claimed', a
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger: mockBaseLogger({ fn: vi.fn }),
       signal: controller.signal,
       onProgressEvent(event) {
@@ -1016,7 +1025,7 @@ test('a restore cancelled partway through a file empties the workspace', async (
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: workspacePath,
+      workspace: restorable(workspacePath),
       logger: mockBaseLogger({ fn: vi.fn }),
       signal: controller.signal,
       // Low enough that even these small files report mid-copy progress.
@@ -1037,5 +1046,51 @@ test('a restore cancelled partway through a file empties the workspace', async (
     })
   ).toEqual(err({ type: 'cancelled', message: 'Restore cancelled' }));
 
+  expect(listWorkspace(workspacePath)).toEqual([]);
+});
+
+test('restore closes the workspace store instead of leaving it on a deleted database', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const workspace = restorable(workspacePath);
+  const logger = mockBaseLogger({ fn: vi.fn });
+
+  expect(
+    await restoreBackup({ backup: backup.path, workspace, logger })
+  ).toEqual(ok());
+
+  // Emptying the workspace unlinks the database this connection was opened on.
+  // Left open it would go on serving the file the restore replaced, and writes
+  // through it would land somewhere nothing will ever read again.
+  expect(() => workspace.store.getCurrentElectionId()).toThrow(
+    /database client .* is closed/
+  );
+
+  // What the restore put on disk is what the next connection finds.
+  using restored = openWorkspace(workspacePath, logger);
+  expect(restored.store.getCurrentElectionId()).toBeDefined();
+});
+
+test('restore closes the workspace store even when it fails after claiming it', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const workspace = restorable(workspacePath);
+  await rm(join(backup.path, 'workspace', ADMIN_WORKSPACE_DATABASE_NAME));
+
+  expect(
+    (
+      await restoreBackup({
+        backup: backup.path,
+        workspace,
+        logger: mockBaseLogger({ fn: vi.fn }),
+      })
+    ).err()
+  ).toMatchObject({ type: 'backup-verification-failed' });
+
+  // A failed restore empties the workspace too, so the connection is just as
+  // dead as after one that succeeded, and the caller is just as finished.
+  expect(() => workspace.store.getCurrentElectionId()).toThrow(
+    /database client .* is closed/
+  );
   expect(listWorkspace(workspacePath)).toEqual([]);
 });

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -203,101 +203,109 @@ async function replaceBackupFile(
   }));
 }
 
-test('restore copies the database, ballot images, and election packages', async () => {
-  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
-  using source = await makeConfiguredWorkspace();
-  addCvrWithBallotImage(source, { ballotId: 'ballot-1' });
-  addCvrWithBallotImage(source, { ballotId: 'ballot-2' });
+test(
+  'restore copies the database, ballot images, and election packages',
+  { timeout: 30_000 },
+  async () => {
+    const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
+    using source = await makeConfiguredWorkspace();
+    addCvrWithBallotImage(source, { ballotId: 'ballot-1' });
+    addCvrWithBallotImage(source, { ballotId: 'ballot-2' });
 
-  const electionId = source.store.getCurrentElectionId()!;
-  const sourceBallotImagePaths = source.store
-    .getAllBallotImagePaths(electionId)
-    .sort();
-  expect(sourceBallotImagePaths).toHaveLength(2);
-  const sourceElectionPackagePath =
-    source.store.getElectionPackageFilePath(electionId)!;
+    const electionId = source.store.getCurrentElectionId()!;
+    const sourceBallotImagePaths = source.store
+      .getAllBallotImagePaths(electionId)
+      .sort();
+    expect(sourceBallotImagePaths).toHaveLength(2);
+    const sourceElectionPackagePath =
+      source.store.getElectionPackageFilePath(electionId)!;
 
-  const created = (
-    await createBackup({
-      workspace: source,
-      target: makeTemporaryDirectory(),
-      logger,
-    })
-  ).unsafeUnwrap();
+    const created = (
+      await createBackup({
+        workspace: source,
+        target: makeTemporaryDirectory(),
+        logger,
+      })
+    ).unsafeUnwrap();
 
-  const workspacePath = makeUnconfiguredWorkspacePath();
-  const events: ProgressEvent[] = [];
-  expect(
-    await restoreBackup({
-      backup: created.path,
-      workspace: restorable(workspacePath),
-      logger,
-      onProgressEvent: (event) => events.push(event),
-    })
-  ).toEqual(ok());
+    const workspacePath = makeUnconfiguredWorkspacePath();
+    const events: ProgressEvent[] = [];
+    expect(
+      await restoreBackup({
+        backup: created.path,
+        workspace: restorable(workspacePath),
+        logger,
+        onProgressEvent: (event) => events.push(event),
+      })
+    ).toEqual(ok());
 
-  // Progress walks through the phases in order, and the copy events account
-  // for every file and byte the manifest promised.
-  expect(events[0]).toEqual({ type: 'preparing' });
-  expect(events.at(-2)).toEqual({ type: 'verifying' });
-  expect(events.at(-1)).toEqual({ type: 'flushing_workspace' });
-  const copyEvents = events.filter((event) => event.type === 'copy_files');
-  const manifest = await readBackupManifest(new Backup(created.path));
-  expect(copyEvents[0]).toMatchObject({ copiedCount: 0, copiedBytes: 0 });
-  expect(copyEvents.at(-1)).toEqual({
-    type: 'copy_files',
-    copiedCount: manifest.files.length,
-    totalCount: manifest.files.length,
-    copiedBytes: iter(manifest.files).sum(({ size }) => size),
-    totalBytes: iter(manifest.files).sum(({ size }) => size),
-  });
+    // Progress walks through the phases in order, and the copy events account
+    // for every file and byte the manifest promised.
+    expect(events[0]).toEqual({ type: 'preparing' });
+    expect(events.at(-2)).toEqual({ type: 'verifying' });
+    expect(events.at(-1)).toEqual({ type: 'flushing_workspace' });
+    const copyEvents = events.filter((event) => event.type === 'copy_files');
+    const manifest = await readBackupManifest(new Backup(created.path));
+    expect(copyEvents[0]).toMatchObject({ copiedCount: 0, copiedBytes: 0 });
+    expect(copyEvents.at(-1)).toEqual({
+      type: 'copy_files',
+      copiedCount: manifest.files.length,
+      totalCount: manifest.files.length,
+      copiedBytes: iter(manifest.files).sum(({ size }) => size),
+      totalBytes: iter(manifest.files).sum(({ size }) => size),
+    });
 
-  // Restoring replaces the machine's entire data state, so both the attempt
-  // and its outcome belong in the audit log.
-  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
-    LogEventId.BackupRestoreInit,
-    'system_administrator',
-    expect.objectContaining({ message: expect.stringContaining(created.path) })
-  );
-  expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
-    LogEventId.BackupRestoreComplete,
-    'system_administrator',
-    expect.objectContaining({ disposition: 'success' })
-  );
+    // Restoring replaces the machine's entire data state, so both the attempt
+    // and its outcome belong in the audit log.
+    expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+      LogEventId.BackupRestoreInit,
+      'system_administrator',
+      expect.objectContaining({
+        message: expect.stringContaining(created.path),
+      })
+    );
+    expect(vi.mocked(logger.log)).toHaveBeenCalledWith(
+      LogEventId.BackupRestoreComplete,
+      'system_administrator',
+      expect.objectContaining({ disposition: 'success' })
+    );
 
-  using restored = openWorkspace(workspacePath, logger);
+    using restored = openWorkspace(workspacePath, logger);
 
-  // The database came across whole: same election, same current election, same
-  // CVR data hanging off it.
-  expect(restored.store.getCurrentElectionId()).toEqual(electionId);
-  expect(restored.store.getElection(electionId)).toEqual(
-    source.store.getElection(electionId)
-  );
+    // The database came across whole: same election, same current election, same
+    // CVR data hanging off it.
+    expect(restored.store.getCurrentElectionId()).toEqual(electionId);
+    expect(restored.store.getElection(electionId)).toEqual(
+      source.store.getElection(electionId)
+    );
 
-  // Ballot images land at the same workspace-relative paths, with the same
-  // contents.
-  const restoredBallotImagePaths = restored.store
-    .getAllBallotImagePaths(electionId)
-    .sort();
-  expect(
-    restoredBallotImagePaths.map((path) => relative(restored.path, path))
-  ).toEqual(sourceBallotImagePaths.map((path) => relative(source.path, path)));
-  for (const [index, restoredPath] of restoredBallotImagePaths.entries()) {
-    expect(readFileSync(restoredPath)).toEqual(
-      readFileSync(sourceBallotImagePaths[index]!)
+    // Ballot images land at the same workspace-relative paths, with the same
+    // contents.
+    const restoredBallotImagePaths = restored.store
+      .getAllBallotImagePaths(electionId)
+      .sort();
+    expect(
+      restoredBallotImagePaths.map((path) => relative(restored.path, path))
+    ).toEqual(
+      sourceBallotImagePaths.map((path) => relative(source.path, path))
+    );
+    for (const [index, restoredPath] of restoredBallotImagePaths.entries()) {
+      expect(readFileSync(restoredPath)).toEqual(
+        readFileSync(sourceBallotImagePaths[index]!)
+      );
+    }
+
+    // As does the election package.
+    const restoredElectionPackagePath =
+      restored.store.getElectionPackageFilePath(electionId)!;
+    expect(relative(restored.path, restoredElectionPackagePath)).toEqual(
+      relative(source.path, sourceElectionPackagePath)
+    );
+    expect(readFileSync(restoredElectionPackagePath)).toEqual(
+      readFileSync(sourceElectionPackagePath)
     );
   }
-
-  // As does the election package.
-  const restoredElectionPackagePath =
-    restored.store.getElectionPackageFilePath(electionId)!;
-  expect(relative(restored.path, restoredElectionPackagePath)).toEqual(
-    relative(source.path, sourceElectionPackagePath)
-  );
-  expect(readFileSync(restoredElectionPackagePath)).toEqual(
-    readFileSync(sourceElectionPackagePath)
-  );
-});
+);
 
 test('restore recreates workspace directories the backup has no files in', async () => {
   const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -37,6 +37,7 @@ import {
 } from '../../util/workspace.js';
 import { createBackup } from '../create/index.js';
 import { Backup } from '../backup.js';
+import { FileBackedMachineModeController } from '../../machine_mode.js';
 import {
   BackupManifest,
   BACKUP_MANIFEST_VERSION,
@@ -1144,4 +1145,30 @@ test('restore refuses a write in progress even in a workspace an interrupted res
   ).toMatchObject({ type: 'write-in-progress' });
 
   workspace.store['client'].run('rollback');
+});
+
+test('restore refuses a workspace belonging to a client machine', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  FileBackedMachineModeController.forWorkspace(workspacePath).set('client');
+  const workspace = restorable(workspacePath);
+  const contentsBefore = listWorkspace(workspacePath);
+
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace,
+      logger: mockBaseLogger({ fn: vi.fn }),
+    })
+  ).toEqual(
+    err({
+      type: 'not-host-mode',
+      message:
+        'Only a VxAdmin in host mode can be backed up or restored, but this one is in client mode',
+    })
+  );
+
+  // Restoring would have emptied the workspace, taking the mode with it and
+  // silently turning a client machine into a host one.
+  expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
 });

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -1094,3 +1094,54 @@ test('restore closes the workspace store even when it fails after claiming it', 
   );
   expect(listWorkspace(workspacePath)).toEqual([]);
 });
+
+test('restore refuses while a write transaction is open on the workspace', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const workspace = restorable(workspacePath);
+  const contentsBefore = listWorkspace(workspacePath);
+
+  // What a CVR import looks like from here: it holds its transaction open
+  // across awaits for the whole import.
+  workspace.store['client'].run('begin transaction');
+
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace,
+      logger: mockBaseLogger({ fn: vi.fn }),
+    })
+  ).toEqual(
+    err({
+      type: 'write-in-progress',
+      message:
+        'Cannot restore while another operation is writing to the database',
+    })
+  );
+
+  // Refused before anything was claimed, so the write can carry on.
+  expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
+  workspace.store['client'].run('rollback');
+});
+
+test('restore refuses a write in progress even in a workspace an interrupted restore left', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  await writeFile(join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME), '');
+  const workspace = restorable(workspacePath);
+  workspace.store['client'].run('begin transaction');
+
+  // Recovering an interrupted restore is no reason to cut off a write that is
+  // happening right now.
+  expect(
+    (
+      await restoreBackup({
+        backup: backup.path,
+        workspace,
+        logger: mockBaseLogger({ fn: vi.fn }),
+      })
+    ).err()
+  ).toMatchObject({ type: 'write-in-progress' });
+
+  workspace.store['client'].run('rollback');
+});

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -28,6 +28,7 @@ import {
   makeBackup,
   makeConfiguredWorkspace,
   mockDiskSpace,
+  whileWriting,
 } from '../../../test/backup.js';
 import {
   ADMIN_WORKSPACE_DATABASE_NAME,
@@ -1120,16 +1121,14 @@ test('restore refuses while a write transaction is open on the workspace', async
   const workspace = restorable(workspacePath);
   const contentsBefore = listWorkspace(workspacePath);
 
-  // What a CVR import looks like from here: it holds its transaction open
-  // across awaits for the whole import.
-  workspace.store['client'].run('begin transaction');
-
   expect(
-    await restoreBackup({
-      backup: backup.path,
-      workspace,
-      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-    })
+    await whileWriting(workspace, () =>
+      restoreBackup({
+        backup: backup.path,
+        workspace,
+        logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+      })
+    )
   ).toEqual(
     err({
       type: 'write-in-progress',
@@ -1140,7 +1139,6 @@ test('restore refuses while a write transaction is open on the workspace', async
 
   // Refused before anything was claimed, so the write can carry on.
   expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
-  workspace.store['client'].run('rollback');
 });
 
 test('restore refuses a write in progress even in a workspace an interrupted restore left', async () => {
@@ -1148,21 +1146,20 @@ test('restore refuses a write in progress even in a workspace an interrupted res
   const workspacePath = makeUnconfiguredWorkspacePath();
   await writeFile(join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME), '');
   const workspace = restorable(workspacePath);
-  workspace.store['client'].run('begin transaction');
 
   // Recovering an interrupted restore is no reason to cut off a write that is
   // happening right now.
   expect(
     (
-      await restoreBackup({
-        backup: backup.path,
-        workspace,
-        logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-      })
+      await whileWriting(workspace, () =>
+        restoreBackup({
+          backup: backup.path,
+          workspace,
+          logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+        })
+      )
     ).err()
   ).toMatchObject({ type: 'write-in-progress' });
-
-  workspace.store['client'].run('rollback');
 });
 
 test('restore refuses a workspace belonging to a client machine', async () => {

--- a/apps/admin/backend/src/backup/restore/index.ts
+++ b/apps/admin/backend/src/backup/restore/index.ts
@@ -30,16 +30,20 @@ export { RESTORE_IN_PROGRESS_MARKER_FILENAME } from './prepare_step.js';
  * current election — unless a marker left by an interrupted restore shows that
  * the apparent configuration is half-restored debris, in which case the
  * restore is what recovers the workspace.
+ *
+ * Emptying the workspace means deleting the database out from under whoever
+ * opened it, so the workspace's store is closed first and is not reopened.
+ * Once the workspace has been claimed the caller is done with it whatever the
+ * outcome, since a failed restore empties it too: a machine has to restart, at
+ * which point it reads either the restored database or none at all.
  */
 export async function restoreBackup(
   rawOptions: RestoreBackupOptions
 ): Promise<Result<void, RestoreError>> {
-  // Resolve the caller-supplied paths up front, as `createBackup` does, so the
-  // workspace paths `openWorkspace` resolves and the paths we log and derive
-  // here agree.
+  // The workspace resolved its own path when it was opened; only the backup's
+  // needs resolving, as `createBackup` resolves its target.
   const options: RestoreBackupOptions = {
     ...rawOptions,
-    workspace: resolve(rawOptions.workspace),
     backup: resolve(rawOptions.backup),
   };
   const { logger } = options;
@@ -61,14 +65,14 @@ const CANCELLED_ERROR: RestoreError = {
 async function tryRestoreBackup(
   options: RestoreBackupOptions
 ): Promise<Result<void, RestoreError>> {
-  const { logger, onProgressEvent, signal } = options;
+  const { logger, onProgressEvent, signal, workspace } = options;
   onProgressEvent?.({ type: 'preparing' });
 
   if (signal?.aborted) {
     return err(CANCELLED_ERROR);
   }
 
-  const checkResult = checkWorkspaceIsRestorable(options.workspace, logger);
+  const checkResult = checkWorkspaceIsRestorable(workspace);
   if (checkResult.isErr()) {
     return checkResult;
   }
@@ -86,7 +90,7 @@ async function tryRestoreBackup(
   const manifest = vetResult.ok();
 
   const spaceResult = await checkWorkspaceHasSufficientSpace({
-    workspacePath: options.workspace,
+    workspacePath: workspace.path,
     manifest,
     minAvailableStorageBytes: options.minAvailableStorageBytes,
   });
@@ -101,13 +105,19 @@ async function tryRestoreBackup(
     return err(CANCELLED_ERROR);
   }
 
-  await claimWorkspace(options.workspace);
+  // The database file is about to be deleted, so the connection to it goes
+  // first. Held open, it would keep reading and writing the unlinked file: the
+  // restored database would land on disk while this connection went on serving
+  // the one it replaced.
+  workspace.store.close();
+
+  await claimWorkspace(workspace.path);
   let succeeded = false;
   try {
     const copyResult = await copyBackupFiles({
       backup,
       manifest,
-      workspacePath: options.workspace,
+      workspacePath: workspace.path,
       onProgressEvent,
       signal,
       progressEventIntervalBytes: options.progressEventIntervalBytes,
@@ -119,7 +129,7 @@ async function tryRestoreBackup(
     onProgressEvent?.({ type: 'verifying' });
     const verifyResult = verifyRestoredWorkspace({
       manifest,
-      workspacePath: options.workspace,
+      workspacePath: workspace.path,
       logger,
     });
     if (verifyResult.isErr()) {
@@ -130,14 +140,14 @@ async function tryRestoreBackup(
     // restore complete, which must not happen while the restored files live
     // only in the page cache.
     onProgressEvent?.({ type: 'flushing_workspace' });
-    const flushResult = await flushRestoredWorkspace(options.workspace);
+    const flushResult = await flushRestoredWorkspace(workspace.path);
     succeeded = flushResult.isOk();
     return flushResult;
   } finally {
     if (succeeded) {
-      await completeRestore(options.workspace);
+      await completeRestore(workspace.path);
     } else {
-      await abandonFailedRestore(options.workspace);
+      await abandonFailedRestore(workspace.path);
     }
   }
 }

--- a/apps/admin/backend/src/backup/restore/index.ts
+++ b/apps/admin/backend/src/backup/restore/index.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 import { err, Result } from '@votingworks/basics';
-import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { Logger, LogEventId } from '@votingworks/logging';
 import { copyBackupFiles } from './copy_step.js';
 import { openBackup, vetManifest } from './open_step.js';
 import {
@@ -47,11 +47,11 @@ export async function restoreBackup(
     backup: resolve(rawOptions.backup),
   };
   const { logger } = options;
-  logger.log(LogEventId.BackupRestoreInit, 'system', {
+  await logger.logAsCurrentRole(LogEventId.BackupRestoreInit, {
     message: `Restoring a backup from ${options.backup}…`,
   });
 
-  return logRestoreResult(logger, await tryRestoreBackup(options));
+  return await logRestoreResult(logger, await tryRestoreBackup(options));
 }
 
 /**
@@ -152,18 +152,18 @@ async function tryRestoreBackup(
   }
 }
 
-function logRestoreResult(
-  logger: BaseLogger,
+async function logRestoreResult(
+  logger: Logger,
   result: Result<void, RestoreError>
-): Result<void, RestoreError> {
+): Promise<Result<void, RestoreError>> {
   if (result.isOk()) {
-    logger.log(LogEventId.BackupRestoreComplete, 'system', {
+    await logger.logAsCurrentRole(LogEventId.BackupRestoreComplete, {
       disposition: 'success',
       message: 'Backup restored successfully.',
     });
   } else {
     const error = result.err();
-    logger.log(LogEventId.BackupRestoreComplete, 'system', {
+    await logger.logAsCurrentRole(LogEventId.BackupRestoreComplete, {
       disposition: 'failure',
       errorType: error.type,
       message: `Failed to restore backup: ${error.message}`,

--- a/apps/admin/backend/src/backup/restore/open_step.ts
+++ b/apps/admin/backend/src/backup/restore/open_step.ts
@@ -1,5 +1,5 @@
 import { err, ok, Result, throwIllegalValue } from '@votingworks/basics';
-import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { Logger, LogEventId } from '@votingworks/logging';
 import { LATEST_SOFTWARE_VERSION } from '@votingworks/types';
 import { getMachineConfig } from '../../machine_config.js';
 import { AuthenticatedBackup } from '../authenticated_backup.js';
@@ -37,7 +37,7 @@ export async function openBackup(
  */
 export async function vetManifest(
   backup: AuthenticatedBackup,
-  logger: BaseLogger
+  logger: Logger
 ): Promise<Result<BackupManifest, RestoreError>> {
   const readManifestResult = await backup.readManifest();
 
@@ -79,7 +79,7 @@ export async function vetManifest(
 
   const { machineId } = getMachineConfig();
   if (manifest.machineId !== machineId) {
-    logger.log(LogEventId.BackupRestoreMachineMismatch, 'system', {
+    await logger.logAsCurrentRole(LogEventId.BackupRestoreMachineMismatch, {
       backupManifestMachineId: manifest.machineId,
       machineId,
       message: `Backup was created by ${manifest.machineId} which does not match ${machineId}`,

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -4,8 +4,7 @@ import { join } from 'node:path';
 import { emptydir } from 'fs-extra';
 import { err, iter, ok, Result } from '@votingworks/basics';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
-import { BaseLogger } from '@votingworks/logging';
-import { createWorkspace } from '../../util/workspace.js';
+import { Workspace } from '../../util/workspace.js';
 import { BackupManifest } from '../backup_manifest.js';
 import { RestoreError } from './types.js';
 
@@ -28,14 +27,12 @@ function getMarkerPath(workspacePath: string): string {
  * which case the restore is what recovers it.
  */
 export function checkWorkspaceIsRestorable(
-  workspacePath: string,
-  logger: BaseLogger
+  workspace: Workspace
 ): Result<void, RestoreError> {
-  if (existsSync(getMarkerPath(workspacePath))) {
+  if (existsSync(getMarkerPath(workspace.path))) {
     return ok();
   }
 
-  using workspace = createWorkspace(workspacePath, logger);
   const currentElectionId = workspace.store.getCurrentElectionId();
   if (currentElectionId) {
     return err({

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -6,6 +6,7 @@ import { err, iter, ok, Result } from '@votingworks/basics';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
 import { Workspace } from '../../util/workspace.js';
 import { BackupManifest } from '../backup_manifest.js';
+import { checkWorkspaceIsHostMode } from '../host_mode.js';
 import { RestoreError } from './types.js';
 
 const DEFAULT_MIN_AVAILABLE_STORAGE_BYTES = 50_000_000; // 50 MB
@@ -22,13 +23,19 @@ function getMarkerPath(workspacePath: string): string {
 }
 
 /**
- * Checks that the workspace is one a restore may take over: not being written
- * to, and either unconfigured or left behind by an interrupted restore (per
- * the marker), in which case the restore is what recovers it.
+ * Checks that the workspace is one a restore may take over: a host machine's,
+ * not being written to, and either unconfigured or left behind by an
+ * interrupted restore (per the marker), in which case the restore is what
+ * recovers it.
  */
 export function checkWorkspaceIsRestorable(
   workspace: Workspace
 ): Result<void, RestoreError> {
+  const hostModeResult = checkWorkspaceIsHostMode(workspace);
+  if (hostModeResult.isErr()) {
+    return hostModeResult;
+  }
+
   // The restore closes this connection and deletes the database under it, so
   // an operation partway through writing would be cut off mid-transaction with
   // no way to tell whether its work survived. Checked before the marker, since

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -22,13 +22,26 @@ function getMarkerPath(workspacePath: string): string {
 }
 
 /**
- * Checks that the workspace is one a restore may take over: either
- * unconfigured, or left behind by an interrupted restore (per the marker), in
- * which case the restore is what recovers it.
+ * Checks that the workspace is one a restore may take over: not being written
+ * to, and either unconfigured or left behind by an interrupted restore (per
+ * the marker), in which case the restore is what recovers it.
  */
 export function checkWorkspaceIsRestorable(
   workspace: Workspace
 ): Result<void, RestoreError> {
+  // The restore closes this connection and deletes the database under it, so
+  // an operation partway through writing would be cut off mid-transaction with
+  // no way to tell whether its work survived. Checked before the marker, since
+  // a workspace left by an interrupted restore is no reason to cut off a write
+  // that is happening right now.
+  if (workspace.store['client'].isInTransaction()) {
+    return err({
+      type: 'write-in-progress',
+      message:
+        'Cannot restore while another operation is writing to the database',
+    });
+  }
+
   if (existsSync(getMarkerPath(workspace.path))) {
     return ok();
   }

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -41,7 +41,7 @@ export function checkWorkspaceIsRestorable(
   // no way to tell whether its work survived. Checked before the marker, since
   // a workspace left by an interrupted restore is no reason to cut off a write
   // that is happening right now.
-  if (workspace.store['client'].isInTransaction()) {
+  if (workspace.store.isInTransaction()) {
     return err({
       type: 'write-in-progress',
       message:

--- a/apps/admin/backend/src/backup/restore/types.ts
+++ b/apps/admin/backend/src/backup/restore/types.ts
@@ -8,6 +8,7 @@ export type RestoreError =
   | { type: 'cancelled'; message: string }
   | { type: 'workspace-already-configured'; message: string }
   | { type: 'write-in-progress'; message: string }
+  | { type: 'not-host-mode'; message: string }
   | { type: 'backup-read-failed'; message: string }
   | { type: 'backup-authentication-failed'; message: string }
   | { type: 'backup-verification-failed'; message: string }

--- a/apps/admin/backend/src/backup/restore/types.ts
+++ b/apps/admin/backend/src/backup/restore/types.ts
@@ -1,3 +1,4 @@
+import { Workspace } from '../../util/workspace.js';
 import { ProgressTracking } from '../progress.js';
 
 /**
@@ -29,13 +30,18 @@ export interface RestoreBackupOptions extends ProgressTracking {
   backup: string;
 
   /**
-   * The workspace directory into which the backup should be restored. Its
-   * contents belong to the restore: whatever it holds is emptied before
-   * copying begins, so it must not contain anything worth keeping. A workspace
-   * whose database is already configured with an election is refused rather
-   * than cleared.
+   * The workspace into which the backup should be restored, with an
+   * already-open client for the database. Its contents belong to the restore:
+   * whatever it holds is emptied before copying begins, so it must not contain
+   * anything worth keeping. A workspace whose database is already configured
+   * with an election is refused rather than cleared.
+   *
+   * The restore closes this workspace's store on its way to emptying the
+   * directory, and does not reopen it. Whatever holds the workspace must be
+   * finished with it: on a machine this means restarting, since the process
+   * kept running would be reading a database file that no longer exists.
    */
-  workspace: string;
+  workspace: Workspace;
 
   /**
    * How many bytes must remain available on the workspace's volume after the

--- a/apps/admin/backend/src/backup/restore/types.ts
+++ b/apps/admin/backend/src/backup/restore/types.ts
@@ -7,6 +7,7 @@ import { ProgressTracking } from '../progress.js';
 export type RestoreError =
   | { type: 'cancelled'; message: string }
   | { type: 'workspace-already-configured'; message: string }
+  | { type: 'write-in-progress'; message: string }
   | { type: 'backup-read-failed'; message: string }
   | { type: 'backup-authentication-failed'; message: string }
   | { type: 'backup-verification-failed'; message: string }

--- a/apps/admin/backend/src/backup/restore/verify_step.ts
+++ b/apps/admin/backend/src/backup/restore/verify_step.ts
@@ -1,6 +1,6 @@
 import { err, ok, Result } from '@votingworks/basics';
 import { syncFilesystem } from '@votingworks/fs';
-import { BaseLogger } from '@votingworks/logging';
+import { Logger } from '@votingworks/logging';
 import { createWorkspace } from '../../util/workspace.js';
 import { BackupManifest } from '../backup_manifest.js';
 import { RestoreError } from './types.js';
@@ -17,7 +17,7 @@ export function verifyRestoredWorkspace({
 }: {
   manifest: BackupManifest;
   workspacePath: string;
-  logger: BaseLogger;
+  logger: Logger;
 }): Result<void, RestoreError> {
   // A manifest lists only files, so a backup carries no record of workspace
   // directories that were empty (e.g. `ballot-images` before any CVRs are

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -15,7 +15,12 @@ import {
   unique,
   deepEqual,
 } from '@votingworks/basics';
-import { Bindable, Client as DbClient, Statement } from '@votingworks/db';
+import {
+  BackupError,
+  Bindable,
+  Client as DbClient,
+  Statement,
+} from '@votingworks/db';
 import {
   AdjudicationReason,
   Contest,
@@ -233,6 +238,32 @@ export class Store implements BaseStore {
       ballotImagesPath,
       electionPackagesPath
     );
+  }
+
+  /**
+   * Whether this store is partway through a write. A CVR import holds its
+   * transaction open across awaits for the whole import, so this is how an
+   * operation that would disturb the database — backing it up, or replacing it
+   * with a restore — tells that it has to wait.
+   */
+  isInTransaction(): boolean {
+    return this.client.isInTransaction();
+  }
+
+  /**
+   * Writes a snapshot of this store's database to `path`, which must not
+   * already name a file. Taken over this store's own connection, so writes
+   * made through it while the snapshot runs are part of the snapshot rather
+   * than a reason to start it over.
+   *
+   * See {@link Client.backup} for what a caller has to handle: a write already
+   * in progress, and a snapshot stopped by `signal`.
+   */
+  backupTo(
+    path: string,
+    options?: { onProgress?: (fraction: number) => void; signal?: AbortSignal }
+  ): Promise<Result<void, BackupError>> {
+    return this.client.backup(path, options);
   }
 
   /**

--- a/apps/admin/backend/test/backup.ts
+++ b/apps/admin/backend/test/backup.ts
@@ -174,3 +174,22 @@ export async function makeBackup(): Promise<Backup> {
   ).unsafeUnwrap();
   return new Backup(created.path);
 }
+
+/**
+ * Runs `fn` while a write transaction is held open on `workspace`'s database,
+ * standing in for a CVR import, which holds one open across awaits for the
+ * whole import. Reaches past the store for the client because nothing else
+ * can open a transaction and leave it open, which is the state under test.
+ */
+export async function whileWriting<T>(
+  workspace: Workspace,
+  fn: () => Promise<T>
+): Promise<T> {
+  const dbClient = workspace.store['client'];
+  dbClient.run('begin transaction');
+  try {
+    return await fn();
+  } finally {
+    dbClient.run('rollback');
+  }
+}

--- a/apps/admin/backend/test/backup.ts
+++ b/apps/admin/backend/test/backup.ts
@@ -8,7 +8,7 @@ import {
 } from '@votingworks/fixtures';
 import { assertDefined } from '@votingworks/basics';
 import { DEFAULT_SYSTEM_SETTINGS, Id } from '@votingworks/types';
-import { BaseLogger, LogSource, mockBaseLogger } from '@votingworks/logging';
+import { BaseLogger, LogSource, mockLogger } from '@votingworks/logging';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
 import { createWorkspace, Workspace } from '../src/util/workspace.js';
 import { createBackup } from '../src/backup/create/index.js';
@@ -169,7 +169,7 @@ export async function makeBackup(): Promise<Backup> {
     await createBackup({
       workspace: source,
       target: makeTemporaryDirectory(),
-      logger: mockBaseLogger({ fn: vi.fn }),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).unsafeUnwrap();
   return new Backup(created.path);

--- a/libs/db/src/backup_cancelled_error.ts
+++ b/libs/db/src/backup_cancelled_error.ts
@@ -1,0 +1,7 @@
+/**
+ * Thrown from a snapshot's progress callback to stop it partway, which is the
+ * only way `better-sqlite3` offers to abort one: it closes the backup and
+ * rejects when the callback throws. Never escapes {@link Client.backup}, which
+ * reports a stopped snapshot as a `cancelled` result.
+ */
+export class BackupCancelledError extends Error {}

--- a/libs/db/src/client.test.ts
+++ b/libs/db/src/client.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, expect, test, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
 import { SqliteError } from 'better-sqlite3';
 import * as fs from 'node:fs';
 import { basename, dirname, join } from 'node:path';
-import { makeTemporaryFile } from '@votingworks/fixtures';
+import { err, ok, typedAs } from '@votingworks/basics';
+import {
+  makeTemporaryDirectory,
+  makeTemporaryFile,
+} from '@votingworks/fixtures';
 import { mockBaseLogger } from '@votingworks/logging';
-import { Client, DbConnectionOptions, Statement } from './client';
+import { BackupError, Client, DbConnectionOptions, Statement } from './client';
 import { SchemaDigestMismatchError } from './schema_digest_mismatch_error';
 
 afterEach(() => {
@@ -27,7 +32,7 @@ test('file database client', async () => {
   client.run('insert into muppets (name) values (?)', 'Fozzie');
 
   const backupDbFile = makeTemporaryFile();
-  await client.backup(backupDbFile);
+  expect(await client.backup(backupDbFile)).toEqual(ok());
 
   const clientForBackup = Client.fileClient(
     backupDbFile,
@@ -56,7 +61,7 @@ test('backs up a database whose connection is not yet established', async () => 
   // here to touch the database.
   const client = Client.fileClient(dbFile, mockBaseLogger({ fn: vi.fn }));
   const backupDbFile = makeTemporaryFile();
-  await client.backup(backupDbFile);
+  expect(await client.backup(backupDbFile)).toEqual(ok());
 
   const clientForBackup = Client.fileClient(
     backupDbFile,
@@ -75,7 +80,7 @@ test('backs up a memory database', async () => {
   client.run('insert into muppets (name) values (?)', 'Rizzo');
 
   const backupDbFile = makeTemporaryFile();
-  await client.backup(backupDbFile);
+  expect(await client.backup(backupDbFile)).toEqual(ok());
 
   const clientForBackup = Client.fileClient(
     backupDbFile,
@@ -759,4 +764,118 @@ test('vacuuming reduces file size', () => {
 
   // vacuuming reduces the file size
   expect(postDeleteSize).toBeGreaterThan(postVacuumSize);
+});
+
+/**
+ * A path for a snapshot to be written to. Not `makeTemporaryFile`, which
+ * creates the file: a destination SQLite did not create is one it does not
+ * remove when it refuses to copy.
+ */
+function makeSnapshotPath(): string {
+  return join(makeTemporaryDirectory(), 'snapshot.db');
+}
+
+/**
+ * Builds a client whose database takes several steps to copy, so that a
+ * snapshot of it reports progress more than once and can be stopped partway.
+ */
+function makeClientWithLargeDatabase(): Client {
+  const client = Client.fileClient(
+    makeTemporaryFile(),
+    mockBaseLogger({ fn: vi.fn })
+  );
+  client.exec('create table blobs (data blob not null)');
+  for (let i = 0; i < 200; i += 1) {
+    client.run('insert into blobs (data) values (?)', Buffer.alloc(64 * 1024));
+  }
+  return client;
+}
+
+test('backup reports how much of the database it has copied', async () => {
+  const client = makeClientWithLargeDatabase();
+  const fractions: number[] = [];
+
+  expect(
+    await client.backup(makeSnapshotPath(), {
+      onProgress: (fraction) => fractions.push(fraction),
+    })
+  ).toEqual(ok());
+
+  expect(fractions.length).toBeGreaterThan(1);
+  expect(fractions.every((f) => f >= 0 && f <= 1)).toEqual(true);
+  expect(fractions).toEqual([...fractions].sort((a, b) => a - b));
+  expect(fractions.at(-1)).toEqual(1);
+});
+
+test('backup refuses while this connection is partway through writing', async () => {
+  const client = Client.memoryClient();
+  client.exec('create table muppets (name varchar(255) not null)');
+  client.run('begin transaction');
+
+  // SQLite will not copy a page while a write transaction is open on the
+  // connection running the copy, and `better-sqlite3` reports that refusal as
+  // a copy that finished with nothing left to do.
+  expect(await client.backup(makeSnapshotPath())).toEqual(
+    err(typedAs<BackupError>({ type: 'write-in-progress' }))
+  );
+
+  client.run('rollback');
+});
+
+test('backup catches a write that begins after it checks', async () => {
+  const client = makeClientWithLargeDatabase();
+  const backupDbFile = makeSnapshotPath();
+
+  // Slip the write in after the check, to stand in for the window between it
+  // and the copy starting. It takes a real write, not just an open
+  // transaction, for SQLite to hold the write lock that makes the copy a
+  // no-op — which it reports by deleting the destination and claiming success.
+  vi.spyOn(client, 'isInTransaction').mockImplementationOnce(() => {
+    client.run('begin transaction');
+    client.run('insert into blobs (data) values (?)', Buffer.alloc(1));
+    return false;
+  });
+
+  expect(await client.backup(backupDbFile)).toEqual(
+    err(typedAs<BackupError>({ type: 'write-in-progress' }))
+  );
+  expect(fs.existsSync(backupDbFile)).toEqual(false);
+
+  client.run('rollback');
+});
+
+test('backup does not start once its signal has aborted', async () => {
+  const client = makeClientWithLargeDatabase();
+  const backupDbFile = makeSnapshotPath();
+
+  expect(
+    await client.backup(backupDbFile, { signal: AbortSignal.abort() })
+  ).toEqual(err(typedAs<BackupError>({ type: 'cancelled' })));
+
+  expect(fs.existsSync(backupDbFile)).toEqual(false);
+});
+
+test('backup stopped partway leaves no partial snapshot', async () => {
+  const client = makeClientWithLargeDatabase();
+  const backupDbFile = makeSnapshotPath();
+  const controller = new AbortController();
+
+  expect(
+    await client.backup(backupDbFile, {
+      signal: controller.signal,
+      onProgress: () => controller.abort(),
+    })
+  ).toEqual(err(typedAs<BackupError>({ type: 'cancelled' })));
+
+  // Half a database is not something anyone should find where a snapshot was
+  // asked for.
+  expect(fs.existsSync(backupDbFile)).toEqual(false);
+});
+
+test('backup surfaces a failure that is not a refusal or a cancellation', async () => {
+  const client = makeClientWithLargeDatabase();
+
+  await expect(
+    client.backup(join(makeTemporaryDirectory(), 'no-such-dir', 'snapshot.db'))
+  ).rejects.toThrow('directory does not exist');
 });

--- a/libs/db/src/client.ts
+++ b/libs/db/src/client.ts
@@ -1,4 +1,4 @@
-import { assert } from '@votingworks/basics';
+import { assert, err, ok, Result } from '@votingworks/basics';
 import { BaseLogger, LogEventId, LogSource } from '@votingworks/logging';
 import {
   isIntegrationTest,
@@ -12,6 +12,7 @@ import makeDebug from 'debug';
 import * as fs from 'node:fs';
 import Database from 'better-sqlite3';
 import { dirname, join } from 'node:path';
+import { BackupCancelledError } from './backup_cancelled_error';
 import { SchemaDigestMismatchError } from './schema_digest_mismatch_error';
 import { findSchemaViolations } from './schema_validation';
 
@@ -20,6 +21,11 @@ type Database = Database.Database;
 const debug = makeDebug('db-client');
 
 const MEMORY_DB_PATH = ':memory:';
+
+/**
+ * Why {@link Client.backup} did not produce a snapshot.
+ */
+export type BackupError = { type: 'write-in-progress' } | { type: 'cancelled' };
 
 /**
  * Table holding the digest of the schema the database was created with. It is
@@ -632,13 +638,83 @@ export class Client {
   }
 
   /**
-   * Writes a copy of the database to the given path.
+   * Writes a copy of the database to the given path, taken while the database
+   * goes on being used: pages written through this connection while the copy
+   * runs are picked up by it, so the result is a consistent snapshot rather
+   * than a file smeared across the time it took to write.
+   *
+   * That only holds for writes made through *this* connection. A write from
+   * another one takes SQLite's write lock and restarts the copy from the
+   * beginning, which for a database of any size never finishes; a write
+   * already in progress is reported as `write-in-progress` rather than waited
+   * on. SQLite reports a copy it refused to start as one that finished with
+   * nothing left to do, removing the destination on its way out, so a write
+   * that begins in the moment between the check and the copy is caught after
+   * the fact and reported the same way. That is why `filePath` must not
+   * already name a file: a destination SQLite did not create is one it does
+   * not remove, leaving a refusal indistinguishable from a snapshot.
+   *
+   * Pass `onProgress` to hear how much of the database has been copied, as a
+   * fraction. Pass `signal` to stop partway. A snapshot that stops for any
+   * reason leaves no file behind, so nothing partial is left to be mistaken
+   * for a copy of the database.
    */
   async backup(
     filePath: string,
-    options?: Parameters<Database['backup']>[1]
-  ): Promise<void> {
-    await this.getDatabase().backup(filePath, options);
+    options: {
+      onProgress?: (fraction: number) => void;
+      signal?: AbortSignal;
+    } = {}
+  ): Promise<Result<void, BackupError>> {
+    const { onProgress, signal } = options;
+
+    if (signal?.aborted) {
+      return err({ type: 'cancelled' });
+    }
+
+    // A copy cannot start while this connection is partway through writing,
+    // and `better-sqlite3` reports that refusal as a copy that succeeded
+    // without doing anything.
+    if (this.isInTransaction()) {
+      return err({ type: 'write-in-progress' });
+    }
+
+    try {
+      await this.getDatabase().backup(filePath, {
+        progress({ totalPages, remainingPages }) {
+          if (signal?.aborted) {
+            // The only way to stop a copy partway: `better-sqlite3` closes it
+            // and rejects when its progress callback throws.
+            throw new BackupCancelledError();
+          }
+
+          onProgress?.((totalPages - remainingPages) / totalPages);
+
+          // The return type says a number, but that is only for a caller
+          // choosing the next chunk's size; `undefined` leaves it to
+          // `better-sqlite3`.
+          return undefined as unknown as number;
+        },
+      });
+    } catch (error) {
+      if (error instanceof BackupCancelledError) {
+        fs.rmSync(filePath, { force: true });
+        return err({ type: 'cancelled' });
+      }
+
+      throw error;
+    }
+
+    if (!fs.existsSync(filePath)) {
+      return err({ type: 'write-in-progress' });
+    }
+
+    // The copy resolves once nothing is left to send without calling the
+    // progress callback again, so the last thing a caller hears about is a
+    // fraction just short of the whole database.
+    onProgress?.(1);
+
+    return ok();
   }
 
   /**

--- a/libs/db/src/index.ts
+++ b/libs/db/src/index.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+export * from './backup_cancelled_error';
 export * from './client';
 export * from './schema_digest_mismatch_error';
 export * from './schema_validation';


### PR DESCRIPTION
## Overview

Refs #7897 

Best reviewed by commit since there isn't really an overarching theme to the changes. One important assumption that is implied by a849f46: after a restore completes we should prompt the user to restart the machine—and it'd be the only option we give them. It's possible that we could make everything work with a reopen of the sqlite database, but we'd need to make sure everything handles that okay and isn't holding on to an old version of the client. There are a number of places that perform various operations at startup that wouldn't happen automatically after a restore. So for now the safest option is to just restart after a restore.

## Testing Plan
New automated tests.