### PR TITLE
Stop exempting `@votingworks/types` from no-import-workspace-subfolders

### DIFF
--- a/apps/admin/frontend/src/screens/tally/cvrs_state.ts
+++ b/apps/admin/frontend/src/screens/tally/cvrs_state.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
-import { Id, PollingPlace } from '@votingworks/types/src';
+import { Id, PollingPlace } from '@votingworks/types';
 import { assertDefined } from '@votingworks/basics';
 
 import * as api from '../../api.js';

--- a/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_cvrs_panel.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { pollingPlaceTypeName } from '@votingworks/types/src';
+import { pollingPlaceTypeName } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../test/react_testing_library.js';
 import { LocationCvrsPanel } from './location_cvrs_panel.js';

--- a/apps/admin/frontend/src/screens/tally/location_import_card.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_import_card.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-regex-literals */
 import { expect, test, vi } from 'vitest';
 
-import { pollingPlaceTypeName } from '@votingworks/types/src';
+import { pollingPlaceTypeName } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 
 import { render, screen } from '../../../test/react_testing_library.js';

--- a/apps/admin/frontend/src/screens/tally/location_list.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_list.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { PollingPlace } from '@votingworks/types/src';
+import { PollingPlace } from '@votingworks/types';
 import { CastVoteRecordFileRecord } from '@votingworks/admin-backend';
 import userEvent from '@testing-library/user-event';
 

--- a/apps/admin/frontend/src/screens/tally/location_status_card.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/location_status_card.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { pollingPlaceTypeName } from '@votingworks/types/src';
+import { pollingPlaceTypeName } from '@votingworks/types';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../test/react_testing_library.js';
 import { LocationStatusCard } from './location_status_card.js';

