### PR TITLE
Cache Turbo's artifacts between CircleCI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,22 @@ jobs:
           path: apps/admin/backend/reports/
       - store_artifacts:
           path: apps/admin/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/admin-frontend
   test-apps-admin-frontend:
@@ -78,6 +94,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/admin/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/admin-integration-testing
   test-apps-admin-integration-testing:
@@ -122,6 +154,22 @@ jobs:
                       "s3://$SCREENSHOT_BUCKET/screenshots/admin/" \
                       --exclude "*" --include "*.png" --delete
                   fi
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/central-scan-backend
   test-apps-central-scan-backend:
@@ -148,6 +196,22 @@ jobs:
           path: apps/central-scan/backend/reports/
       - store_artifacts:
           path: apps/central-scan/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/central-scan-frontend
   test-apps-central-scan-frontend:
@@ -172,6 +236,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/central-scan/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/central-scan-integration-testing
   test-apps-central-scan-integration-testing:
@@ -216,6 +296,22 @@ jobs:
                       "s3://$SCREENSHOT_BUCKET/screenshots/central-scan/" \
                       --exclude "*" --include "*.png" --delete
                   fi
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/design-backend
   test-apps-design-backend:
@@ -242,6 +338,22 @@ jobs:
           path: apps/design/backend/reports/
       - store_artifacts:
           path: apps/design/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/design-frontend
   test-apps-design-frontend:
@@ -266,6 +378,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/design/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/mark-scan-backend
   test-apps-mark-scan-backend:
@@ -292,6 +420,22 @@ jobs:
           path: apps/mark-scan/backend/reports/
       - store_artifacts:
           path: apps/mark-scan/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/mark-scan-frontend
   test-apps-mark-scan-frontend:
@@ -316,6 +460,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/mark-scan/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/mark-scan-integration-testing
   test-apps-mark-scan-integration-testing:
@@ -360,6 +520,22 @@ jobs:
                       "s3://$SCREENSHOT_BUCKET/screenshots/mark-scan/" \
                       --exclude "*" --include "*.png" --delete
                   fi
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/mark-backend
   test-apps-mark-backend:
@@ -386,6 +562,22 @@ jobs:
           path: apps/mark/backend/reports/
       - store_artifacts:
           path: apps/mark/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/mark-frontend
   test-apps-mark-frontend:
@@ -410,6 +602,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/mark/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/mark-integration-testing
   test-apps-mark-integration-testing:
@@ -454,6 +662,22 @@ jobs:
                       "s3://$SCREENSHOT_BUCKET/screenshots/mark/" \
                       --exclude "*" --include "*.png" --delete
                   fi
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/pollbook-frontend
   test-apps-pollbook-frontend:
@@ -478,6 +702,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/pollbook/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/print-backend
   test-apps-print-backend:
@@ -504,6 +744,22 @@ jobs:
           path: apps/print/backend/reports/
       - store_artifacts:
           path: apps/print/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/print-frontend
   test-apps-print-frontend:
@@ -528,6 +784,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/print/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/print-integration-testing
   test-apps-print-integration-testing:
@@ -572,6 +844,22 @@ jobs:
                       "s3://$SCREENSHOT_BUCKET/screenshots/print/" \
                       --exclude "*" --include "*.png" --delete
                   fi
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/scan-backend
   test-apps-scan-backend:
@@ -598,6 +886,22 @@ jobs:
           path: apps/scan/backend/reports/
       - store_artifacts:
           path: apps/scan/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/scan-frontend
   test-apps-scan-frontend:
@@ -622,6 +926,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: apps/scan/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/scan-integration-testing
   test-apps-scan-integration-testing:
@@ -666,6 +986,22 @@ jobs:
                       "s3://$SCREENSHOT_BUCKET/screenshots/scan/" \
                       --exclude "*" --include "*.png" --delete
                   fi
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/exercises
   test-docs-exercises:
@@ -690,6 +1026,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: docs/exercises/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/auth
   test-libs-auth:
@@ -714,6 +1066,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/auth/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/backend
   test-libs-backend:
@@ -738,6 +1106,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/backend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/ballot-encoder
   test-libs-ballot-encoder:
@@ -762,6 +1146,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/ballot-encoder/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/ballot-interpreter
   test-libs-ballot-interpreter:
