### PR TITLE
VxAdmin: confine a restore to backups signed in this jurisdiction

### DIFF
--- a/apps/admin/backend/src/app.cvr_files.test.ts
+++ b/apps/admin/backend/src/app.cvr_files.test.ts
@@ -21,7 +21,10 @@ import {
   generateCastVoteRecordExportDirectoryName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
+import {
+  authenticateArtifactUsingSignatureFile,
+  mockSigningMachineCertFields,
+} from '@votingworks/auth';
 import {
   CastVoteRecordExportModifications,
   combineImageAndLayoutHashes,
@@ -67,7 +70,9 @@ vi.mock(import('@votingworks/utils'), async (importActual) => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(authenticateArtifactUsingSignatureFile).mockResolvedValue(ok());
+  vi.mocked(authenticateArtifactUsingSignatureFile).mockResolvedValue(
+    ok(mockSigningMachineCertFields({ component: 'central-scan' }))
+  );
   featureFlagMock.enableFeatureFlag(
     BooleanEnvironmentVariableName.SKIP_CVR_BALLOT_HASH_CHECK
   );

--- a/apps/admin/backend/src/backup/authenticated_backup.ts
+++ b/apps/admin/backend/src/backup/authenticated_backup.ts
@@ -1,6 +1,9 @@
 import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
-import { VXADMIN_BACKUP_MANIFEST_FILE_NAME } from '@votingworks/auth';
+import {
+  VXADMIN_BACKUP_MANIFEST_FILE_NAME,
+  VxAdminCustomCertFields,
+} from '@votingworks/auth';
 import { Result } from '@votingworks/basics';
 import { BackupManifest } from './backup_manifest.js';
 import {
@@ -27,11 +30,15 @@ import {
  * covered by the hashes *within* the manifest, and still lives on untrusted
  * media, so each file has to be verified against its manifest entry as it is
  * read.
+ *
+ * Authentication says a VxAdmin signed the manifest, not which one, so the
+ * signer's identity is carried alongside it — see {@link signer}.
  */
 export class AuthenticatedBackup implements AsyncDisposable {
   constructor(
     private readonly backupPath: string,
-    private readonly stagingPath: string
+    private readonly stagingPath: string,
+    private readonly signingMachine: VxAdminCustomCertFields
   ) {}
 
   /**
@@ -39,6 +46,15 @@ export class AuthenticatedBackup implements AsyncDisposable {
    */
   get path(): string {
     return this.backupPath;
+  }
+
+  /**
+   * The VxAdmin whose cert signed this backup's manifest, as the cert states
+   * it. This is the only trustworthy account of where the backup came from:
+   * everything the manifest says about its own origin is text the signer chose.
+   */
+  get signer(): VxAdminCustomCertFields {
+    return this.signingMachine;
   }
 
   /**

--- a/apps/admin/backend/src/backup/backup.ts
+++ b/apps/admin/backend/src/backup/backup.ts
@@ -6,7 +6,13 @@ import {
   constructSignatureFilePath,
   VXADMIN_BACKUP_MANIFEST_FILE_NAME,
 } from '@votingworks/auth';
-import { err, extractErrorMessage, ok, Result } from '@votingworks/basics';
+import {
+  assert,
+  err,
+  extractErrorMessage,
+  ok,
+  Result,
+} from '@votingworks/basics';
 import { copyFile, CopyFileError } from '@votingworks/fs';
 import { AuthenticatedBackup } from './authenticated_backup.js';
 
@@ -103,8 +109,14 @@ export class Backup {
         });
       }
 
+      // `authenticateArtifactUsingSignatureFile` already refused anything but a
+      // VxAdmin cert for this artifact type; this narrows that to the type
+      // system, since only a VxAdmin cert carries a jurisdiction.
+      const signer = authenticateResult.ok();
+      assert(signer.component === 'admin');
+
       opened = true;
-      return ok(new AuthenticatedBackup(this.backupPath, stagingPath));
+      return ok(new AuthenticatedBackup(this.backupPath, stagingPath, signer));
     } finally {
       if (!opened) {
         await rm(stagingPath, { recursive: true, force: true });

--- a/apps/admin/backend/src/backup/cli/main.test.ts
+++ b/apps/admin/backend/src/backup/cli/main.test.ts
@@ -31,6 +31,8 @@ import {
 import { CANCELLED_EXIT_CODE, main } from './main.js';
 import { createWorkspace, Workspace } from '../../util/workspace.js';
 
+vi.setConfig({ testTimeout: 30_000 });
+
 interface RunResult {
   code: number;
   stdout: string;

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -23,6 +23,8 @@ import { writeManifest } from './manifest_step.js';
 import { swap } from './swap_step.js';
 import { BackupManifestStructSchema } from '../backup_manifest.js';
 
+vi.setConfig({ testTimeout: 30_000 });
+
 vi.mock(
   import('@votingworks/backend'),
   async (importActual): Promise<typeof import('@votingworks/backend')> => {

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { err, ok } from '@votingworks/basics';
+import { err } from '@votingworks/basics';
 import { dirname, join, relative } from 'node:path';
 import { readdirSync, readFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
@@ -146,7 +146,7 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
   }
 
   const firstManifest = readManifest();
-  expect(await authenticateBackup()).toEqual(ok());
+  expect((await authenticateBackup()).err()).toBeUndefined();
   const firstBallotImages = readdirSync(
     join(
       backupPath,
@@ -169,7 +169,7 @@ test('a second backup atomically replaces the first, leaving no leftovers', asyn
   expect(secondResult.unsafeUnwrap().path).toEqual(backupPath);
 
   const secondManifest = readManifest();
-  expect(await authenticateBackup()).toEqual(ok());
+  expect((await authenticateBackup()).err()).toBeUndefined();
   expect(secondManifest.createdAt).not.toEqual(firstManifest.createdAt);
   expect(secondManifest.files.length).toBeGreaterThan(
     firstManifest.files.length

--- a/apps/admin/backend/src/backup/create/manifest_step.test.ts
+++ b/apps/admin/backend/src/backup/create/manifest_step.test.ts
@@ -7,7 +7,6 @@ import {
 } from '@votingworks/fixtures';
 import { DEV_MACHINE_ID, LATEST_SOFTWARE_VERSION } from '@votingworks/types';
 import { mockLogger } from '@votingworks/logging';
-import { ok } from '@votingworks/basics';
 import {
   authenticateArtifactUsingSignatureFile,
   SIGNATURE_FILE_EXTENSION,
@@ -71,12 +70,14 @@ test('writes a manifest alongside a signature that authenticates it', async () =
   ).toBeGreaterThan(0);
 
   expect(
-    await authenticateArtifactUsingSignatureFile({
-      type: 'vxadmin_backup',
-      context: 'import',
-      directoryPath: backupPath,
-    })
-  ).toEqual(ok());
+    (
+      await authenticateArtifactUsingSignatureFile({
+        type: 'vxadmin_backup',
+        context: 'import',
+        directoryPath: backupPath,
+      })
+    ).err()
+  ).toBeUndefined();
 });
 
 test('the signature does not authenticate a tampered-with manifest', async () => {

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { appendFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
@@ -72,6 +72,10 @@ vi.mock(
 
 beforeEach(() => {
   mockDiskSpace();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 /**
@@ -478,11 +482,10 @@ test('restore fails if the backup manifest software version does not match', asy
 
 test('restore warns but does not fail if the machine ID does not match', async () => {
   const backup = await makeBackup();
-  const otherMachineId = 'VX-00-999';
-  await rewriteManifest(backup, (manifest) => ({
-    ...manifest,
-    machineId: otherMachineId,
-  }));
+  // The backup is signed by the dev VxAdmin cert, so making this machine
+  // anyone else is what makes the backup another machine's.
+  const thisMachineId = 'VX-00-999';
+  vi.stubEnv('VX_MACHINE_ID', thisMachineId);
 
   const workspacePath = makeUnconfiguredWorkspacePath();
   const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
@@ -506,9 +509,61 @@ test('restore warns but does not fail if the machine ID does not match', async (
   // apart from a restore onto the machine that made it.
   const warnings = vi
     .mocked(logger.log)
-    .mock.calls.filter((call) => JSON.stringify(call).includes(otherMachineId));
+    .mock.calls.filter((call) => JSON.stringify(call).includes(thisMachineId));
   expect(warnings).toHaveLength(1);
   expect(JSON.stringify(warnings[0])).toContain(DEV_MACHINE_ID);
+});
+
+test('the recorded machine ID is the signer, not what the manifest claims', async () => {
+  const backup = await makeBackup();
+  // A manifest is written by whoever holds a signing key, so a machine ID in
+  // one is a claim. Here it claims to be this very machine while the cert that
+  // signed it says otherwise, which is what the record has to survive.
+  const thisMachineId = 'VX-00-999';
+  vi.stubEnv('VX_MACHINE_ID', thisMachineId);
+  await rewriteManifest(backup, (manifest) => ({
+    ...manifest,
+    machineId: thisMachineId,
+  }));
+
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
+  expect(
+    await restoreBackup({
+      backup: backup.path,
+      workspace: restorable(makeUnconfiguredWorkspacePath()),
+      logger,
+    })
+  ).toEqual(ok());
+
+  const warnings = vi
+    .mocked(logger.log)
+    .mock.calls.filter((call) => JSON.stringify(call).includes(DEV_MACHINE_ID));
+  expect(warnings).toHaveLength(1);
+});
+
+test('restore fails if the backup was signed in another jurisdiction', async () => {
+  const backup = await makeBackup();
+  // Every VxAdmin's cert chains to the same VotingWorks CA, so a valid
+  // signature on its own says only that some VxAdmin somewhere made this.
+  vi.stubEnv('VX_MACHINE_JURISDICTION', 'st.somewhere-else');
+
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const result = await restoreBackup({
+    backup: backup.path,
+    workspace: restorable(workspacePath),
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+  });
+
+  expect(result.err()).toMatchObject({
+    type: 'backup-authentication-failed',
+  });
+
+  // Refused during vetting, so the workspace still holds what it had.
+  expect(listWorkspace(workspacePath)).toEqual([
+    'ballot-images',
+    ADMIN_WORKSPACE_DATABASE_NAME,
+    'election-packages',
+  ]);
 });
 
 test.each<{ description: string; tamper: (backup: Backup) => Promise<void> }>([
@@ -537,12 +592,14 @@ test.each<{ description: string; tamper: (backup: Backup) => Promise<void> }>([
   const backup = await makeBackup();
   // Proves the tampering below is what breaks authentication, not the fixture.
   expect(
-    await authenticateArtifactUsingSignatureFile({
-      type: 'vxadmin_backup',
-      context: 'import',
-      directoryPath: backup.path,
-    })
-  ).toEqual(ok());
+    (
+      await authenticateArtifactUsingSignatureFile({
+        type: 'vxadmin_backup',
+        context: 'import',
+        directoryPath: backup.path,
+      })
+    ).err()
+  ).toBeUndefined();
 
   await tamper(backup);
 

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -48,6 +48,8 @@ import {
 import { restoreBackup, RESTORE_IN_PROGRESS_MARKER_FILENAME } from './index.js';
 import { ProgressEvent } from '../progress.js';
 
+vi.setConfig({ testTimeout: 30_000 });
+
 vi.mock(
   import('@votingworks/backend'),
   async (importActual): Promise<typeof import('@votingworks/backend')> => {

--- a/apps/admin/backend/src/backup/restore/open_step.ts
+++ b/apps/admin/backend/src/backup/restore/open_step.ts
@@ -1,7 +1,10 @@
 import { err, ok, Result, throwIllegalValue } from '@votingworks/basics';
 import { Logger, LogEventId } from '@votingworks/logging';
 import { LATEST_SOFTWARE_VERSION } from '@votingworks/types';
-import { getMachineConfig } from '../../machine_config.js';
+import {
+  getMachineConfig,
+  getMachineJurisdiction,
+} from '../../machine_config.js';
 import { AuthenticatedBackup } from '../authenticated_backup.js';
 import { Backup } from '../backup.js';
 import { BACKUP_WORKSPACE_DIR, BackupManifest } from '../backup_manifest.js';
@@ -31,9 +34,13 @@ export async function openBackup(
 
 /**
  * Reads the authenticated manifest and checks that it describes a backup this
- * software can restore. A backup made by a different machine is recorded
- * rather than refused: moving a backup between machines is how failed hardware
- * is replaced.
+ * software can restore, and one this machine has any business restoring.
+ *
+ * A backup signed by a different machine is recorded rather than refused:
+ * moving a backup between machines is how failed hardware is replaced. One
+ * signed in a different *jurisdiction* is refused — no jurisdiction has cause
+ * to restore another's data — which is what keeps "a different machine" from
+ * meaning any VxAdmin in existence.
  */
 export async function vetManifest(
   backup: AuthenticatedBackup,
@@ -77,12 +84,33 @@ export async function vetManifest(
     });
   }
 
+  // Every machine's cert chains to the same VotingWorks CA, so a signature
+  // says a VxAdmin signed this and nothing more. The signer's jurisdiction is
+  // the one account of where a backup came from that its author did not write:
+  // a manifest holds whatever the signer chose to type, while the jurisdiction
+  // is what the CA issued them.
+  const jurisdiction = getMachineJurisdiction();
+  if (backup.signer.jurisdiction !== jurisdiction) {
+    return err({
+      type: 'backup-authentication-failed',
+      message:
+        `Backup was signed by a VxAdmin in jurisdiction ` +
+        `${backup.signer.jurisdiction}, but this machine belongs to ` +
+        `${jurisdiction}`,
+    });
+  }
+
+  // Which machine made the backup is read from the signing cert, not from the
+  // manifest. Restoring another machine's backup is allowed, so nothing
+  // refuses a manifest naming the wrong machine — which is exactly why the
+  // manifest's own account of its origin is not what gets recorded here.
   const { machineId } = getMachineConfig();
-  if (manifest.machineId !== machineId) {
+  if (backup.signer.machineId !== machineId) {
     await logger.logAsCurrentRole(LogEventId.BackupRestoreMachineMismatch, {
+      signingMachineId: backup.signer.machineId,
       backupManifestMachineId: manifest.machineId,
       machineId,
-      message: `Backup was created by ${manifest.machineId} which does not match ${machineId}`,
+      message: `Backup was created by ${backup.signer.machineId} which does not match ${machineId}`,
     });
   }
 

--- a/apps/admin/backend/src/machine_config.ts
+++ b/apps/admin/backend/src/machine_config.ts
@@ -1,4 +1,6 @@
-import { DEV_MACHINE_ID } from '@votingworks/types';
+import { DEV_JURISDICTION } from '@votingworks/auth';
+import { DEV_MACHINE_ID, TEST_JURISDICTION } from '@votingworks/types';
+import { isIntegrationTest } from '@votingworks/utils';
 import { MachineConfig } from './types.js';
 
 /**
@@ -10,4 +12,17 @@ export function getMachineConfig(): MachineConfig {
     machineId: process.env.VX_MACHINE_ID || DEV_MACHINE_ID,
     codeVersion: process.env.VX_CODE_VERSION || 'dev',
   };
+}
+
+/**
+ * Returns the jurisdiction this machine belongs to. Kept apart from
+ * {@link getMachineConfig}, whose result is handed to the frontend: a
+ * jurisdiction is something the machine is checked against, not something it
+ * reports.
+ */
+export function getMachineJurisdiction(): string {
+  /* istanbul ignore next - covered by integration testing */
+  return isIntegrationTest()
+    ? TEST_JURISDICTION
+    : process.env.VX_MACHINE_JURISDICTION ?? DEV_JURISDICTION;
 }

--- a/apps/admin/backend/src/util/auth.ts
+++ b/apps/admin/backend/src/util/auth.ts
@@ -1,11 +1,10 @@
 import {
-  DEV_JURISDICTION,
   DippedSmartCardAuthApi,
   DippedSmartCardAuthMachineState,
 } from '@votingworks/auth';
-import { isIntegrationTest } from '@votingworks/utils';
-import { DEFAULT_SYSTEM_SETTINGS, TEST_JURISDICTION } from '@votingworks/types';
+import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { LoggingUserRole } from '@votingworks/logging';
+import { getMachineJurisdiction } from '../machine_config.js';
 import type { BaseStore } from '../types.js';
 
 /**
@@ -17,10 +16,7 @@ export function constructAuthMachineState(
 ): DippedSmartCardAuthMachineState {
   const electionId = store.getCurrentElectionId();
 
-  /* istanbul ignore next - covered by integration testing */
-  const jurisdiction = isIntegrationTest()
-    ? TEST_JURISDICTION
-    : process.env.VX_MACHINE_JURISDICTION ?? DEV_JURISDICTION;
+  const jurisdiction = getMachineJurisdiction();
 
   if (!electionId) {
     return {

--- a/libs/auth/src/artifact_authentication.test.ts
+++ b/libs/auth/src/artifact_authentication.test.ts
@@ -9,6 +9,7 @@ import {
   CastVoteRecordExportMetadata,
   CVR,
   DEV_MACHINE_ID,
+  TEST_JURISDICTION,
 } from '@votingworks/types';
 
 import { getTestFilePath } from '../test/utils';
@@ -20,6 +21,7 @@ import {
   SIGNATURE_FILE_EXTENSION,
   VXADMIN_BACKUP_MANIFEST_FILE_NAME,
 } from './artifact_authentication';
+import { MachineCustomCertFields } from './certs';
 import { ArtifactAuthenticationConfig } from './config';
 
 vi.mock(
@@ -215,24 +217,36 @@ test.each<{
   artifactGenerator: ArtifactGenerator;
   exportingMachineConfig: ArtifactAuthenticationConfig;
   importingMachineConfig: ArtifactAuthenticationConfig;
+  expectedSigner: MachineCustomCertFields;
 }>([
   {
     description: 'cast vote records',
     artifactGenerator: () => castVoteRecords,
     exportingMachineConfig: vxScanTestConfig,
     importingMachineConfig: vxAdminTestConfig,
+    expectedSigner: { component: 'scan', machineId: DEV_MACHINE_ID },
   },
   {
     description: 'election package',
     artifactGenerator: () => electionPackage,
     exportingMachineConfig: vxAdminTestConfig,
     importingMachineConfig: vxScanTestConfig,
+    expectedSigner: {
+      component: 'admin',
+      machineId: DEV_MACHINE_ID,
+      jurisdiction: TEST_JURISDICTION,
+    },
   },
   {
     description: 'VxAdmin backup',
     artifactGenerator: () => vxAdminBackup,
     exportingMachineConfig: vxAdminTestConfig,
     importingMachineConfig: vxAdminTestConfig,
+    expectedSigner: {
+      component: 'admin',
+      machineId: DEV_MACHINE_ID,
+      jurisdiction: TEST_JURISDICTION,
+    },
   },
 ])(
   'Preparing signature file and authenticating artifact using signature file - $description',
@@ -240,6 +254,7 @@ test.each<{
     artifactGenerator,
     exportingMachineConfig,
     importingMachineConfig,
+    expectedSigner,
   }) => {
     const { artifactToExport, artifactToImport } = artifactGenerator();
     const signatureFile = await prepareSignatureFile(
@@ -253,12 +268,15 @@ test.each<{
       ),
       signatureFile.fileContents
     );
+    // Authentication yields who signed the artifact, not just that someone
+    // did: a caller confining an artifact to its jurisdiction has no other
+    // trustworthy source for that.
     expect(
       await authenticateArtifactUsingSignatureFile(
         artifactToImport,
         importingMachineConfig
       )
-    ).toEqual(ok());
+    ).toEqual(ok(expectedSigner));
   }
 );
 

--- a/libs/auth/src/artifact_authentication.ts
+++ b/libs/auth/src/artifact_authentication.ts
@@ -434,11 +434,16 @@ export async function prepareSignatureFile(
  * Verifies the authenticity of the provided artifact using its signature file, which is expected
  * to be found at the same file path as the artifact, but with a .vxsig extension, e.g.
  * /path/to/artifact.txt.vxsig. Returns an error Result if artifact authentication fails.
+ *
+ * On success, returns the custom fields of the cert that signed the artifact. Authentication
+ * establishes only that *a* VotingWorks machine of the expected component signed it, so a caller
+ * that cares *which* machine — to bind the artifact's own claims about its origin to the signer,
+ * or to confine an artifact to its jurisdiction — has to check these fields itself.
  */
 export async function authenticateArtifactUsingSignatureFile(
   artifact: ArtifactToImport,
   configOverride?: ArtifactAuthenticationConfig
-): Promise<Result<void, Error>> {
+): Promise<Result<MachineCustomCertFields, Error>> {
   const config =
     configOverride ??
     /* istanbul ignore next */ constructArtifactAuthenticationConfig();
@@ -454,6 +459,7 @@ export async function authenticateArtifactUsingSignatureFile(
         artifactSignatureBundle
       );
     await performArtifactSpecificAuthenticationChecks(artifact, machineDetails);
+    return ok(machineDetails);
   } catch (error) {
     const artifactSummary = JSON.stringify(artifact);
     const errorMessage = extractErrorMessage(error);
@@ -463,5 +469,4 @@ export async function authenticateArtifactUsingSignatureFile(
       )
     );
   }
-  return ok();
 }

--- a/libs/auth/src/certs.ts
+++ b/libs/auth/src/certs.ts
@@ -49,7 +49,12 @@ interface BaseMachineCustomCertFields {
   machineId: string;
 }
 
-interface VxAdminCustomCertFields extends BaseMachineCustomCertFields {
+/**
+ * Parsed custom cert fields for a VxAdmin machine cert. Exported because a
+ * VxAdmin is the only machine that signs an artifact whose consumer cares
+ * which jurisdiction signed it.
+ */
+export interface VxAdminCustomCertFields extends BaseMachineCustomCertFields {
   component: 'admin';
   jurisdiction: string;
 }

--- a/libs/auth/src/index.ts
+++ b/libs/auth/src/index.ts
@@ -2,6 +2,13 @@ export * from './artifact_authentication';
 export * as cac from './cac';
 export type { Card, CardStatus } from './card';
 export * from './cast_vote_record_hashes';
+export type {
+  CardCustomCertFields,
+  Component,
+  CustomCertFields,
+  MachineCustomCertFields,
+  VxAdminCustomCertFields,
+} from './certs';
 export * from './config';
 export {
   manageOpensslConfig,

--- a/libs/auth/src/test_utils.ts
+++ b/libs/auth/src/test_utils.ts
@@ -4,6 +4,8 @@ import {
 } from '@votingworks/types';
 import type { Mocked, vi } from 'vitest';
 
+import { MachineCustomCertFields } from './certs';
+import { DEV_JURISDICTION } from './jurisdictions';
 import { DippedSmartCardAuthApi } from './dipped_smart_card_auth_api';
 import {
   InsertedSmartCardAuthApi,
@@ -48,5 +50,22 @@ export function buildMockInsertedSmartCardAuth(
     readCardData: fn(),
     writeCardData: fn(),
     clearCardData: fn(),
+  };
+}
+
+/**
+ * Stands in for the signing machine's cert fields that
+ * `authenticateArtifactUsingSignatureFile` returns, for tests that mock
+ * artifact authentication and do not care who signed what. Pass `overrides` to
+ * test code that does care.
+ */
+export function mockSigningMachineCertFields(
+  overrides: Partial<MachineCustomCertFields> = {}
+): MachineCustomCertFields {
+  return {
+    component: 'admin',
+    machineId: '0000',
+    jurisdiction: DEV_JURISDICTION,
+    ...overrides,
   };
 }

--- a/libs/backend/src/election_package/election_package_io.test.ts
+++ b/libs/backend/src/election_package/election_package_io.test.ts
@@ -54,7 +54,10 @@ import {
   generateElectionBasedSubfolderName,
   getFeatureFlagMock,
 } from '@votingworks/utils';
-import { authenticateArtifactUsingSignatureFile } from '@votingworks/auth';
+import {
+  authenticateArtifactUsingSignatureFile,
+  mockSigningMachineCertFields,
+} from '@votingworks/auth';
 import { join } from 'node:path';
 import * as fs from 'node:fs';
 import { Buffer } from 'node:buffer';
@@ -93,7 +96,9 @@ vi.mock(
 );
 
 beforeEach(() => {
-  vi.mocked(authenticateArtifactUsingSignatureFile).mockResolvedValue(ok());
+  vi.mocked(authenticateArtifactUsingSignatureFile).mockResolvedValue(
+    ok(mockSigningMachineCertFields())
+  );
   mockFeatureFlagger.resetFeatureFlags();
 });
 


### PR DESCRIPTION
## Overview

Refs #7897

Every VxAdmin's cert chains to the same VotingWorks CA, so any machine in any jurisdiction could create a backup that any other machine would restore. Restore now checks the signing cert's jurisdiction against this machine's and refuses a mismatch. Which machine signed it still isn't checked since moving a backup between machines is how failed hardware gets replaced, and that stays allowed within a jurisdiction.

## Testing Plan

New automated tests.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

