### PR TITLE
VxDesign: fix useTitle crashing tests after jsdom teardown

### DIFF
--- a/apps/design/frontend/src/hooks/use_title.test.ts
+++ b/apps/design/frontend/src/hooks/use_title.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { setBaseTitle, useTitle } from './use_title.js';
 
@@ -52,4 +52,20 @@ test('empty title parts', async () => {
   await waitFor(() => {
     expect(document.title).toEqual('My Site');
   });
+});
+
+test('skips the reset when the document is gone before it fires', () => {
+  vi.useFakeTimers();
+  try {
+    const { unmount } = renderHook(() => useTitle('My Page'));
+    expect(document.title).toEqual('My Page – My Site');
+    unmount();
+    // The test environment tears down the document while a reset is pending.
+    vi.stubGlobal('document', undefined);
+    expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+  } finally {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  }
+  expect(document.title).toEqual('My Page – My Site');
 });

--- a/apps/design/frontend/src/hooks/use_title.ts
+++ b/apps/design/frontend/src/hooks/use_title.ts
@@ -23,6 +23,8 @@ let resetToBaseTitleTimeout: ReturnType<typeof setTimeout> | undefined;
  * to avoid flickering when the title is updated in quick succession.
  */
 function resetToBaseTitle() {
+  // Prevent errors in tests if jsdom has been torn down before this fires
+  if (typeof document === 'undefined') return;
   /* istanbul ignore next */
   document.title = baseTitle ?? '';
 }


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

`useTitle` schedules a 100ms timer to reset `document.title` when a component unmounts. For the last test in a file, that timer can fire after vitest has torn down the jsdom environment, throwing `ReferenceError: document is not defined` as an unhandled error and failing the run even though every test passed. This PR guards the reset when there is no document, and adds a test that fails without the guard.

## Demo Video or Screenshot

N/A

## Testing Plan

Updated automated tests.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