@@ -790,6 +1190,22 @@ jobs:
           path: libs/ballot-interpreter/src/__image_snapshots__/__diff_output__/
       - store_artifacts:
           path: libs/ballot-interpreter/src/summary-ballot/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/basics
   test-libs-basics:
@@ -814,6 +1230,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/basics/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/bmd-ballot-fixtures
   test-libs-bmd-ballot-fixtures:
@@ -840,6 +1272,22 @@ jobs:
           path: libs/bmd-ballot-fixtures/reports/
       - store_artifacts:
           path: libs/bmd-ballot-fixtures/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/cdf-schema-builder
   test-libs-cdf-schema-builder:
@@ -864,6 +1312,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/cdf-schema-builder/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/custom-paper-handler
   test-libs-custom-paper-handler:
@@ -888,6 +1352,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/custom-paper-handler/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/db
   test-libs-db:
@@ -912,6 +1392,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/db/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/dev-dock-backend
   test-libs-dev-dock-backend:
@@ -936,6 +1432,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/dev-dock/backend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/dev-dock-frontend
   test-libs-dev-dock-frontend:
@@ -960,6 +1472,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/dev-dock/frontend/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # eslint-plugin-vx
   test-libs-eslint-plugin-vx:
@@ -984,6 +1512,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/eslint-plugin-vx/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/fixture-generators
   test-libs-fixture-generators:
@@ -1008,6 +1552,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/fixture-generators/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/fixtures
   test-libs-fixtures:
@@ -1032,6 +1592,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/fixtures/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/fs
   test-libs-fs:
@@ -1056,6 +1632,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/fs/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/fujitsu-thermal-printer
   test-libs-fujitsu-thermal-printer:
@@ -1080,6 +1672,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/fujitsu-thermal-printer/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/grout
   test-libs-grout:
@@ -1104,6 +1712,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/grout/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/grout-test-utils
   test-libs-grout-test-utils:
@@ -1128,6 +1752,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/grout/test-utils/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/hmpb
   test-libs-hmpb:
@@ -1154,6 +1794,22 @@ jobs:
           path: libs/hmpb/reports/
       - store_artifacts:
           path: libs/hmpb/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/image-utils
   test-libs-image-utils:
@@ -1178,6 +1834,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/image-utils/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/integration-test-utils
   test-libs-integration-test-utils:
@@ -1202,6 +1874,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/integration-test-utils/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/logging
   test-libs-logging:
@@ -1226,6 +1914,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/logging/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/logging-utils
   test-libs-logging-utils:
@@ -1250,6 +1954,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/logging-utils/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/mark-flow-ui
   test-libs-mark-flow-ui:
@@ -1274,6 +1994,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/mark-flow-ui/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/message-coder
   test-libs-message-coder:
@@ -1298,6 +2034,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/message-coder/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/monorepo-utils
   test-libs-monorepo-utils:
@@ -1322,6 +2074,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/monorepo-utils/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/networking
   test-libs-networking:
@@ -1346,6 +2114,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/networking/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/pdi-scanner
   test-libs-pdi-scanner:
@@ -1370,6 +2154,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/pdi-scanner/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/printing
   test-libs-printing:
@@ -1396,6 +2196,22 @@ jobs:
           path: libs/printing/reports/
       - store_artifacts:
           path: libs/printing/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/test-decks
   test-libs-test-decks:
@@ -1422,6 +2238,22 @@ jobs:
           path: libs/test-decks/reports/
       - store_artifacts:
           path: libs/test-decks/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/test-utils
   test-libs-test-utils:
@@ -1446,6 +2278,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/test-utils/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/types
   test-libs-types:
@@ -1470,6 +2318,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/types/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/ui
   test-libs-ui:
@@ -1494,6 +2358,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/ui/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/usb-drive
   test-libs-usb-drive:
@@ -1518,6 +2398,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/usb-drive/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   # @votingworks/utils
   test-libs-utils:
@@ -1542,6 +2438,22 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: ./reports/
       - store_test_results:
           path: libs/utils/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   test-rust-crates:
     executor: 'nodejs'
@@ -1607,6 +2519,22 @@ jobs:
           name: Validate
           command: |
             ./script/validate-monorepo
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
   notify-gallery:
     executor: nodejs
