### PR TITLE
VxDesign: Stage ballot PDFs on disk before zipping

### DIFF
--- a/apps/design/backend/src/app.results.test.ts
+++ b/apps/design/backend/src/app.results.test.ts
@@ -24,7 +24,10 @@ import {
   Tabulation,
 } from '@votingworks/types';
 import { encodeQuickResultsMessage } from '@votingworks/auth';
-import { electionWithMsEitherNeitherFixtures } from '@votingworks/fixtures';
+import {
+  electionWithMsEitherNeitherFixtures,
+  makeTemporaryFile,
+} from '@votingworks/fixtures';
 import { readElectionPackageFromBuffer } from '@votingworks/backend';
 import { renderAllBallotPdfsAndCreateElectionDefinition } from '@votingworks/hmpb';
 import type * as grout from '@votingworks/grout';
@@ -110,7 +113,7 @@ async function setUpElectionInSystem(
   vi.mocked(renderAllBallotPdfsAndCreateElectionDefinition).mockImplementation(
     // eslint-disable-next-line @typescript-eslint/require-await
     async (_, _ballotTemplates, ballotProps) => ({
-      ballotPdfs: ballotProps.map(() => Uint8Array.from('mock-pdf-contents')),
+      ballotPaths: ballotProps.map(() => makeTemporaryFile()),
       electionDefinition: safeParseElectionDefinition(
         JSON.stringify(ballotProps[0].election, null, 2)
       ).unsafeUnwrap(),
@@ -2128,7 +2131,7 @@ test('LiveReports uses modified exported election, not original vxdesign electio
   ).mockImplementationOnce(
     // eslint-disable-next-line @typescript-eslint/require-await
     async (_, _ballotTemplates, ballotProps) => ({
-      ballotPdfs: ballotProps.map(() => Uint8Array.from('mock-pdf-contents')),
+      ballotPaths: ballotProps.map(() => makeTemporaryFile()),
       electionDefinition: reorderedElectionDefinition,
     })
   );

--- a/apps/design/backend/src/app.test.ts
+++ b/apps/design/backend/src/app.test.ts
@@ -3569,7 +3569,7 @@ test('Election package management', async () => {
   // Complete the task
   emitProgress('Test progress message', 10, 10);
   deferredRenderResult.resolve({
-    ballotPdfs: props.map(() => Uint8Array.from('mock-pdf-contents')),
+    ballotPaths: props.map(() => makeTemporaryFile()),
     electionDefinition: baseElectionDefinition,
   });
   await taskPromise;
@@ -5145,7 +5145,7 @@ test('setBallotTemplate changes the ballot template used to render ballots', asy
 
   const props = allBaseBallotProps(electionDefinition.election);
   vi.mocked(renderAllBallotPdfsAndCreateElectionDefinition).mockResolvedValue({
-    ballotPdfs: props.map(() => Uint8Array.from('mock-pdf-contents')),
+    ballotPaths: props.map(() => makeTemporaryFile()),
     electionDefinition,
   });
   await exportElectionPackage({

--- a/apps/design/backend/src/file_storage_client.ts
+++ b/apps/design/backend/src/file_storage_client.ts
@@ -62,6 +62,8 @@ export class S3FileStorageClient {
     filePath: string,
     contents: Buffer
   ): Promise<Result<void, FileStorageClientError>> {
+    // [TODO] Use @aws-sdk/lib-storage/Upload instead, to enable multipart
+    // uploads > 5GB.
     await this.s3Client.send(
       new PutObjectCommand({
         Bucket: process.env.AWS_S3_BUCKET_NAME,

--- a/apps/design/backend/src/store.test.ts
+++ b/apps/design/backend/src/store.test.ts
@@ -12,7 +12,10 @@ import {
 import { createHash } from 'node:crypto';
 import * as types from '@votingworks/types';
 import { mockBaseLogger } from '@votingworks/logging';
-import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
+import {
+  electionFamousNames2021Fixtures,
+  makeTemporaryFile,
+} from '@votingworks/fixtures';
 import {
   allBaseBallotProps,
   renderAllBallotPdfsAndCreateElectionDefinition,
@@ -588,7 +591,7 @@ test('getExportedElectionDefinition returns the exported election including reor
   // Mock the ballot rendering to return the reordered election
   const props = allBaseBallotProps(reorderedElection);
   vi.mocked(renderAllBallotPdfsAndCreateElectionDefinition).mockResolvedValue({
-    ballotPdfs: props.map(() => Uint8Array.from('mock-pdf-contents')),
+    ballotPaths: props.map(() => makeTemporaryFile()),
     electionDefinition: reorderedElectionDefinition,
   });
 
@@ -815,7 +818,7 @@ test('getExportedElection returns election-out-of-date error when election data 
   // Mock the ballot rendering to return a valid election
   const props = allBaseBallotProps(baseElectionDefinition.election);
   vi.mocked(renderAllBallotPdfsAndCreateElectionDefinition).mockResolvedValue({
-    ballotPdfs: props.map(() => Uint8Array.from('mock-pdf-contents')),
+    ballotPaths: props.map(() => makeTemporaryFile()),
     electionDefinition: baseElectionDefinition,
   });
 

--- a/apps/design/backend/src/worker/ballot_pdfs.test.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.test.ts
@@ -1,50 +1,58 @@
 import { expect, test, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import {
-  convertPdfToGrayscale,
+  convertPdfFileToGrayscale,
   convertPdfToSpotColor,
   NhStateSpotColors,
 } from '@votingworks/hmpb';
+import { makeTemporaryFile } from '@votingworks/fixtures';
 
 import { normalizeBallotColorModeForPrinting } from './ballot_pdfs.js';
 
 vi.mock(import('@votingworks/hmpb'), async (importActual) => ({
   ...(await importActual()),
-  convertPdfToGrayscale: vi.fn(),
+  convertPdfFileToGrayscale: vi.fn(),
   convertPdfToSpotColor: vi.fn(),
 }));
 
 test('normalizeBallotColorModeForPrinting - converts NH ballots to grayscale', async () => {
   const mockColorPdf = Buffer.of(0xca, 0xfe);
   const mockGrayscalePdfNh = Buffer.of(0xca, 0xef);
-  vi.mocked(convertPdfToGrayscale).mockResolvedValueOnce(mockGrayscalePdfNh);
 
-  expect(
-    await normalizeBallotColorModeForPrinting(mockColorPdf, 'NhBallot')
-  ).toStrictEqual(mockGrayscalePdfNh);
-  expect(convertPdfToGrayscale).toHaveBeenCalledWith(mockColorPdf);
+  vi.mocked(convertPdfFileToGrayscale).mockImplementationOnce(async (p) => {
+    await fs.writeFile(p, mockGrayscalePdfNh);
+  });
+
+  const ballotPath = makeTemporaryFile({ content: mockColorPdf });
+  const ballotTemplateId = 'NhBallot';
+  await normalizeBallotColorModeForPrinting({ ballotPath, ballotTemplateId });
+
+  expect(await fs.readFile(ballotPath)).toStrictEqual(mockGrayscalePdfNh);
 });
 
 test('normalizeBallotColorModeForPrinting - converts NH state ballots to spot color', async () => {
   const mockColorPdf = Buffer.of(0xca, 0xfe);
   const mockSpotColorPdf = Buffer.of(0xfa, 0xce);
-  vi.mocked(convertPdfToSpotColor).mockResolvedValueOnce(mockSpotColorPdf);
 
-  expect(
-    await normalizeBallotColorModeForPrinting(mockColorPdf, 'NhStateBallot')
-  ).toStrictEqual(mockSpotColorPdf);
-  expect(convertPdfToSpotColor).toHaveBeenCalledWith(
-    mockColorPdf,
-    Object.values(NhStateSpotColors)
-  );
+  vi.mocked(convertPdfToSpotColor).mockImplementationOnce(async (p) => {
+    expect(p.spotColors).toEqual(Object.values(NhStateSpotColors));
+    await fs.writeFile(p.pdfPath, mockSpotColorPdf);
+  });
+
+  const ballotPath = makeTemporaryFile({ content: mockColorPdf });
+  const ballotTemplateId = 'NhStateBallot';
+  await normalizeBallotColorModeForPrinting({ ballotPath, ballotTemplateId });
+
+  expect(await fs.readFile(ballotPath)).toStrictEqual(mockSpotColorPdf);
 });
 
 test('normalizeBallotColorModeForPrinting - doesnt convert non-NH ballots', async () => {
   const mockColorPdf = Buffer.of(0xac, 0xfe);
 
-  expect(
-    await normalizeBallotColorModeForPrinting(mockColorPdf, 'VxDefaultBallot')
-  ).toStrictEqual(mockColorPdf);
+  const ballotPath = makeTemporaryFile({ content: mockColorPdf });
+  const ballotTemplateId = 'VxDefaultBallot';
+  await normalizeBallotColorModeForPrinting({ ballotPath, ballotTemplateId });
 
-  expect(convertPdfToGrayscale).not.toHaveBeenCalled();
+  expect(await fs.readFile(ballotPath)).toStrictEqual(mockColorPdf);
 });

--- a/apps/design/backend/src/worker/ballot_pdfs.ts
+++ b/apps/design/backend/src/worker/ballot_pdfs.ts
@@ -1,27 +1,42 @@
+import { assert } from '@votingworks/basics';
 import {
   convertPdfToGrayscale,
-  convertPdfToSpotColor,
   calibrationSheetTemplate,
   Renderer,
   BallotTemplateId,
   NhStateSpotColors,
+  convertPdfFileToGrayscale,
+  convertPdfToSpotColor,
 } from '@votingworks/hmpb';
 import { HmpbBallotPaperSize } from '@votingworks/types';
 
-export async function normalizeBallotColorModeForPrinting(
-  ballotPdf: Uint8Array,
-  ballotTemplateId: BallotTemplateId
-): Promise<Uint8Array> {
-  switch (ballotTemplateId) {
+const NEEDS_COLOR_NORMALIZATION: Record<BallotTemplateId, boolean> = {
+  MiBallot: false,
+  MsBallot: false,
+  NhBallot: true,
+  NhStateBallot: true,
+  VxDefaultBallot: false,
+};
+
+export function needsColorNormalization(template: BallotTemplateId): boolean {
+  return NEEDS_COLOR_NORMALIZATION[template];
+}
+
+export async function normalizeBallotColorModeForPrinting(p: {
+  ballotPath: string;
+  ballotTemplateId: BallotTemplateId;
+}): Promise<void> {
+  switch (p.ballotTemplateId) {
     case 'NhBallot':
-      return await convertPdfToGrayscale(ballotPdf);
+      return await convertPdfFileToGrayscale(p.ballotPath);
     case 'NhStateBallot':
-      return await convertPdfToSpotColor(
-        ballotPdf,
-        Object.values(NhStateSpotColors)
-      );
+      return await convertPdfToSpotColor({
+        pdfPath: p.ballotPath,
+        spotColors: Object.values(NhStateSpotColors),
+      });
     default:
-      return ballotPdf;
+      assert(!needsColorNormalization(p.ballotTemplateId));
+      break;
   }
 }
 

--- a/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
+++ b/apps/design/backend/src/worker/generate_election_package_and_ballots.ts
@@ -1,4 +1,7 @@
 import JsZip from 'jszip';
+import * as os from 'node:os';
+import * as fs from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
 import { Buffer } from 'node:buffer';
 import {
   ElectionSerializationFormat,
@@ -15,6 +18,7 @@ import {
   EncodedBallotEntry,
   BaseBallotProps,
   SoftwareVersion,
+  ElectionDefinition,
 } from '@votingworks/types';
 import {
   hmpbStringsCatalog,
@@ -24,6 +28,7 @@ import {
   ElectionSerializationOptions,
   ScratchDir,
   RendererPool,
+  BallotTemplateId,
 } from '@votingworks/hmpb';
 import {
   generateAudioIdsAndClips,
@@ -47,6 +52,7 @@ import {
 } from '../ballots.js';
 import { getBallotPdfFileName } from '../utils.js';
 import {
+  needsColorNormalization,
   normalizeBallotColorModeForPrinting,
   renderCalibrationSheetPdf,
 } from './ballot_pdfs.js';
@@ -203,15 +209,13 @@ async function triggerCircleCiQaBuild(params: {
   }
 }
 
-function generateEncodedBallots(
-  normalizedBallotPdfs: Array<{
-    props: BaseBallotProps;
-    ballotPdf: Uint8Array<ArrayBufferLike>;
-  }>
-): NodeJS.ReadableStream {
+function generateEncodedBallots(p: {
+  ballotProps: BaseBallotProps[];
+  ballotPaths: string[];
+}): NodeJS.ReadableStream {
   return Readable.from(
-    (function* generateJsonLines() {
-      for (const { props, ballotPdf } of normalizedBallotPdfs) {
+    (async function* generateJsonLines() {
+      for (const [props, path] of iter(p.ballotProps).zip(p.ballotPaths)) {
         const encodedBallot: EncodedBallotEntry = {
           ballotStyleId: props.ballotStyleId,
           precinctId: props.precinctId,
@@ -220,7 +224,7 @@ function generateEncodedBallots(
           watermark: props.watermark,
           compact: props.compact,
           ballotAuditId: props.ballotAuditId,
-          encodedBallot: Buffer.from(ballotPdf).toString('base64'),
+          encodedBallot: await fs.readFile(path, 'base64'),
         };
         yield `${JSON.stringify(encodedBallot)}\n`;
       }
@@ -354,7 +358,7 @@ async function generate(
     version: jurisdiction.softwareVersion,
   };
 
-  const { electionDefinition, ballotPdfs } =
+  const { electionDefinition, ballotPaths } =
     await renderAllBallotPdfsAndCreateElectionDefinition(
       rendererPool,
       ballotTemplates[ballotTemplateId],
@@ -363,6 +367,14 @@ async function generate(
       scratchDir,
       emitProgress
     );
+
+  const calibrationSheetPdf = await rendererPool.runTask((renderer) =>
+    renderCalibrationSheetPdf(renderer, election.ballotLayout.paperSize)
+  );
+
+  // Close renderer pool early to free up memory for remaining tasks.
+  // eslint-disable-next-line no-console
+  await rendererPool.close().catch(console.error);
 
   electionPackageZip.file(
     ElectionPackageFileName.ELECTION,
@@ -400,59 +412,32 @@ async function generate(
     );
   }
 
-  // Normalizing the ballot PDF colors is not very memory intensive, so it's safe
-  // to do them all at once rather than using a worker pool like we do when
-  // rendering ballots.
-  const normalizedBallotPdfs = await Promise.all(
-    iter(allBallotProps)
-      .zip(ballotPdfs)
-      .map(async ([props, ballotPdf]) => ({
-        props,
-        ballotPdf: await normalizeBallotColorModeForPrinting(
-          ballotPdf,
-          ballotTemplateId
-        ),
-      }))
-      .toArray()
-  );
+  await normalizeBallots({ ballotPaths, ballotTemplateId });
 
-  const encodedBallots = generateEncodedBallots(normalizedBallotPdfs);
+  const encodedBallots = generateEncodedBallots({
+    ballotProps: allBallotProps,
+    ballotPaths,
+  });
   electionPackageZip.file(ElectionPackageFileName.BALLOTS, encodedBallots);
 
-  const electionPackageZipContents = await electionPackageZip.generateAsync({
-    type: 'nodebuffer',
-    streamFiles: true,
-  });
-  const electionPackageHash = createHash('sha256')
-    .update(electionPackageZipContents)
-    .digest('hex');
-
-  const combinedHash = formatElectionHashes(
-    electionDefinition.ballotHash,
-    electionPackageHash
-  );
-
-  electionPackageZip.file(
-    ElectionPackageFileName.APP_STRINGS,
-    JSON.stringify(appStrings, null, 2)
-  );
-
   // Add ballots to ZIP files, grouped by ballot type:
-  for (const { props, ballotPdf } of normalizedBallotPdfs) {
+  for (const [props, ballotPath] of iter(allBallotProps).zip(ballotPaths)) {
     const fileName = getBallotPdfFileName(props);
     const { ballotMode } = props;
 
     switch (ballotMode) {
       case 'official':
-        officialBallotsZip.file(fileName, ballotPdf);
+        // [TODO] Create lazy file streams to avoid opening all files at once,
+        // or switch to zip library better suited for streaming from file.
+        officialBallotsZip.file(fileName, createReadStream(ballotPath));
         break;
 
       case 'sample':
-        sampleBallotsZip.file(fileName, ballotPdf);
+        sampleBallotsZip.file(fileName, createReadStream(ballotPath));
         break;
 
       case 'test':
-        testBallotsZip.file(fileName, ballotPdf);
+        testBallotsZip.file(fileName, createReadStream(ballotPath));
         break;
 
       default: {
@@ -463,10 +448,6 @@ async function generate(
   }
 
   const calibrationSheetFilename = 'VxScan-calibration-sheet.pdf';
-  const calibrationSheetPdf = await rendererPool.runTask((renderer) =>
-    renderCalibrationSheetPdf(renderer, election.ballotLayout.paperSize)
-  );
-
   officialBallotsZip.file(calibrationSheetFilename, calibrationSheetPdf);
 
   if (shouldExportTestBallots) {
@@ -480,9 +461,9 @@ async function generate(
     sampleBallotsUrl,
     testBallotsUrl,
   ] = await Promise.all([
-    writeZipFile(ctx, electionPackageZipContents, {
+    writeElectionZip(ctx, electionDefinition, {
       jurisdictionId,
-      name: `election-package-${combinedHash}.zip`,
+      zip: electionPackageZip,
     }),
 
     writeBallotsZip(ctx, {
@@ -529,6 +510,33 @@ async function generate(
   });
 }
 
+/**
+ * Normalizes ballot PDF files, performing any color mode conversion necessary
+ * for the specified ballot template.
+ */
+async function normalizeBallots(p: {
+  ballotPaths: string[];
+  ballotTemplateId: BallotTemplateId;
+}) {
+  if (!needsColorNormalization(p.ballotTemplateId)) return;
+
+  const it = p.ballotPaths.values();
+
+  async function worker() {
+    while (true) {
+      const next = it.next();
+      if (next.done) return;
+
+      await normalizeBallotColorModeForPrinting({
+        ballotPath: next.value,
+        ballotTemplateId: p.ballotTemplateId,
+      });
+    }
+  }
+
+  await Promise.all(Array.from({ length: os.availableParallelism() }, worker));
+}
+
 async function writeBallotsZip(
   ctx: WorkerContext,
   p: { jurisdictionId: string; name: string; zip: JsZip }
@@ -541,6 +549,34 @@ async function writeBallotsZip(
   return writeZipFile(ctx, contents, {
     jurisdictionId: p.jurisdictionId,
     name: p.name,
+  });
+}
+
+async function writeElectionZip(
+  ctx: WorkerContext,
+  electionDefinition: ElectionDefinition,
+  p: { jurisdictionId: string; zip: JsZip }
+) {
+  // [TODO] Generate a stream instead and pipe to S3.
+  const electionPackageZipContents = await p.zip.generateAsync({
+    type: 'nodebuffer',
+    streamFiles: true,
+  });
+
+  // [TODO] Use streaming hasher to avoid limit errors when hashing large
+  // election packages.
+  const electionPackageHash = createHash('sha256')
+    .update(electionPackageZipContents)
+    .digest('hex');
+
+  const combinedHash = formatElectionHashes(
+    electionDefinition.ballotHash,
+    electionPackageHash
+  );
+
+  return writeZipFile(ctx, electionPackageZipContents, {
+    jurisdictionId: p.jurisdictionId,
+    name: `election-package-${combinedHash}.zip`,
   });
 }
 

--- a/apps/design/backend/src/worker/generate_test_decks.ts
+++ b/apps/design/backend/src/worker/generate_test_decks.ts
@@ -175,6 +175,8 @@ async function generate(
 
   for (const [precinct, ballotSpecs] of precinctHmpbBallotSpecs) {
     // Generate HMPB test deck
+    // [TODO] Stage PDFs on disk before archiving, to avoid OOM errors on large
+    // elections.
     const testDeckPdf = await createPrecinctTestDeck({
       rendererPool,
       electionDefinition,

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import { beforeEach, expect, test, vi } from 'vitest';
 import {
   getCastVoteRecordExportDirectoryPaths,
@@ -409,7 +410,7 @@ test('audit ballot IDs', async () => {
     ballotAuditId: '123',
   };
   const rendererPool = await createPlaywrightRendererPool();
-  const { ballotPdfs, electionDefinition: electionDefinitionModified } =
+  const { ballotPaths, electionDefinition: electionDefinitionModified } =
     await renderAllBallotPdfsAndCreateElectionDefinition(
       rendererPool,
       ballotTemplates.VxDefaultBallot,
@@ -417,7 +418,7 @@ test('audit ballot IDs', async () => {
       { format: 'vxf', version: LATEST_SOFTWARE_VERSION },
       { path: makeTemporaryDirectory() }
     );
-  const ballotPdf = ballotPdfs[0];
+  const ballotPdf = fs.readFileSync(ballotPaths[0]);
   await rendererPool.close();
   const ballotImages = await pdfToImageSheet(ballotPdf);
 

--- a/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { sliceBallotHashForEncoding } from '@votingworks/ballot-encoder';
 import { assert, assertDefined, find, iter } from '@votingworks/basics';
@@ -858,7 +859,7 @@ test('Ballot audit IDs', async () => {
     ballotAuditId: 'test-ballot-audit-id',
   };
   const rendererPool = await createPlaywrightRendererPool();
-  const { ballotPdfs, electionDefinition: electionDefinitionModified } =
+  const { ballotPaths, electionDefinition: electionDefinitionModified } =
     await renderAllBallotPdfsAndCreateElectionDefinition(
       rendererPool,
       ballotTemplates.VxDefaultBallot,
@@ -866,7 +867,7 @@ test('Ballot audit IDs', async () => {
       { format: 'vxf', version: LATEST_SOFTWARE_VERSION },
       makeScratchDir()
     );
-  const ballotPdf = ballotPdfs[0]!;
+  const ballotPdf = fs.readFileSync(ballotPaths[0]!);
   await rendererPool.close();
   const images = asSheet(await pdfToPageImages(ballotPdf).toArray());
   expect(images).toHaveLength(2);

--- a/libs/hmpb/src/normalize_pdf.test.ts
+++ b/libs/hmpb/src/normalize_pdf.test.ts
@@ -3,7 +3,8 @@ import { Buffer } from 'node:buffer';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { safeParseInt } from '@votingworks/types';
-import { normalizePdf } from './normalize_pdf.js';
+import { makeTemporaryFile } from '@votingworks/fixtures';
+import { normalizePdf, normalizePdfFile } from './normalize_pdf.js';
 
 function toBuffer(str: string): Buffer {
   return Buffer.from(str, 'latin1');
@@ -311,4 +312,22 @@ describe('normalizePdf', () => {
     const twice = normalizePdf(Buffer.from(once));
     expect(fromBytes(once)).toEqual(fromBytes(twice));
   });
+});
+
+test('normalizePdfFile/normalizePdfOutput parity smoke test', async () => {
+  const content = [
+    '<<',
+    "/CreationDate (D:20260325120000-07'00')",
+    "/ModDate (D:20260325130000+00'00')",
+    '/ID [<AE62F4165DB0622FD2E57DED09838D><AE62F4165DB0622FD2E57DED09838D>]',
+    '>>',
+  ].join(' ');
+
+  const pdf = makePdf({ objects: [{ num: 1, content }] });
+  const pdfPath = makeTemporaryFile({ content: pdf });
+  await normalizePdfFile(pdfPath);
+
+  const actual = fs.readFileSync(pdfPath, 'latin1');
+  const expected = fromBytes(normalizePdf(toBuffer(pdf)));
+  expect(actual).toEqual(expected);
 });

--- a/libs/hmpb/src/normalize_pdf.ts
+++ b/libs/hmpb/src/normalize_pdf.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs/promises';
+
 import { Buffer } from 'node:buffer';
 import { assert } from '@votingworks/basics';
 import { safeParseInt } from '@votingworks/types';
@@ -174,4 +176,15 @@ export function normalizePdf(pdf: Buffer): Uint8Array {
   );
 
   return Buffer.from(str, 'latin1');
+}
+
+/**
+ * Normalizes a PDF file in place. See {@link normalizePdf} for details.
+ *
+ * NOTE: Non-atomic - assumes usage with scratch files. Errors during conversion
+ * may leave the file in an undefined state.
+ */
+export async function normalizePdfFile(pdfPath: string): Promise<void> {
+  const original = await fs.readFile(pdfPath);
+  await fs.writeFile(pdfPath, normalizePdf(original));
 }

--- a/libs/hmpb/src/pdf_conversion.test.ts
+++ b/libs/hmpb/src/pdf_conversion.test.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import { describe, expect, test } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { promisify } from 'node:util';
@@ -15,9 +16,12 @@ import {
   StandardFonts,
 } from 'pdf-lib';
 import { assert, assertDefined } from '@votingworks/basics';
+import { makeTemporaryFile } from '@votingworks/fixtures';
 import {
+  convertPdfFileToGrayscale,
   convertPdfToGrayscale,
   convertPdfToSpotColor,
+  SpotColor,
 } from './pdf_conversion.js';
 import { fixturesDir } from './ballot_fixtures.js';
 import { Colors } from './ballot_components.js';
@@ -95,7 +99,7 @@ describe('convertPdfToSpotColor', () => {
     // Page 2 has no tint, exercising the untouched-content-stream path.
     const pdf = await buildColorPdf([ColorTints.BLUE, BLACK, WHITE], [BLACK]);
 
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       pdf,
       Object.values(NhStateSpotColors)
     );
@@ -122,7 +126,7 @@ describe('convertPdfToSpotColor', () => {
       borderColor: rgb(...hexToRgb(ColorTints.BLUE)),
       borderWidth: 3,
     });
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       await doc.save(),
       Object.values(NhStateSpotColors)
     );
@@ -131,7 +135,7 @@ describe('convertPdfToSpotColor', () => {
 
   test('produces a single named spot plate plus black', async () => {
     const pdf = await buildColorPdf([ColorTints.BLUE, BLACK]);
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       pdf,
       Object.values(NhStateSpotColors)
     );
@@ -171,14 +175,14 @@ describe('convertPdfToSpotColor', () => {
     // tints is unconditionally a bug.
     const pdf = await buildColorPdf([ColorTints.BLUE, BLACK], [ColorTints.RED]);
     await expect(
-      convertPdfToSpotColor(pdf, Object.values(NhStateSpotColors))
+      convertPdfBufferToSpotColor(pdf, Object.values(NhStateSpotColors))
     ).rejects.toThrow(/at most one spot color/);
   });
 
   test('converts only the party tint, leaving other grays on the black plate', async () => {
     // Like a Return of Votes form: a party tint plus a gray design shade.
     const pdf = await buildColorPdf([ColorTints.BLUE, GRAY_SHADE, BLACK]);
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       pdf,
       Object.values(NhStateSpotColors)
     );
@@ -195,7 +199,7 @@ describe('convertPdfToSpotColor', () => {
 
   test('applies no ink when no source color is present', async () => {
     const noTint = await buildColorPdf([BLACK, WHITE, GRAY_SHADE]);
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       noTint,
       Object.values(NhStateSpotColors)
     );
@@ -218,7 +222,7 @@ describe('convertPdfToSpotColor', () => {
       height: 15,
       color: rgb(...hexToRgb(ColorTints.BLUE)),
     });
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       await doc.save(),
       Object.values(NhStateSpotColors)
     );
@@ -236,7 +240,7 @@ describe('convertPdfToSpotColor', () => {
     const ballot = await readFile(
       join(fixturesDir, 'nh-state-primary-election/dem-blank-ballot.pdf')
     );
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       ballot,
       Object.values(NhStateSpotColors)
     );
@@ -249,7 +253,7 @@ describe('convertPdfToSpotColor', () => {
     const ballot = await readFile(
       join(fixturesDir, 'nh-state-general-election/blank-ballot.pdf')
     );
-    const converted = await convertPdfToSpotColor(
+    const converted = await convertPdfBufferToSpotColor(
       ballot,
       Object.values(NhStateSpotColors)
     );
@@ -302,3 +306,22 @@ describe('NH spot color declarations', () => {
     }
   });
 });
+
+test('convertPdfFileToGrayscale/convertPdfToGrayscale parity smoke test', async () => {
+  const pdf = await buildColorPdf([ColorTints.RED]);
+  const pdfPath = makeTemporaryFile({ content: pdf });
+
+  await convertPdfFileToGrayscale(pdfPath);
+  const result = fs.readFileSync(pdfPath);
+  expect(result).toEqual(await convertPdfToGrayscale(pdf));
+});
+
+async function convertPdfBufferToSpotColor(
+  pdf: Uint8Array,
+  spotColors: SpotColor[]
+) {
+  const pdfPath = makeTemporaryFile({ content: pdf });
+  await convertPdfToSpotColor({ pdfPath, spotColors });
+
+  return fs.readFileSync(pdfPath);
+}

--- a/libs/hmpb/src/pdf_conversion.ts
+++ b/libs/hmpb/src/pdf_conversion.ts
@@ -1,7 +1,7 @@
 import { tmpNameSync } from 'tmp';
 import { promisify } from 'node:util';
 import { execFile } from 'node:child_process';
-import { readFile, rm, writeFile } from 'node:fs/promises';
+import { readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import {
   decodePDFRawStream,
@@ -14,7 +14,7 @@ import {
   PDFRef,
 } from 'pdf-lib';
 import { assert } from '@votingworks/basics';
-import { normalizePdf } from './normalize_pdf.js';
+import { normalizePdf, normalizePdfFile } from './normalize_pdf.js';
 
 /**
  * Converts a PDF to grayscale via Ghostscript, without normalizing the output.
@@ -22,21 +22,36 @@ import { normalizePdf } from './normalize_pdf.js';
 async function ghostscriptGrayscale(pdf: Uint8Array): Promise<Buffer> {
   const tmpPdfFilePath = tmpNameSync();
   await writeFile(tmpPdfFilePath, pdf);
-  const tmpGrayscalePdfFilePath = tmpNameSync();
-  await promisify(execFile)('gs', [
-    `-sOutputFile=${tmpGrayscalePdfFilePath}`,
-    '-sDEVICE=pdfwrite',
-    '-sColorConversionStrategy=Gray',
-    '-dProcessColorModel=/DeviceGray',
-    '-dNOPAUSE',
-    '-dBATCH',
-    tmpPdfFilePath,
-  ]);
+
   try {
-    return await readFile(tmpGrayscalePdfFilePath);
+    await ghostscriptGrayscaleFile(tmpPdfFilePath);
+    return await readFile(tmpPdfFilePath);
   } finally {
-    await rm(tmpGrayscalePdfFilePath);
     await rm(tmpPdfFilePath);
+  }
+}
+
+/**
+ * Converts the PDF at the given path to grayscale via Ghostscript, replacing
+ * the original file iff successful.
+ */
+async function ghostscriptGrayscaleFile(pdfPath: string): Promise<void> {
+  const outputPath = tmpNameSync();
+
+  try {
+    await promisify(execFile)('gs', [
+      `-sOutputFile=${outputPath}`,
+      '-sDEVICE=pdfwrite',
+      '-sColorConversionStrategy=Gray',
+      '-dProcessColorModel=/DeviceGray',
+      '-dNOPAUSE',
+      '-dBATCH',
+      pdfPath,
+    ]);
+
+    await rename(outputPath, pdfPath);
+  } finally {
+    await rm(outputPath, { force: true });
   }
 }
 
@@ -47,6 +62,19 @@ export async function convertPdfToGrayscale(
   pdf: Uint8Array
 ): Promise<Uint8Array> {
   return normalizePdf(await ghostscriptGrayscale(pdf));
+}
+
+/**
+ * Converts the PDF at the given path to grayscale, replacing the original file.
+ *
+ * NOTE: Non-atomic - assumes usage with scratch files. Errors during conversion
+ * may leave the file in an undefined state.
+ */
+export async function convertPdfFileToGrayscale(
+  pdfPath: string
+): Promise<void> {
+  await ghostscriptGrayscaleFile(pdfPath);
+  await normalizePdfFile(pdfPath);
 }
 
 /**
@@ -234,7 +262,8 @@ function pageContentString(context: PDFContext, pageNode: PDFDict): string {
 }
 
 /**
- * Converts a color ballot PDF into a spot-color PDF for two-ink printing.
+ * Converts a color ballot PDF into a spot-color PDF for two-ink printing,
+ * replacing the original file.
  *
  * First converts the PDF to grayscale, then identifies the given {@link
  * SpotColor}s in the PDF's content streams using their resulting grayscale
@@ -244,12 +273,17 @@ function pageContentString(context: PDFContext, pageNode: PDFDict): string {
  *
  * Throws if the PDF contains more than one of the given spot colors, since in
  * our use case we only expect one spot color per ballot template.
+ *
+ * NOTE: Non-atomic - assumes usage with scratch files. Errors during conversion
+ * may leave the file in an undefined state.
  */
-export async function convertPdfToSpotColor(
-  pdf: Uint8Array,
-  spotColors: readonly SpotColor[]
-): Promise<Uint8Array> {
-  const grayscalePdf = await ghostscriptGrayscale(pdf);
+export async function convertPdfToSpotColor(p: {
+  pdfPath: string;
+  spotColors: readonly SpotColor[];
+}): Promise<void> {
+  await ghostscriptGrayscaleFile(p.pdfPath);
+  const grayscalePdf = await readFile(p.pdfPath);
+
   const doc = await PDFDocument.load(grayscalePdf, { updateMetadata: false });
   const { context } = doc;
 
@@ -258,7 +292,7 @@ export async function convertPdfToSpotColor(
   function separationRef(spotIndex: number): PDFRef {
     const cached = separationRefs.get(spotIndex);
     if (cached !== undefined) return cached;
-    const spot = spotColors[spotIndex];
+    const spot = p.spotColors[spotIndex];
     const tintTransformRef = context.register(
       context.obj({
         FunctionType: 2,
@@ -286,7 +320,7 @@ export async function convertPdfToSpotColor(
     const original = pageContentString(context, page.node);
     const { content, appliedSpotColors } = replaceTintOperatorsWithSpotColors(
       original,
-      spotColors
+      p.spotColors
     );
     if (appliedSpotColors.length === 0) continue;
 
@@ -318,7 +352,7 @@ export async function convertPdfToSpotColor(
       resources.set(PDFName.of('ColorSpace'), colorSpaces);
     }
     for (const spotColor of appliedSpotColors) {
-      const spotIndex = spotColors.indexOf(spotColor);
+      const spotIndex = p.spotColors.indexOf(spotColor);
       const name = PDFName.of(spotColorResourceName(spotIndex));
       const existing = colorSpaces.get(name);
       assert(
@@ -340,5 +374,6 @@ export async function convertPdfToSpotColor(
   );
 
   const saved = await doc.save({ useObjectStreams: false });
-  return normalizePdf(Buffer.from(saved));
+  const normalized = normalizePdf(Buffer.from(saved));
+  await writeFile(p.pdfPath, normalized);
 }

--- a/libs/hmpb/src/render_ballot.tsx
+++ b/libs/hmpb/src/render_ballot.tsx
@@ -39,6 +39,7 @@ import {
 import { QrCode } from '@votingworks/ui';
 import { encodeHmpbBallotPageMetadata } from '@votingworks/ballot-encoder';
 import * as fs from 'node:fs/promises';
+import { Readable } from 'node:stream';
 import {
   DocumentElement,
   RenderDocument,
@@ -643,10 +644,7 @@ export async function layOutBallotsAndCreateElectionDefinition<
   rendererPool: RendererPool,
   template: BallotPageTemplate<P>,
   ballotProps: P[],
-  electionSerializationOptions: {
-    format: ElectionSerializationFormat;
-    version: SoftwareVersion;
-  },
+  electionSerializationOptions: ElectionSerializationOptions,
   scratchDir: ScratchDir,
   emitProgress?: (label: string, progress: number, total: number) => void
 ): Promise<{
@@ -676,8 +674,10 @@ export async function layOutBallotsAndCreateElectionDefinition<
         recordBallotPositions(positions);
       }
 
-      const layoutPath = path.join(scratchDir.path, `${randomUUID()}.html`);
-      await fs.writeFile(layoutPath, await document.getContent());
+      const layoutPath = await writeScratchFile(scratchDir, {
+        data: await document.getContent(),
+        extension: 'html',
+      });
 
       return {
         props,
@@ -794,7 +794,7 @@ export async function renderAllBallotPdfsAndCreateElectionDefinition<
   scratchDir: ScratchDir,
   emitProgress?: (label: string, progress: number, total: number) => void
 ): Promise<{
-  ballotPdfs: Uint8Array[];
+  ballotPaths: string[];
   electionDefinition: ElectionDefinition;
 }> {
   const { layoutPaths, electionDefinition } =
@@ -807,9 +807,7 @@ export async function renderAllBallotPdfsAndCreateElectionDefinition<
       emitProgress
     );
 
-  // [TODO] Stage PDFs on disk instead of accumulating in memory. They are later
-  // written to disk anyway for ghostscript-based color conversion passes.
-  const ballotPdfs = await rendererPool.runTasks(
+  const ballotPaths = await rendererPool.runTasks(
     iter(ballotProps)
       .zip(layoutPaths)
       .map(([props, layoutPath]) => async (renderer: Renderer) => {
@@ -823,12 +821,14 @@ export async function renderAllBallotPdfsAndCreateElectionDefinition<
           console.error(`cleanup failed for temp layout ${layoutPath}:`, error);
         });
 
-        return renderBallotPdfWithMetadataQrCode(
+        const pdf = await renderBallotPdfWithMetadataQrCode(
           props,
           document,
           electionDefinition,
           electionSerializationOptions.version
         );
+
+        return writeScratchFile(scratchDir, { data: pdf, extension: 'pdf' });
       })
       .toArray(),
 
@@ -837,7 +837,7 @@ export async function renderAllBallotPdfsAndCreateElectionDefinition<
         emitProgress('Rendering ballot PDFs', progress, total))
   );
 
-  return { ballotPdfs, electionDefinition };
+  return { ballotPaths, electionDefinition };
 }
 
 /**
@@ -891,4 +891,21 @@ export async function layOutMinimalBallotsToCreateElectionDefinition<
   );
 
   return electionDefinition;
+}
+
+/**
+ * Writes to a new file in the given scratch dir and returns the resulting
+ * file path.
+ */
+async function writeScratchFile(
+  dir: ScratchDir,
+  p: {
+    data: string | Buffer | Readable | Uint8Array;
+    extension: string;
+  }
+): Promise<string> {
+  const filePath = path.join(dir.path, `${randomUUID()}.${p.extension}`);
+  await fs.writeFile(filePath, p.data);
+
+  return filePath;
 }

--- a/libs/hmpb/vitest.config.ts
+++ b/libs/hmpb/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     setupFiles: ['test/setupTests.ts'],
     coverage: {
       thresholds: {
-        lines: -79,
-        branches: -128,
+        lines: -77,
+        branches: -120,
       },
       exclude: [
         '**/*.test.ts',


### PR DESCRIPTION
## Overview

Addressing https://github.com/votingworks/vxsuite/issues/9217

Builds on https://github.com/votingworks/vxsuite/pull/9236, which saves ballot layout HTML files to disk between the layout and render phases.

This makes a similar change for the final PDFs, saving them to disk and later streaming them to the relevant ZIP file.

Keeps the memory footprint fairly constant for the PDF generation phase. Was previously OOM'ing on my ~50GB VM for a ~7K-ballot job, but hovers around 3GB after this change (which includes base NodeJS mem usage and a fairly large election object).

There's an additional ~200-400MB in use for each chromium worker (1 per core), so once we start streaming the ZIP files to disk/S3 vs generating them in-memory, we should fit snugly on an 8GB machine and will definitely be fine on the 14GB Heroku worker or a 16GB mid-range laptop.

Required updating our PDF color conversion/normalization utilities to accept file paths over buffers - not too much of a change, since they were already writing to temporary files and reading them back out anyway. Left a few buffer-based ones unchanged, which were being used in tests or other code paths we haven't updated yet.

Always paranoid about large amounts of disk-based IO, so let me know if you spot any holes to plug up.

### TODO
- The ZIP files are still generated in-memory, so that's the last memory bottleneck. JsZip supports streaming generation, which works in prototypes, but might also replace with something else if it simplifies the code, now that we have more need for streaming both the inputs and output.
- Haven't updated the test deck paths yet - memory profile will be different there, since we'd run a concatenation pass on a potentially large number of PDFs at a time.
- S3 uploads fail for files > 5GB (the election package I tested comes in at 9.5GB - will switch over to multi-part S3 uploads, which fits well with the streaming ZIP change above.

## Demo Video or Screenshot
N/A

## Testing Plan
- Existing tests for regression coverage + a couple extra for the new file-based PDF utility APIs
- Tested on a Heroku review app - wanted to verify that the RAM quota is separate from the disk allocation (i.e. the disk isn't ramfs). Still unsure what the disk limits are (not seeing them published anywhere), so will do some more testing at the upper limits we expect, to see if we hit any limits there.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