--- a/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
@@ -28,7 +28,7 @@ const rule: TSESLint.RuleModule<'noImportSubfolders', readonly unknown[]> =
           assert(typeof importSource === 'string');
           if (importSource.startsWith(VOTINGWORKS_WORKSPACE_PREFIX)) {
             const folders = importSource.split('/');
-            if (folders.length > 2 && folders[1] !== 'types') {
+            if (folders.length > 2) {
               context.report({
                 node,
                 messageId: 'noImportSubfolders',

--- a/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
+++ b/libs/eslint-plugin-vx/src/rules/no_import_workspace_subfolders.ts
@@ -4,45 +4,57 @@ import { createRule } from '../util';
 
 const VOTINGWORKS_WORKSPACE_PREFIX = '@votingworks';
 
-const rule: TSESLint.RuleModule<'noImportSubfolders', readonly unknown[]> =
-  createRule({
-    name: 'no-import-workspace-subfolders',
-    meta: {
-      docs: {
-        description:
-          'When importing libraries from the VotingWorks workspace, do not include subfolders like /src in the import',
-      },
-      fixable: 'code',
-      messages: {
-        noImportSubfolders: 'Do not import subfolders of the target library.',
-      },
-      schema: [],
-      type: 'problem',
+const rule: TSESLint.RuleModule<
+  'noImportSubfolders' | 'importEntryPoint',
+  readonly unknown[]
+> = createRule({
+  name: 'no-import-workspace-subfolders',
+  meta: {
+    docs: {
+      description:
+        'When importing libraries from the VotingWorks workspace, do not include subfolders like /src in the import',
     },
-    defaultOptions: [],
+    // Offered as a suggestion rather than a fix: rewriting the specifier to
+    // the package entry point is only correct when that entry point exports
+    // every name being imported, which the rule cannot check. Applied
+    // blindly by `--fix` it can break the build, or silently widen a
+    // deliberately narrow import back to the whole package.
+    hasSuggestions: true,
+    messages: {
+      noImportSubfolders: 'Do not import subfolders of the target library.',
+      importEntryPoint: "Import from '{{packageName}}' instead.",
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
 
-    create(context) {
-      return {
-        ImportDeclaration(node: TSESTree.ImportDeclaration) {
-          const importSource = node.source.value;
-          assert(typeof importSource === 'string');
-          if (importSource.startsWith(VOTINGWORKS_WORKSPACE_PREFIX)) {
-            const folders = importSource.split('/');
-            if (folders.length > 2) {
-              context.report({
-                node,
-                messageId: 'noImportSubfolders',
-                fix: (fixer) =>
-                  fixer.replaceText(
-                    node.source,
-                    `'${folders[0]}/${folders[1]}'`
-                  ),
-              });
-            }
+  create(context) {
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const importSource = node.source.value;
+        assert(typeof importSource === 'string');
+        if (importSource.startsWith(VOTINGWORKS_WORKSPACE_PREFIX)) {
+          const folders = importSource.split('/');
+          if (folders.length > 2) {
+            const packageName = `${folders[0]}/${folders[1]}`;
+            context.report({
+              node,
+              messageId: 'noImportSubfolders',
+              suggest: [
+                {
+                  messageId: 'importEntryPoint',
+                  data: { packageName },
+                  fix: (fixer) =>
+                    fixer.replaceText(node.source, `'${packageName}'`),
+                },
+              ],
+            });
           }
-        },
-      };
-    },
-  });
+        }
+      },
+    };
+  },
+});
 
 export default rule;

--- a/libs/eslint-plugin-vx/tests/rules/no_import_workspace_subfolders.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_import_workspace_subfolders.test.ts
@@ -35,15 +35,6 @@ ruleTester.run('no-import-workspace-subfolders', rule, {
     {
       code: `import * as a from 'random/library/with/many/slashes'`,
     },
-    {
-      code: `import a from '@votingworks/types/something/else'`,
-    },
-    {
-      code: `import { a } from '@votingworks/types/api/services/scan'`,
-    },
-    {
-      code: `import * as a from '@votingworks/types/a/bunch/of/folders'`,
-    },
   ],
   invalid: [
     {
@@ -74,6 +65,11 @@ ruleTester.run('no-import-workspace-subfolders', rule, {
     {
       code: `import * as a from '@votingworks/something/src/utils'`,
       output: `import * as a from '@votingworks/something'`,
+      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+    },
+    {
+      code: `import { a } from '@votingworks/types/src'`,
+      output: `import { a } from '@votingworks/types'`,
       errors: [{ messageId: 'noImportSubfolders', line: 1 }],
     },
   ],

--- a/libs/eslint-plugin-vx/tests/rules/no_import_workspace_subfolders.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/no_import_workspace_subfolders.test.ts
@@ -39,38 +39,115 @@ ruleTester.run('no-import-workspace-subfolders', rule, {
   invalid: [
     {
       code: `import a from '@votingworks/something/src'`,
-      output: `import a from '@votingworks/something'`,
-      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+      errors: [
+        {
+          messageId: 'noImportSubfolders',
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'importEntryPoint',
+              data: { packageName: '@votingworks/something' },
+              output: `import a from '@votingworks/something'`,
+            },
+          ],
+        },
+      ],
     },
     {
       code: `import { a } from '@votingworks/something/src'`,
-      output: `import { a } from '@votingworks/something'`,
-      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+      errors: [
+        {
+          messageId: 'noImportSubfolders',
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'importEntryPoint',
+              data: { packageName: '@votingworks/something' },
+              output: `import { a } from '@votingworks/something'`,
+            },
+          ],
+        },
+      ],
     },
     {
       code: `import * as a from '@votingworks/something/src'`,
-      output: `import * as a from '@votingworks/something'`,
-      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+      errors: [
+        {
+          messageId: 'noImportSubfolders',
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'importEntryPoint',
+              data: { packageName: '@votingworks/something' },
+              output: `import * as a from '@votingworks/something'`,
+            },
+          ],
+        },
+      ],
     },
     {
       code: `import a from '@votingworks/something/utils'`,
-      output: `import a from '@votingworks/something'`,
-      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+      errors: [
+        {
+          messageId: 'noImportSubfolders',
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'importEntryPoint',
+              data: { packageName: '@votingworks/something' },
+              output: `import a from '@votingworks/something'`,
+            },
+          ],
+        },
+      ],
     },
     {
       code: `import { a } from '@votingworks/something/src/utils/lib'`,
-      output: `import { a } from '@votingworks/something'`,
-      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+      errors: [
+        {
+          messageId: 'noImportSubfolders',
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'importEntryPoint',
+              data: { packageName: '@votingworks/something' },
+              output: `import { a } from '@votingworks/something'`,
+            },
+          ],
+        },
+      ],
     },
     {
       code: `import * as a from '@votingworks/something/src/utils'`,
-      output: `import * as a from '@votingworks/something'`,
-      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+      errors: [
+        {
+          messageId: 'noImportSubfolders',
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'importEntryPoint',
+              data: { packageName: '@votingworks/something' },
+              output: `import * as a from '@votingworks/something'`,
+            },
+          ],
+        },
+      ],
     },
     {
       code: `import { a } from '@votingworks/types/src'`,
-      output: `import { a } from '@votingworks/types'`,
-      errors: [{ messageId: 'noImportSubfolders', line: 1 }],
+      errors: [
+        {
+          messageId: 'noImportSubfolders',
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'importEntryPoint',
+              data: { packageName: '@votingworks/types' },
+              output: `import { a } from '@votingworks/types'`,
+            },
+          ],
+        },
+      ],
     },
   ],
 });

--- a/libs/ui/src/smart_cards_screen.test.tsx
+++ b/libs/ui/src/smart_cards_screen.test.tsx
@@ -20,7 +20,6 @@ import {
   readElectionGeneral,
 } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