@@ -1838,6 +2766,15 @@ commands:
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
+          name: Configure Turbo for CI
+          command: |
+            # Identifies the toolchain that produced cached artifacts.
+            echo 'export VX_TOOLCHAIN_ID="votingworks/cimg-debian12:4.8.0"' >> $BASH_ENV
+            # Run summaries record each task's hash under .turbo/runs;
+            # script/prune-turbo-cache uses them to trim the cache before it
+            # is saved.
+            echo 'export TURBO_RUN_SUMMARY=true' >> $BASH_ENV
+      - run:
           name: Fix node-gyp gyp entrypoint permissions
           command: |
             # TODO: Remove once we upgrade past pnpm 11.10, which ships
@@ -1876,6 +2813,11 @@ commands:
                 paths:
                   - /root/.local/share/pnpm/store/v10
                   - /root/.cache/ms-playwright
+            - restore_cache:
+                name: Restore Turbo Cache
+                keys:
+                  - turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                  - turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-
       - restore_cache:
           name: Restore Cargo Cache
           key:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,8 @@ Tasks and their wiring (`turbo.json`):
 | `build:self`    | `^build:self` | `build/**`, `*.node`                               |
 | `type-check`    | `^build:self` | `tsconfig.tsbuildinfo`                             |
 | `lint:self`     | `^build:self` | (logs only)                                        |
-| `test:run:self` | `build:self`  | (logs only)                                        |
-| `test:ci:self`  | `build:self`  | (logs only; design's Postgres/migration CI steps)  |
+| `test:run:self` | `build:self`  | `reports/**` (junit)                               |
+| `test:ci:self`  | `build:self`  | `reports/**`; design's Postgres/migration CI steps |
 | `clean:self`    | —             | not cached                                         |
 | `dev:server`    | `^build:self` | not cached (persistent; frontend Vite dev server)  |
 | `dev`           | `build:self`  | not cached (persistent + interruptible; a backend) |
@@ -258,9 +258,31 @@ per-machine (not shared between developers) and unbounded — see
 [docs/turborepo.md](docs/turborepo.md) for how to clear it, force a rebuild, and
 other troubleshooting.
 
-**CI caching:** CI currently runs Turbo tasks per package without a shared
-remote cache (each job builds fresh). Enabling Turbo remote caching in CI is a
-planned follow-up.
+**CI caching:** each CircleCI job restores Turbo's cache directory
+(`.turbo/cache`) via `restore_cache`, and jobs on `main` save it again at the
+end. Branch jobs are read-only: CircleCI cache keys are immutable, so a key has
+to rotate per revision to stay fresh, and letting every job write on every push
+to every branch would pile up an archive per job per push. A branch still
+restores `main`'s baseline, which is where nearly all of the reuse is; the only
+cost is that a branch rebuilds its own changed packages on each push.
+
+The key is scoped to the job name (~60 jobs sharing one key would keep only
+whichever finished first, and per-job archives stay small) and to the config
+checksum, which covers the executor image — an image bump can't replay artifacts
+built by a different toolchain. CI also exports `VX_TOOLCHAIN_ID` (the image
+tag), declared in `globalEnv`, so the same guard applies inside Turbo's own
+hashes.
+
+Before saving, `script/prune-turbo-cache` trims the cache to the entries the job
+actually used, which it reads from the run summaries Turbo writes under
+`.turbo/runs` (CI sets `TURBO_RUN_SUMMARY`). Turbo never evicts, so without this
+the restore/save cycle would grow the archive without bound. Pruning by age
+would be wrong: Turbo does not update an entry's mtime on a cache hit, so the
+oldest entries are typically the hottest ones.
+
+Because a job's cache is written when it finishes, this shares work only _across
+pushes_ to `main`; sharing across the jobs of a single pipeline needs a remote
+cache, which is a planned follow-up.
 
 **Tooling scripts:** repo tooling that depends on built workspace packages
 (`configure-env`, `generate-circleci-config`) is a shell `bin/` in the package

--- a/apps/pollbook/backend/.circleci/config.yml
+++ b/apps/pollbook/backend/.circleci/config.yml
@@ -25,6 +25,15 @@ commands:
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
       - run:
+          name: Configure Turbo for CI
+          command: |
+            # Identifies the toolchain that produced cached artifacts.
+            echo 'export VX_TOOLCHAIN_ID="votingworks/cimg-debian12:4.8.0"' >> $BASH_ENV
+            # Run summaries record each task's hash under .turbo/runs;
+            # script/prune-turbo-cache uses them to trim the cache before
+            # it is saved.
+            echo 'export TURBO_RUN_SUMMARY=true' >> $BASH_ENV
+      - run:
           name: Fix node-gyp gyp entrypoint permissions
           command: |
             # TODO: Remove once we upgrade past pnpm 11.10, which ships
@@ -65,6 +74,11 @@ commands:
                 paths:
                   - /root/.local/share/pnpm/store/v10
                   - /root/.cache/ms-playwright
+            - restore_cache:
+                name: Restore Turbo Cache
+                keys:
+                  - turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                  - turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-
       - restore_cache:
           name: Restore Cargo Cache
           key:
@@ -109,6 +123,22 @@ jobs:
                 path: apps/pollbook/backend/reports/
             - store_artifacts:
                 path: apps/pollbook/backend/src/__image_snapshots__/__diff_output__/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
 
 workflows:
   test-pollbook-backend:

--- a/docs/turborepo.md
+++ b/docs/turborepo.md
@@ -92,6 +92,22 @@ you built in one worktree is restored for free in another. Two things to know:
   speed-up is on rebuilds of commits you've already built.
 - The cache is **unbounded** — it grows over time and is never auto-evicted.
 
+## Caching in CI
+
+CI keeps its own cache, separate from any developer's. Each CircleCI job
+restores `.turbo/cache` at the start; jobs on `main` prune it to the entries
+that job used (`script/prune-turbo-cache`) and save it again at the end.
+Branches are read-only against `main`'s cache, so a branch build reuses
+everything it hasn't changed but doesn't write anything back.
+
+Two consequences worth knowing when reading a CI log:
+
+- The first build after any change to `.circleci/config.yml` is cold. The cache
+  key includes that file's checksum, which is what keeps an executor image bump
+  from replaying artifacts built by a different toolchain.
+- CircleCI expires caches after 15 days, which is also the maximum retention it
+  allows, so even a constantly-reused entry is rebuilt at least that often.
+
 ## Troubleshooting
 
 ### Force a rebuild (ignore the cache for one run)

--- a/docs/turborepo.md
+++ b/docs/turborepo.md
@@ -86,9 +86,10 @@ Turbo shares one local cache across all git worktrees of this repo (it lives
 under the shared `.git` directory, not inside any single worktree). So a package
 you built in one worktree is restored for free in another. Two things to know:
 
-- The cache is **per-machine** — it is not shared between developers or with CI.
-  A fresh checkout of a commit nobody on this machine has built yet gets few
-  hits; the speed-up is on rebuilds of commits you've already built.
+- The cache is **per-machine** — it is not shared between developers, nor with
+  CI (which keeps its own, via CircleCI's `save_cache`/`restore_cache`). A fresh
+  checkout of a commit nobody on this machine has built yet gets few hits; the
+  speed-up is on rebuilds of commits you've already built.
 - The cache is **unbounded** — it grows over time and is never auto-evicted.
 
 ## Troubleshooting

--- a/libs/monorepo-utils/src/circleci.ts
+++ b/libs/monorepo-utils/src/circleci.ts
@@ -9,6 +9,75 @@ function jobIdForPackage(pkg: PnpmPackageInfo): string {
 
 const RUST_CRATES_JOB_ID = 'test-rust-crates';
 
+const DOCKER_IMAGE = 'votingworks/cimg-debian12:4.8.0';
+
+// Turbo's on-disk cache lives at `<repo root>/.turbo/cache`. CI persists it so
+// a job restores its dependency chain instead of rebuilding it.
+//
+// Only `main` writes the cache; branch jobs are read-only against it. CircleCI
+// cache keys are immutable, so a key has to rotate per revision to stay fresh,
+// and letting all ~60 jobs write on every push to every branch would pile up
+// an archive per job per push. Branches still restore main's baseline, which
+// is where nearly all of the reuse is.
+//
+// The key is scoped to the job (dozens of jobs sharing one key would keep only
+// whichever finished first, and per-job archives stay small) and to the config
+// checksum, which covers the executor image — an image bump can't replay
+// artifacts built by a different toolchain.
+const TURBO_CACHE_PATH = '.turbo/cache';
+const TURBO_CACHE_KEY_PREFIX =
+  'turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main';
+
+function turboCacheRestoreSteps(indent: string): string[] {
+  return [
+    `${indent}- restore_cache:`,
+    `${indent}    name: Restore Turbo Cache`,
+    `${indent}    keys:`,
+    // An exact hit only happens when re-running a job on the same `main`
+    // commit; everything else falls back to the newest `main` archive.
+    `${indent}      - ${TURBO_CACHE_KEY_PREFIX}-{{ .Revision }}`,
+    `${indent}      - ${TURBO_CACHE_KEY_PREFIX}-`,
+  ];
+}
+
+// Branches that write the Turbo cache. Normally just `main` — add a branch
+// here temporarily to exercise the prune/save path on it before merging.
+const CACHE_WRITING_BRANCHES = ['main'];
+
+// Always an `or:`, even for a single branch: special-casing one branch to a
+// bare `equal:` would leave whichever form is currently unused uncovered.
+function cacheWritingBranchCondition(indent: string): string[] {
+  return [
+    `${indent}  or:`,
+    ...CACHE_WRITING_BRANCHES.map(
+      (branch) =>
+        `${indent}    - equal: [ ${branch}, << pipeline.git.branch >> ]`
+    ),
+  ];
+}
+
+function turboCacheSaveSteps(indent: string): string[] {
+  return [
+    `${indent}- when:`,
+    `${indent}    condition:`,
+    ...cacheWritingBranchCondition(`${indent}    `),
+    `${indent}    steps:`,
+    `${indent}      - run:`,
+    `${indent}          name: Prune Turbo Cache`,
+    // Save even when the job failed: the build artifacts are still valid and
+    // worth reusing, and turbo never caches a failing task anyway.
+    `${indent}          when: always`,
+    `${indent}          command: |`,
+    `${indent}            ./script/prune-turbo-cache`,
+    `${indent}      - save_cache:`,
+    `${indent}          name: Save Turbo Cache`,
+    `${indent}          when: always`,
+    `${indent}          key: ${TURBO_CACHE_KEY_PREFIX}-{{ .Revision }}`,
+    `${indent}          paths:`,
+    `${indent}            - ${TURBO_CACHE_PATH}`,
+  ];
+}
+
 const POSTGRES_PACKAGES: string[] = ['apps/design/backend'];
 // The following packages are only tested when there is a change to its directory.
 const PACKAGES_ONLY_TEST_ON_CHANGES = ['apps/pollbook/backend'];
@@ -141,6 +210,8 @@ function generateTestJobForNodeJsPackage(
       lines.push(`${indent}            fi`);
     }
   }
+
+  lines.push(...turboCacheSaveSteps('    '));
 
   return lines;
 }
@@ -281,7 +352,7 @@ function generateCircleCiFilteredAppConfigForPackage(
     'executors:',
     '  nodejs:',
     '    docker:',
-    '      - image: votingworks/cimg-debian12:4.8.0',
+    `      - image: ${DOCKER_IMAGE}`,
     '        auth:',
     '          username: $VX_DOCKER_USERNAME',
     '          password: $VX_DOCKER_PASSWORD',
@@ -297,6 +368,15 @@ function generateCircleCiFilteredAppConfigForPackage(
     '          name: Ensure Rust tooling is in PATH',
     '          command: |',
     '            echo \'export PATH="/root/.cargo/bin:$PATH"\' >> $BASH_ENV',
+    '      - run:',
+    '          name: Configure Turbo for CI',
+    '          command: |',
+    '            # Identifies the toolchain that produced cached artifacts.',
+    `            echo 'export VX_TOOLCHAIN_ID="${DOCKER_IMAGE}"' >> $BASH_ENV`,
+    "            # Run summaries record each task's hash under .turbo/runs;",
+    '            # script/prune-turbo-cache uses them to trim the cache before',
+    '            # it is saved.',
+    `            echo 'export TURBO_RUN_SUMMARY=true' >> $BASH_ENV`,
     '      - run:',
     '          name: Fix node-gyp gyp entrypoint permissions',
     '          command: |',
@@ -338,6 +418,7 @@ function generateCircleCiFilteredAppConfigForPackage(
     '                paths:',
     '                  - /root/.local/share/pnpm/store/v10',
     '                  - /root/.cache/ms-playwright',
+    ...turboCacheRestoreSteps('            '),
     '      - restore_cache:',
     '          name: Restore Cargo Cache',
     '          key:',
@@ -435,14 +516,14 @@ orbs:
 executors:
   nodejs:
     docker:
-      - image: votingworks/cimg-debian12:4.8.0
+      - image: ${DOCKER_IMAGE}
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
 
   nodejs_postgres:
     docker:
-      - image: votingworks/cimg-debian12:4.8.0
+      - image: ${DOCKER_IMAGE}
         auth:
           username: $VX_DOCKER_USERNAME
           password: $VX_DOCKER_PASSWORD
@@ -486,6 +567,7 @@ ${rustJobLines.map((line) => `  ${line}\n`).join('')}
           name: Validate
           command: |
             ./script/validate-monorepo
+${turboCacheSaveSteps('      ').join('\n')}
 
 ${generateNotifyGalleryJob()
   .map((line) => `  ${line}`)
@@ -517,6 +599,15 @@ commands:
           name: Ensure Rust tooling is in PATH
           command: |
             echo 'export PATH="/root/.cargo/bin:$PATH"' >> $BASH_ENV
+      - run:
+          name: Configure Turbo for CI
+          command: |
+            # Identifies the toolchain that produced cached artifacts.
+            echo 'export VX_TOOLCHAIN_ID="${DOCKER_IMAGE}"' >> $BASH_ENV
+            # Run summaries record each task's hash under .turbo/runs;
+            # script/prune-turbo-cache uses them to trim the cache before it
+            # is saved.
+            echo 'export TURBO_RUN_SUMMARY=true' >> $BASH_ENV
       - run:
           name: Fix node-gyp gyp entrypoint permissions
           command: |
@@ -556,6 +647,7 @@ commands:
                 paths:
                   - /root/.local/share/pnpm/store/v10
                   - /root/.cache/ms-playwright
+${turboCacheRestoreSteps('            ').join('\n')}
       - restore_cache:
           name: Restore Cargo Cache
           key:

--- a/script/prune-turbo-cache
+++ b/script/prune-turbo-cache
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+require('esbuild-runner').install({
+  type: 'transform',
+});
+
+try {
+  process.exitCode = require('./src/prune-turbo-cache/cli').main({
+    stdin: process.stdin,
+    stdout: process.stdout,
+    stderr: process.stderr,
+  });
+} catch (error) {
+  console.error(error.stack);
+  process.exitCode = 1;
+}

--- a/script/src/prune-turbo-cache/cli.ts
+++ b/script/src/prune-turbo-cache/cli.ts
@@ -1,0 +1,149 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { IO } from '../types';
+
+// Every cache entry is stored as <hash>.tar.zst alongside these sidecars, so
+// the leading hash identifies the entry a file belongs to.
+const CACHE_ENTRY_SUFFIXES = ['.tar.zst', '-meta.json', '-manifest.json'];
+
+interface RunSummaryTask {
+  readonly hash?: string;
+}
+
+interface RunSummary {
+  readonly tasks?: readonly RunSummaryTask[];
+}
+
+function git(...args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function directoryExists(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Collects the hash of every task turbo ran, across all the run summaries it
+ * wrote. A job runs turbo more than once (build, then lint, then test), and
+ * each run summarizes its dependencies too, so the union covers everything the
+ * job needed.
+ */
+function collectLiveHashes(runsDir: string): Set<string> {
+  const hashes = new Set<string>();
+
+  for (const entry of readdirSync(runsDir)) {
+    if (!entry.endsWith('.json')) continue;
+
+    const summary = JSON.parse(
+      readFileSync(resolve(runsDir, entry), 'utf8')
+    ) as RunSummary;
+
+    for (const task of summary.tasks ?? []) {
+      if (task.hash) {
+        hashes.add(task.hash);
+      }
+    }
+  }
+
+  return hashes;
+}
+
+function hashForCacheFile(fileName: string): string | undefined {
+  const suffix = CACHE_ENTRY_SUFFIXES.find((candidate) =>
+    fileName.endsWith(candidate)
+  );
+  return suffix ? fileName.slice(0, -suffix.length) : undefined;
+}
+
+function directorySizeBytes(dir: string): number {
+  let total = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isFile()) {
+      total += statSync(resolve(dir, entry.name)).size;
+    }
+  }
+  return total;
+}
+
+function formatBytes(bytes: number): string {
+  const megabytes = bytes / 1024 / 1024;
+  return `${megabytes.toFixed(1)}MB`;
+}
+
+/**
+ * Prunes turbo's cache down to the entries the current CI job actually used.
+ *
+ * CI restores the cache at the start of a job and saves it again at the end.
+ * Turbo never evicts anything, so without pruning that archive would grow with
+ * every build until it held the union of every hash the job has ever seen.
+ * Pruning by age would be wrong: turbo does not update an entry's mtime on a
+ * cache hit, so the oldest entries are typically the hottest ones.
+ */
+export function main({ stdout, stderr }: IO): number {
+  const cacheDir = resolve(
+    process.cwd(),
+    git('rev-parse', '--git-common-dir'),
+    '..',
+    '.turbo',
+    'cache'
+  );
+  const runsDir = resolve(git('rev-parse', '--show-toplevel'), '.turbo/runs');
+
+  if (!directoryExists(cacheDir)) {
+    stdout.write(`No turbo cache at ${cacheDir}; nothing to prune.\n`);
+    return 0;
+  }
+
+  // Without summaries there is no way to tell which entries are live, and
+  // deleting everything would throw away a usable cache. CI asks for them by
+  // setting TURBO_RUN_SUMMARY, but a job that fails before turbo runs won't
+  // have written any.
+  if (!directoryExists(runsDir)) {
+    stderr.write(
+      `No turbo run summaries at ${runsDir}; leaving cache as-is.\n`
+    );
+    return 0;
+  }
+
+  const liveHashes = collectLiveHashes(runsDir);
+
+  // Summaries that name no tasks tell us nothing, so treat them the same as
+  // having none at all rather than emptying the cache.
+  if (liveHashes.size === 0) {
+    stderr.write(`No tasks in the turbo run summaries; leaving cache as-is.\n`);
+    return 0;
+  }
+
+  const sizeBefore = directorySizeBytes(cacheDir);
+  let kept = 0;
+  let removed = 0;
+
+  for (const fileName of readdirSync(cacheDir)) {
+    const hash = hashForCacheFile(fileName);
+
+    // Keep anything whose name we don't recognize rather than deleting a file
+    // whose purpose we can't determine.
+    if (!hash || liveHashes.has(hash)) {
+      kept += 1;
+      continue;
+    }
+
+    rmSync(resolve(cacheDir, fileName), { force: true });
+    removed += 1;
+  }
+
+  stdout.write(
+    `Pruned turbo cache: kept ${kept} files, removed ${removed}; ` +
+      `live task hashes: ${liveHashes.size} ` +
+      `(${formatBytes(sizeBefore)} -> ${formatBytes(
+        directorySizeBytes(cacheDir)
+      )}).\n`
+  );
+
+  return 0;
+}

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,11 @@
     ".prettierrc.js",
     "stylelint.shared.js"
   ],
+  // Identifies the toolchain the artifacts were built with (in CI, the Docker
+  // image tag). Native addons and `tsc` output depend on it, but none of it is
+  // visible in the file inputs, so a cache shared across toolchains would
+  // otherwise replay artifacts built by a different compiler.
+  "globalEnv": ["VX_TOOLCHAIN_ID"],
   "tasks": {
     "build:self": {
       "dependsOn": ["^build:self"],
@@ -24,10 +29,16 @@
     },
     "test:run:self": {
       "dependsOn": ["build:self"],
+      // `CI` switches on coverage (and its thresholds) and the junit reporter
+      // in vitest.config.shared.mts, so it has to be part of the hash.
+      "env": ["CI"],
+      "outputs": ["reports/**"],
       "passThroughEnv": ["VX_TEST_WORKERS"]
     },
     "test:ci:self": {
       "dependsOn": ["build:self"],
+      "env": ["CI"],
+      "outputs": ["reports/**"],
       "passThroughEnv": ["VX_TEST_WORKERS"]
     },
     "clean:self": {

--- a/vitest.config.shared.mts
+++ b/vitest.config.shared.mts
@@ -45,8 +45,14 @@ export const base: vitest.ViteUserConfig = {
     },
     clearMocks: true,
     maxWorkers: isCI ? 6 : localMaxWorkers,
-    reporters: isCI ? ['verbose', 'junit'] : [],
-    outputFile: isCI ? 'reports/junit.xml' : undefined,
+    // The junit reporter runs everywhere so that `reports/junit.xml` is
+    // always produced and can be declared as a turbo output for
+    // `test:run:self` — without it, a cached test task would leave CircleCI's
+    // `store_test_results` with nothing to upload. It writes to the file
+    // rather than the console, so local output is unaffected (`junit.xml` is
+    // gitignored).
+    reporters: isCI ? ['verbose', 'junit'] : ['junit'],
+    outputFile: 'reports/junit.xml',
     // 10s everywhere. A full-workspace `pnpm test` runs many suites at once and
     // briefly oversubscribes the CPU, so a tighter budget would flake
     // otherwise-fast tests under that transient load.


### PR DESCRIPTION
## Overview

Each of the CI jobs rebuilds its whole dependency chain from scratch. This PR persists Turbo's cache directory across CircleCI runs, so a job restores that chain instead. Only `main` writes the cache, with branches restoring from it read-only.

There were a few cache-correctness bugs that had to be sorted out first: `CI` wasn't in any task's `env` despite driving coverage and the junit reporter; `test:run:self` declared no outputs, so a cache hit left `store_test_results` with nothing to upload; and the toolchain was invisible to the hash, now covered by `VX_TOOLCHAIN_ID`.

`script/prune-turbo-cache` trims the cache to what a job actually used before saving, reading task hashes from Turbo's run summaries. Turbo never evicts, so otherwise the restore/save cycle grows the archive without bound.

Measured over 62 jobs, against a baseline of four `main` pipelines (202 min, tight at 185–197 min on the common job set). Middle rows are modelled from the workspace dependency graph:

| Scenario | Total compute | vs. baseline |
| --- | --- | --- |
| No caching (today) | 202 min | — |
| First build after merge (cold, writes cache) | ~208 min | +3% |
| Change one app | ~111 min | −45% |
| Change a mid-tier lib (`ui`, `hmpb`, `printing`) | 117–125 min | −38 to −42% |
| Change `libs/types` | ~174 min | −14% |
| Change `libs/basics` | ~194 min | −4% |
| Nothing rebuilds | 110 min | −45% |

Wall clock is 7.6 min → 4.6 min warm; the critical path is `admin-integration-testing` at 397s → 259s.

The win tracks dependent count (`basics` has 54/55 dependents, `types` 48/55, an app 2/55), so touching a core lib buys little. Warm jobs spend under 2s in Turbo — the rest is checkout, `pnpm install`, and the Rust addon install.

## Testing Plan

Validated across four pipelines on this branch, using a temporary commit that let the branch write the cache:

- **Cold + write** — restore misses on both keys, prune reports a real kept/removed split, save uploads (`admin-frontend` 13 MiB, `libs-ui` 2.4 MiB).
- **Warm + hit** — `Found a cache from job … at …-main-`, then `31 cached, 31 total, 675ms >>> FULL TURBO`. Critically, `test:run:self` was a cache hit *and* `store_test_results` still uploaded `reports/junit.xml`, confirming the outputs fix.
- **Prune isn't over-deleting** — `admin-frontend` pruned `kept 96, removed 30` cold and `kept 96, removed 0` warm, with every hash hitting. The 30 were dead intra-job churn.
- **Branch mode** — the prune/save steps don't exist in the job at all, only restore.
- **Failure path** — prune and save still ran under `when: always` on a job whose tests failed.

`script/prune-turbo-cache` was also exercised against synthetic caches for its missing-cache, missing-summaries, empty-summaries, and subdirectory paths.

One thing to expect: any change to `.circleci/config.yml` makes the next build cold everywhere, since its checksum is in the key. That's deliberate — it stops an executor image bump from replaying artifacts built by a different toolchain.