-import { AuthStatus } from '@votingworks/types/src/auth/dipped_smart_card_auth';
 import { screen, within } from '../test/react_testing_library';
 import { newTestContext } from '../test/test_context';
 import {
@@ -648,7 +647,7 @@ test('Insert vendor card', async () => {
 });
 
 test('Insert poll worker card programmed for another election (PINs enabled)', async () => {
-  const authStatus: AuthStatus = {
+  const authStatus: DippedSmartCardAuth.AuthStatus = {
     ...baseAuth,
     programmableCard: {
       status: 'ready',

--- a/libs/utils/src/tabulation/compressed_tallies.ts
+++ b/libs/utils/src/tabulation/compressed_tallies.ts
@@ -16,7 +16,6 @@ import {
 } from '@votingworks/types';
 import { Buffer } from 'node:buffer';
 import { assert, throwIllegalValue, typedAs } from '@votingworks/basics';
-import { ContestResults } from '@votingworks/types/src/tabulation';
 import { getContestsForPrecinctAndElection } from './contest_filtering';
 import { singlePrecinctSelectionFor } from '../precinct_selection';
 
@@ -399,8 +398,11 @@ function decodeContestEntriesFromUint16Array(
   uint16Array: Uint16Array,
   contests: readonly Contest[],
   offset: number
-): { contestResults: Record<ContestId, ContestResults>; nextOffset: number } {
-  const contestResults: Record<ContestId, ContestResults> = {};
+): {
+  contestResults: Record<ContestId, Tabulation.ContestResults>;
+  nextOffset: number;
+} {
+  const contestResults: Record<ContestId, Tabulation.ContestResults> = {};
   let currentOffset = offset;
   for (const contest of contests) {
     const tallyLength = getNumberOfEntriesInContest(contest);
@@ -433,7 +435,7 @@ function decodeContestEntriesFromUint16Array(
 function decodeBitmapTally(
   uint16Array: Uint16Array,
   election: Election
-): Record<PrecinctId, Record<ContestId, ContestResults>> {
+): Record<PrecinctId, Record<ContestId, Tabulation.ContestResults>> {
   // Skip version byte at offset 0
   const { bitmap, nextOffset: dataOffset } = readPrecinctBitmap(
     uint16Array,
@@ -441,7 +443,10 @@ function decodeBitmapTally(
     election.precincts.length
   );
 
-  const result: Record<PrecinctId, Record<ContestId, ContestResults>> = {};
+  const result: Record<
+    PrecinctId,
+    Record<ContestId, Tabulation.ContestResults>
+  > = {};
   let offset = dataOffset;
 
   for (const [i, precinct] of election.precincts.entries()) {
@@ -489,7 +494,7 @@ export function readV0CompressedTallyAsContestResults({
   election: Election;
   precinctSelection: PrecinctSelection;
   encodedTally: string;
-}): Record<ContestId, ContestResults> {
+}): Record<ContestId, Tabulation.ContestResults> {
   const uint16Array = decodeEncodedTallyToUint16Array(encodedTally);
   const version = uint16Array[0];
 
@@ -503,7 +508,7 @@ export function readV0CompressedTallyAsContestResults({
     election,
     precinctSelection
   );
-  const allContestResults: Record<ContestId, ContestResults> = {};
+  const allContestResults: Record<ContestId, Tabulation.ContestResults> = {};
   for (const [contestIdx, contest] of contests.entries()) {
     const serializedContestTally = compressedTally[contestIdx];
     assert(serializedContestTally);
@@ -525,7 +530,7 @@ export function decodeAndReadPerPrecinctCompressedTally({
 }: {
   election: Election;
   encodedTally: string;
-}): Record<PrecinctId, Record<ContestId, ContestResults>> {
+}): Record<PrecinctId, Record<ContestId, Tabulation.ContestResults>> {
   const uint16Array = decodeEncodedTallyToUint16Array(encodedTally);
   const version = uint16Array[0];
   assert(


### PR DESCRIPTION
## Overview

`vx/no-import-workspace-subfolders` exempted `@votingworks/types`. That exception dates from 2021, when `libs/types` shipped hand-maintained subpath entry points at the package root (`libs/types/api/index.js`); those are long gone, so all it did was let through the `/src` reach-through the rule exists to ban — seven imports, including one in production source.

Three commits: fix the seven imports, drop the exception, and demote the rule's rewrite from an auto-fix to a suggestion. That last one matters because the rewrite assumes the package entry point exports every name being imported, which the rule can't check: `libs/utils/src/tabulation/compressed_tallies.ts` imported `ContestResults`, which the barrel doesn't export, so `--fix` (or the pre-commit hook) would have produced code that doesn't compile.

## Demo Video or Screenshot

N/A — lint rule and import specifiers, no behavior change.

## Testing Plan

- `pnpm build`, `pnpm lint` (type-check included) and `script/validate-monorepo` clean repo-wide, which is the real check on the rule change: lint is green with the exception gone.
- `eslint-plugin-vx` 483 tests, plus the three packages whose imports changed — `utils` 405, `ui` 965, `admin-frontend` 422.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added logging where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
