### PR TITLE
fix(fs): refuse to read or write anything that is not a regular file

### DIFF
--- a/apps/admin/backend/src/backup/backup.test.ts
+++ b/apps/admin/backend/src/backup/backup.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { readdirSync } from 'node:fs';
 import { rm, truncate, writeFile } from 'node:fs/promises';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
@@ -55,6 +56,23 @@ test('a backup with no manifest cannot be read', async () => {
     message: expect.stringContaining(backup.manifestPath),
   });
 });
+
+// Worth its own test because it lands before authentication: the signature
+// that protects everything else never gets a chance to run.
+test.runIf(process.platform === 'linux')(
+  'a manifest that is not a regular file cannot be read',
+  async () => {
+    const backup = await makeBackup();
+    await rm(backup.manifestPath);
+    execFileSync('mkfifo', [backup.manifestPath]);
+
+    expect((await backup.open()).err()).toEqual({
+      type: 'read-failed',
+      message: expect.stringContaining('not a regular file'),
+    });
+  },
+  10_000
+);
 
 test('a manifest too large to be one of ours is refused before it is read', async () => {
   const backup = await makeBackup();

--- a/apps/admin/backend/src/backup/backup.ts
+++ b/apps/admin/backend/src/backup/backup.ts
@@ -141,6 +141,16 @@ function describeCopyFileError(path: string, error: CopyFileError): string {
       return `Reading ${path} was cancelled`;
     }
 
+    case 'SourceNotRegularFile': {
+      return `${path} is not a regular file`;
+    }
+
+    /* istanbul ignore next: the destination is a directory this process just
+       created for itself, so nothing can be sitting at the path */
+    case 'DestinationNotRegularFile': {
+      return `Could not write a private copy of ${path}`;
+    }
+
     default: {
       return `${extractErrorMessage(error.error)} (${path})`;
     }

--- a/apps/admin/backend/src/backup/backup_manifest_file.test.ts
+++ b/apps/admin/backend/src/backup/backup_manifest_file.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { truncateSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from 'vitest';
@@ -110,5 +111,17 @@ test('a manifest too large to be one of ours is refused before it is read', asyn
   expect(result.unsafeUnwrapErr()).toMatchObject({
     type: 'read-failed',
     message: expect.stringContaining('100000000'),
+  });
+});
+
+test('a manifest that is not a regular file is refused', async () => {
+  const dir = makeTemporaryDirectory();
+  const manifestPath = join(dir, 'manifest.json');
+  execFileSync('mkfifo', [manifestPath]);
+
+  const result = await new BackupManifestFile(manifestPath).readManifest();
+  expect(result.unsafeUnwrapErr()).toMatchObject({
+    type: 'read-failed',
+    message: expect.stringContaining('not a regular file'),
   });
 });

--- a/apps/admin/backend/src/backup/backup_manifest_file.ts
+++ b/apps/admin/backend/src/backup/backup_manifest_file.ts
@@ -25,6 +25,10 @@ function describeReadFileError(error: ReadFileError): string {
       return `file is larger than the maximum of ${error.maxSize} bytes`;
     }
 
+    case 'NotRegularFile': {
+      return 'file is not a regular file';
+    }
+
     default: {
       return extractErrorMessage(error.error);
     }

--- a/apps/admin/backend/src/backup/create/index.test.ts
+++ b/apps/admin/backend/src/backup/create/index.test.ts
@@ -312,6 +312,28 @@ test('reports an error when writing the manifest fails, leaving no partial backu
   expect(readdirSync(new BackupRoot(target).pathFor('.'))).toEqual([]);
 });
 
+test('reports a manifest the target will not hold, leaving no partial backup', async () => {
+  const workspace = await makeConfiguredWorkspace();
+  const target = makeTemporaryDirectory();
+  vi.mocked(writeManifest).mockResolvedValueOnce(
+    err({ type: 'NotRegularFile' })
+  );
+
+  const result = await createBackup({
+    workspace,
+    target,
+    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+  });
+
+  expect(result.err()).toEqual({
+    type: 'backup-write-failed',
+    message: 'The backup target holds something that is not a regular file',
+  });
+  // Everything copied before the manifest failed goes with it, rather than
+  // being left at a path a later run would have to recognize as debris.
+  expect(readdirSync(new BackupRoot(target).pathFor('.'))).toEqual([]);
+});
+
 test('fails fast when writing the backup fails unexpectedly', async () => {
   const workspace = await makeConfiguredWorkspace();
   const target = makeTemporaryDirectory();

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -8,6 +8,7 @@ import {
   Result,
 } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
+import { CopyFileError } from '@votingworks/fs';
 import { prepare, PrepareError } from './prepare_step.js';
 import { PrepareBackupOptions } from './types.js';
 import { copy } from './copy_step.js';
@@ -110,6 +111,37 @@ const CANCELLED_ERROR: CreateBackupError = {
 };
 
 /**
+ * Describes a failed copy of a staged file. A staged file is a hard link this
+ * process made to a file it had already stat'd, so the source cases here say
+ * something went wrong on this machine rather than on the target.
+ */
+function describeCopyFailure(
+  error: Exclude<CopyFileError, { type: 'Cancelled' }>
+): string {
+  switch (error.type) {
+    case 'FileExceedsMaxSize': {
+      return `A staged file grew past its measured size (max ${error.maxSize} bytes)`;
+    }
+
+    /* istanbul ignore next: the staging area only ever links regular files,
+       having stat'd each one before staging it */
+    case 'SourceNotRegularFile': {
+      return 'A staged file is no longer a regular file';
+    }
+
+    /* istanbul ignore next: requires the target to substitute something for a
+       path between the run clearing it and the copy reaching it */
+    case 'DestinationNotRegularFile': {
+      return 'The backup target holds something that is not a regular file';
+    }
+
+    default: {
+      return extractErrorMessage(error.error);
+    }
+  }
+}
+
+/**
  * Throws away a backup that will never be finished. Best effort: whatever
  * stopped the write may stop the cleanup too, and the next run clears the path
  * before it writes anything.
@@ -176,10 +208,7 @@ async function tryCreateBackup(
 
         return err({
           type: 'backup-write-failed',
-          message:
-            error.type === 'FileExceedsMaxSize'
-              ? `A staged file grew past its measured size (max ${error.maxSize} bytes)`
-              : extractErrorMessage(error.error),
+          message: describeCopyFailure(error),
         });
       }
       manifest = copyResult.ok();

--- a/apps/admin/backend/src/backup/create/index.ts
+++ b/apps/admin/backend/src/backup/create/index.ts
@@ -8,7 +8,7 @@ import {
   Result,
 } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
-import { CopyFileError } from '@votingworks/fs';
+import { CopyFileError, WriteFileError } from '@votingworks/fs';
 import { prepare, PrepareError } from './prepare_step.js';
 import { PrepareBackupOptions } from './types.js';
 import { copy } from './copy_step.js';
@@ -110,13 +110,11 @@ const CANCELLED_ERROR: CreateBackupError = {
   message: 'Backup cancelled',
 };
 
-/**
- * Describes a failed copy of a staged file. A staged file is a hard link this
- * process made to a file it had already stat'd, so the source cases here say
- * something went wrong on this machine rather than on the target.
- */
-function describeCopyFailure(
-  error: Exclude<CopyFileError, { type: 'Cancelled' }>
+const NOT_REGULAR_FILE_MESSAGE =
+  'The backup target holds something that is not a regular file';
+
+function describeFileFailure(
+  error: Exclude<CopyFileError, { type: 'Cancelled' }> | WriteFileError
 ): string {
   switch (error.type) {
     case 'FileExceedsMaxSize': {
@@ -132,7 +130,11 @@ function describeCopyFailure(
     /* istanbul ignore next: requires the target to substitute something for a
        path between the run clearing it and the copy reaching it */
     case 'DestinationNotRegularFile': {
-      return 'The backup target holds something that is not a regular file';
+      return NOT_REGULAR_FILE_MESSAGE;
+    }
+
+    case 'NotRegularFile': {
+      return NOT_REGULAR_FILE_MESSAGE;
     }
 
     default: {
@@ -208,7 +210,7 @@ async function tryCreateBackup(
 
         return err({
           type: 'backup-write-failed',
-          message: describeCopyFailure(error),
+          message: describeFileFailure(error),
         });
       }
       manifest = copyResult.ok();
@@ -227,12 +229,21 @@ async function tryCreateBackup(
       return err(CANCELLED_ERROR);
     }
 
-    await writeManifest({
+    const writeManifestResult = await writeManifest({
       manifest,
       backup: inProgressBackupPath,
       logger: options.logger,
       onProgressEvent: options.onProgressEvent,
     });
+
+    if (writeManifestResult.isErr()) {
+      await discardInProgressBackup(inProgressBackupPath);
+
+      return err({
+        type: 'backup-write-failed',
+        message: describeFileFailure(writeManifestResult.err()),
+      });
+    }
   } catch (error) {
     const { code } = error as NodeJS.ErrnoException;
     if (!code || !EXPECTED_WRITE_ERROR_CODES.includes(code)) {

--- a/apps/admin/backend/src/backup/create/manifest_step.test.ts
+++ b/apps/admin/backend/src/backup/create/manifest_step.test.ts
@@ -1,6 +1,12 @@
 import { expect, test, vi } from 'vitest';
 import { join } from 'node:path';
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import {
   electionFamousNames2021Fixtures,
   makeTemporaryDirectory,
@@ -13,6 +19,8 @@ import {
   VXADMIN_BACKUP_MANIFEST_FILE_NAME,
 } from '@votingworks/auth';
 import { DateTime } from 'luxon';
+import { err, typedAs } from '@votingworks/basics';
+import { WriteFileError } from '@votingworks/fs';
 import {
   BackupManifest,
   BackupManifestStructSchema,
@@ -48,12 +56,14 @@ test('writes a manifest alongside a signature that authenticates it', async () =
   const manifest = makeManifest();
   const progressEvents: ProgressEvent[] = [];
 
-  await writeManifest({
-    manifest,
-    backup: backupPath,
-    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-    onProgressEvent: (event) => progressEvents.push(event),
-  });
+  (
+    await writeManifest({
+      manifest,
+      backup: backupPath,
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+      onProgressEvent: (event) => progressEvents.push(event),
+    })
+  ).unsafeUnwrap();
 
   expect(progressEvents).toEqual([{ type: 'writing_manifest' }]);
 
@@ -83,11 +93,13 @@ test('writes a manifest alongside a signature that authenticates it', async () =
 test('the signature does not authenticate a tampered-with manifest', async () => {
   const backupPath = makeBackupDirectory();
 
-  await writeManifest({
-    manifest: makeManifest(),
-    backup: backupPath,
-    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-  });
+  (
+    await writeManifest({
+      manifest: makeManifest(),
+      backup: backupPath,
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+    })
+  ).unsafeUnwrap();
 
   const manifestPath = join(backupPath, VXADMIN_BACKUP_MANIFEST_FILE_NAME);
   const manifest = BackupManifestStructSchema.parse(
@@ -107,3 +119,29 @@ test('the signature does not authenticate a tampered-with manifest', async () =>
     /^Error authenticating .* using signature file:/
   );
 });
+
+// A backup is written to removable media, so what sits at a path we mean to
+// write is chosen by whoever handed us the drive. `/dev/null` stands in for
+// anything a drive could hold there that opens for writing but swallows what
+// is written to it.
+test.runIf(existsSync('/dev/null')).each([
+  { what: 'the manifest', fileName: VXADMIN_BACKUP_MANIFEST_FILE_NAME },
+  {
+    what: 'the signature',
+    fileName: `${VXADMIN_BACKUP_MANIFEST_FILE_NAME}${SIGNATURE_FILE_EXTENSION}`,
+  },
+])(
+  'refuses to write $what to something that is not a regular file',
+  async ({ fileName }) => {
+    const backupPath = makeBackupDirectory();
+    symlinkSync('/dev/null', join(backupPath, fileName));
+
+    expect(
+      await writeManifest({
+        manifest: makeManifest(),
+        backup: backupPath,
+        logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+      })
+    ).toEqual(err(typedAs<WriteFileError>({ type: 'NotRegularFile' })));
+  }
+);

--- a/apps/admin/backend/src/backup/create/manifest_step.ts
+++ b/apps/admin/backend/src/backup/create/manifest_step.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
-import { writeFile } from 'node:fs/promises';
 import { prepareSignatureFile } from '@votingworks/auth';
+import { Result } from '@votingworks/basics';
+import { WriteFileError, writeFile } from '@votingworks/fs';
 import { WriteManifestOptions } from './types.js';
 import { Backup } from '../backup.js';
 
@@ -11,23 +12,26 @@ import { Backup } from '../backup.js';
  */
 export async function writeManifest(
   options: WriteManifestOptions
-): Promise<void> {
+): Promise<Result<void, WriteFileError>> {
   const { manifest, backup } = options;
   options.onProgressEvent?.({ type: 'writing_manifest' });
 
   const manifestFileContents = JSON.stringify(manifest, null, 2);
-  await writeFile(
-    new Backup(backup).manifestPath,
-    manifestFileContents,
-    'utf-8'
-  );
-
   const signatureFile = await prepareSignatureFile({
     type: 'vxadmin_backup',
     context: 'export',
     manifestFileContents,
   });
-  await writeFile(
+
+  const writeManifestFileResult = await writeFile(
+    new Backup(backup).manifestPath,
+    manifestFileContents
+  );
+  if (writeManifestFileResult.isErr()) {
+    return writeManifestFileResult;
+  }
+
+  return writeFile(
     join(backup, signatureFile.fileName),
     signatureFile.fileContents
   );

--- a/apps/admin/backend/src/backup/restore/copy_step.ts
+++ b/apps/admin/backend/src/backup/restore/copy_step.ts
@@ -129,6 +129,24 @@ export async function copyBackupFiles({
           });
         }
 
+        // A manifest entry names a file, so anything else at that path is a
+        // backup that does not hold what it says it holds.
+        case 'SourceNotRegularFile': {
+          return err({
+            type: 'backup-verification-failed',
+            message: `Backup file is not a regular file: ${file.path}`,
+          });
+        }
+
+        /* istanbul ignore next: the workspace was emptied immediately before
+           the copy began, so nothing can be sitting at the destination */
+        case 'DestinationNotRegularFile': {
+          return err({
+            type: 'backup-read-failed',
+            message: `Cannot write ${file.path}: the workspace holds something that is not a regular file`,
+          });
+        }
+
         case 'ReadFileError':
         case 'WriteFileError': {
           return err({

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { readdirSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
-import { appendFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  appendFile,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import {
   electionFamousNames2021Fixtures,
@@ -629,37 +637,41 @@ test.each<{ description: string; tamper: (backup: Backup) => Promise<void> }>([
   ]);
 });
 
-test('restore fails if a backup file cannot be read', async () => {
-  const backup = await makeBackup();
-  const manifest = await readBackupManifest(backup);
-  const unreadableFile = assertDefined(manifest.files.at(-1));
-  const unreadablePath = join(backup.path, unreadableFile.path);
-  // A directory in place of the file reads as EISDIR, standing in for the
-  // whole class of errors a dying USB drive raises mid-copy — EIO, EACCES —
-  // which, unlike ENOENT, say nothing about whether the backup is intact.
-  await rm(unreadablePath);
-  await mkdir(unreadablePath);
+test.runIf(existsSync('/proc/self/mem'))(
+  'restore fails if a backup file cannot be read',
+  async () => {
+    const backup = await makeBackup();
+    const manifest = await readBackupManifest(backup);
+    const unreadableFile = assertDefined(manifest.files.at(-1));
+    const unreadablePath = join(backup.path, unreadableFile.path);
+    // `/proc/self/mem` is a regular file whose reads fail with EIO — a real
+    // failure partway through a read, which a regular file cannot otherwise be
+    // talked into producing, and which says nothing about whether the backup
+    // is intact.
+    await rm(unreadablePath);
+    await symlink('/proc/self/mem', unreadablePath);
 
-  const workspacePath = makeUnconfiguredWorkspacePath();
-  const result = await restoreBackup({
-    backup: backup.path,
-    workspace: restorable(workspacePath),
-    logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-  });
+    const workspacePath = makeUnconfiguredWorkspacePath();
+    const result = await restoreBackup({
+      backup: backup.path,
+      workspace: restorable(workspacePath),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+    });
 
-  // Any failure to copy has to be reported. Reporting success here hands the
-  // operator a workspace missing a file they will not learn about until
-  // something later needs it.
-  // The error type is left open: this is a broken drive, not a claim about
-  // whether the backup itself is valid.
-  expect(result.err()).toMatchObject({
-    message: expect.stringContaining(unreadableFile.path),
-  });
+    // Any failure to copy has to be reported. Reporting success here hands the
+    // operator a workspace missing a file they will not learn about until
+    // something later needs it.
+    // The error type is left open: this is a broken drive, not a claim about
+    // whether the backup itself is valid.
+    expect(result.err()).toMatchObject({
+      message: expect.stringContaining(unreadableFile.path),
+    });
 
-  await expect(
-    exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
-  ).resolves.toBeFalsy();
-});
+    await expect(
+      exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+    ).resolves.toBeFalsy();
+  }
+);
 
 test('restore fails on missing files from the backup manifest', async () => {
   const backup = await makeBackup();
@@ -685,6 +697,37 @@ test('restore fails on missing files from the backup manifest', async () => {
     exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
   ).resolves.toBeFalsy();
 });
+
+// The manifest is signed, but it names paths and the drive decides what sits
+// at each one.
+test.runIf(process.platform === 'linux')(
+  'restore fails if a backup file is a FIFO rather than a regular file',
+  async () => {
+    const backup = await makeBackup();
+    const manifest = await readBackupManifest(backup);
+    const swappedFile = assertDefined(manifest.files.at(-1));
+    const swappedPath = join(backup.path, swappedFile.path);
+    await rm(swappedPath);
+    execFileSync('mkfifo', [swappedPath]);
+
+    const workspacePath = makeUnconfiguredWorkspacePath();
+    const result = await restoreBackup({
+      backup: backup.path,
+      workspace: restorable(workspacePath),
+      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+    });
+
+    expect(result.err()).toMatchObject({
+      type: 'backup-verification-failed',
+      message: expect.stringContaining(swappedFile.path),
+    });
+
+    await expect(
+      exists(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+    ).resolves.toBeFalsy();
+  },
+  10_000
+);
 
 test('restore fails if any backup files are an unexpected size', async () => {
   const backup = await makeBackup();

--- a/libs/fs/src/copy_file.test.ts
+++ b/libs/fs/src/copy_file.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { err, typedAs } from '@votingworks/basics';
@@ -10,6 +11,7 @@ import {
 } from '@votingworks/fixtures';
 import { CopyFileError, copyFile } from './copy_file';
 import * as openFile from './open_file';
+import * as openRegularFile from './open_regular_file';
 import { READ_CHUNK_SIZE } from './read_chunks';
 
 afterEach(() => {
@@ -169,25 +171,79 @@ test('a source that cannot be opened is reported as such', async () => {
   expect(existsSync(destination)).toEqual(false);
 });
 
-test('a source that opens but cannot be read is not blamed on the destination', async () => {
-  // A directory opens fine and fails the read itself, with EISDIR, standing in
-  // for the errors a failing drive raises partway through.
+test('a source that is not a regular file is refused', async () => {
   const source = makeTemporaryDirectory();
   const destination = makeDestinationPath();
 
-  expect(
-    await copyFile({
-      source,
-      destination,
-      maxSize: 1024 * 1024,
-    })
-  ).toEqual(
+  expect(await copyFile({ source, destination, maxSize: 1024 * 1024 })).toEqual(
+    err(typedAs<CopyFileError>({ type: 'SourceNotRegularFile' }))
+  );
+  expect(existsSync(destination)).toEqual(false);
+});
+
+// If the check regresses this hangs rather than fails; see {@link
+// openRegularFile} for why nothing in the caller can interrupt it.
+test.runIf(process.platform === 'linux')(
+  'a FIFO source is refused rather than waited on',
+  async () => {
+    const source = join(makeTemporaryDirectory(), 'fifo');
+    execFileSync('mkfifo', [source]);
+    const destination = makeDestinationPath();
+
+    expect(await copyFile({ source, destination, maxSize: 1024 })).toEqual(
+      err(typedAs<CopyFileError>({ type: 'SourceNotRegularFile' }))
+    );
+    expect(existsSync(destination)).toEqual(false);
+  },
+  5000
+);
+
+test.runIf(process.platform === 'linux')(
+  'a FIFO destination is refused rather than waited on',
+  async () => {
+    const source = makeTemporaryFile({ content: 'contents' });
+    const destination = join(makeTemporaryDirectory(), 'fifo');
+    execFileSync('mkfifo', [destination]);
+
+    // Nothing is reading it, so the open fails outright rather than reaching
+    // the type check.
+    expect(await copyFile({ source, destination, maxSize: 1024 })).toEqual(
+      err(
+        typedAs<CopyFileError>({
+          type: 'WriteFileError',
+          error: expect.objectContaining({ code: 'ENXIO' }),
+        })
+      )
+    );
+  },
+  5000
+);
+
+test('a read that fails partway through is not blamed on the destination', async () => {
+  const content = 'the contents of the file';
+  const source = makeTemporaryFile({ content });
+  const destination = makeDestinationPath();
+
+  // Stands in for the errors a failing drive raises once a read is underway,
+  // which a regular file cannot be talked into producing on demand.
+  const realOpen = openRegularFile.openRegularFileForReading;
+  vi.spyOn(openRegularFile, 'openRegularFileForReading').mockImplementation(
+    async (path) => {
+      const result = await realOpen(path);
+      if (result.isOk()) {
+        vi.spyOn(result.ok(), 'read').mockRejectedValue(
+          Object.assign(new Error('EIO: i/o error, read'), { code: 'EIO' })
+        );
+      }
+      return result;
+    }
+  );
+
+  expect(await copyFile({ source, destination, maxSize: 1024 })).toEqual(
     err(
       typedAs<CopyFileError>({
         type: 'ReadFileError',
-        error: expect.objectContaining({
-          message: expect.stringContaining('EISDIR'),
-        }),
+        error: expect.objectContaining({ code: 'EIO' }),
       })
     )
   );
@@ -221,21 +277,27 @@ test('a short write is completed rather than trusted', async () => {
   // `write` may accept fewer bytes than offered without erroring. Wrap the
   // destination handle so every write takes at most a few bytes, forcing the
   // copy to notice and finish the job.
-  const realOpen = openFile.open;
-  vi.spyOn(openFile, 'open').mockImplementation(async (path, flags, mode) => {
-    const result = await realOpen(path, flags, mode);
-    if (flags === 'w' && result.isOk()) {
-      const handle = result.ok();
-      const realWrite = handle.write.bind(handle);
-      vi.spyOn(handle, 'write').mockImplementation(((
-        buffer: Buffer,
-        offset: number,
-        length: number
-      ) =>
-        realWrite(buffer, offset, Math.min(length, 7))) as typeof handle.write);
+  const realOpen = openRegularFile.openRegularFileForWriting;
+  vi.spyOn(openRegularFile, 'openRegularFileForWriting').mockImplementation(
+    async (path) => {
+      const result = await realOpen(path);
+      if (result.isOk()) {
+        const handle = result.ok();
+        const realWrite = handle.write.bind(handle);
+        vi.spyOn(handle, 'write').mockImplementation(((
+          buffer: Buffer,
+          offset: number,
+          length: number
+        ) =>
+          realWrite(
+            buffer,
+            offset,
+            Math.min(length, 7)
+          )) as typeof handle.write);
+      }
+      return result;
     }
-    return result;
-  });
+  );
 
   const result = await copyFile({
     source,
@@ -251,27 +313,52 @@ test('a short write is completed rather than trusted', async () => {
   expect(readFileSync(destination, 'utf-8')).toEqual(content);
 });
 
-// `/dev/full` opens fine and fails every write with ENOSPC, which is what a
-// destination disk filling up mid-copy looks like. It is Linux-only, so this is
-// skipped elsewhere; CI, where coverage is enforced, runs on Linux. As a device
-// rather than a regular file, it also exercises cleanup declining to unlink a
-// destination that cannot be holding a partial copy.
-test.runIf(existsSync('/dev/full'))(
-  'a write that fails partway through is not blamed on the source',
+test('a write that fails partway through is not blamed on the source', async () => {
+  const source = makeTemporaryFile({ content: 'contents' });
+  const destination = makeDestinationPath();
+
+  // Stands in for the destination disk filling up mid-copy.
+  const realOpen = openRegularFile.openRegularFileForWriting;
+  vi.spyOn(openRegularFile, 'openRegularFileForWriting').mockImplementation(
+    async (path) => {
+      const result = await realOpen(path);
+      if (result.isOk()) {
+        vi.spyOn(result.ok(), 'write').mockRejectedValue(
+          Object.assign(new Error('ENOSPC: no space left on device, write'), {
+            code: 'ENOSPC',
+          })
+        );
+      }
+      return result;
+    }
+  );
+
+  expect(await copyFile({ source, destination, maxSize: 100 })).toEqual(
+    err(
+      typedAs<CopyFileError>({
+        type: 'WriteFileError',
+        error: expect.objectContaining({ code: 'ENOSPC' }),
+      })
+    )
+  );
+
+  // A failed copy leaves nothing behind, however it failed.
+  expect(existsSync(destination)).toEqual(false);
+});
+
+// A device, not a directory: a directory fails the open before the type check
+// can reject it.
+test.runIf(existsSync('/dev/null'))(
+  'a destination that is not a regular file is refused',
   async () => {
     const source = makeTemporaryFile({ content: 'contents' });
 
     expect(
-      await copyFile({ source, destination: '/dev/full', maxSize: 100 })
+      await copyFile({ source, destination: '/dev/null', maxSize: 100 })
     ).toEqual(
-      err(
-        typedAs<CopyFileError>({
-          type: 'WriteFileError',
-          error: expect.objectContaining({ code: 'ENOSPC' }),
-        })
-      )
+      err(typedAs<CopyFileError>({ type: 'DestinationNotRegularFile' }))
     );
-    expect(existsSync('/dev/full')).toEqual(true);
+    expect(existsSync('/dev/null')).toEqual(true);
   }
 );
 

--- a/libs/fs/src/copy_file.ts
+++ b/libs/fs/src/copy_file.ts
@@ -1,7 +1,10 @@
 import { Result, err, ok } from '@votingworks/basics';
 import { createHash } from 'node:crypto';
 import { rm } from 'node:fs/promises';
-import { open } from './open_file';
+import {
+  openRegularFileForReading,
+  openRegularFileForWriting,
+} from './open_regular_file';
 import { FileExceedsMaxSizeError } from './file_exceeds_max_size_error';
 import { ReadChunkError } from './read_chunk_error';
 import { readChunksWithinLimit } from './read_chunks';
@@ -11,6 +14,8 @@ import { readChunksWithinLimit } from './read_chunks';
  */
 export type CopyFileError =
   | { type: 'OpenFileError'; error: globalThis.Error }
+  | { type: 'SourceNotRegularFile' }
+  | { type: 'DestinationNotRegularFile' }
   | { type: 'FileExceedsMaxSize'; maxSize: number }
   | { type: 'ReadFileError'; error: globalThis.Error }
   | { type: 'WriteFileError'; error: globalThis.Error }
@@ -99,19 +104,26 @@ export async function copyFile({
     return err({ type: 'Cancelled' });
   }
 
-  const openSourceResult = await open(source);
+  const openSourceResult = await openRegularFileForReading(source);
   if (openSourceResult.isErr()) {
-    return err({ type: 'OpenFileError', error: openSourceResult.err() });
+    const error = openSourceResult.err();
+    return err(
+      error.type === 'NotRegularFile'
+        ? { type: 'SourceNotRegularFile' }
+        : { type: 'OpenFileError', error: error.error }
+    );
   }
 
   const sourceFd = openSourceResult.ok();
   try {
-    const openDestinationResult = await open(destination, 'w');
+    const openDestinationResult = await openRegularFileForWriting(destination);
     if (openDestinationResult.isErr()) {
-      return err({
-        type: 'WriteFileError',
-        error: openDestinationResult.err(),
-      });
+      const error = openDestinationResult.err();
+      return err(
+        error.type === 'NotRegularFile'
+          ? { type: 'DestinationNotRegularFile' }
+          : { type: 'WriteFileError', error: error.error }
+      );
     }
 
     const destinationFd = openDestinationResult.ok();

--- a/libs/fs/src/copy_file.ts
+++ b/libs/fs/src/copy_file.ts
@@ -173,10 +173,9 @@ export async function copyFile({
 
       return err({ type: 'WriteFileError', error: error as Error });
     } finally {
-      const shouldRemove = !succeeded && (await destinationFd.stat()).isFile();
       await destinationFd.close();
 
-      if (shouldRemove) {
+      if (!succeeded) {
         await rm(destination, { force: true });
       }
     }

--- a/libs/fs/src/index.ts
+++ b/libs/fs/src/index.ts
@@ -6,5 +6,6 @@ export * from './read_chunks';
 export * from './election';
 export * from './list_directory';
 export * from './open_file';
+export * from './open_regular_file';
 export * from './read_file';
 export * from './syscalls';

--- a/libs/fs/src/index.ts
+++ b/libs/fs/src/index.ts
@@ -8,4 +8,5 @@ export * from './list_directory';
 export * from './open_file';
 export * from './open_regular_file';
 export * from './read_file';
+export * from './write_file';
 export * from './syscalls';

--- a/libs/fs/src/open_file.ts
+++ b/libs/fs/src/open_file.ts
@@ -6,6 +6,10 @@ import { FileHandle, open as fsOpen } from 'node:fs/promises';
  * Opens a file and returns a file descriptor. You are responsible for closing
  * the file descriptor when you are done with it. Use `readFile` instead if you
  * need to read the entire file into memory.
+ *
+ * Opens whatever the path names, including directories, devices and FIFOs; see
+ * {@link openRegularFile} for the reasons a caller reading a file's contents
+ * wants {@link openRegularFileForReading} instead.
  */
 export async function open(
   path: string,

--- a/libs/fs/src/open_regular_file.test.ts
+++ b/libs/fs/src/open_regular_file.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { Buffer } from 'node:buffer';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { err, typedAs } from '@votingworks/basics';
+import {
+  makeTemporaryDirectory,
+  makeTemporaryFile,
+} from '@votingworks/fixtures';
+import * as openFile from './open_file';
+import {
+  OpenRegularFileError,
+  openRegularFileForReading,
+  openRegularFileForWriting,
+} from './open_regular_file';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('opens a regular file and reads it', async () => {
+  const path = makeTemporaryFile({ content: 'contents' });
+
+  const file = (await openRegularFileForReading(path)).unsafeUnwrap();
+  try {
+    expect((await file.readFile()).toString('utf-8')).toEqual('contents');
+  } finally {
+    await file.close();
+  }
+});
+
+test('a file that is not there is an open failure', async () => {
+  expect(
+    await openRegularFileForReading(
+      join(makeTemporaryDirectory(), 'does-not-exist')
+    )
+  ).toEqual(
+    err(
+      typedAs<OpenRegularFileError>({
+        type: 'OpenFileError',
+        error: expect.objectContaining({ code: 'ENOENT' }),
+      })
+    )
+  );
+});
+
+test('a directory is not a regular file', async () => {
+  expect(await openRegularFileForReading(makeTemporaryDirectory())).toEqual(
+    err(typedAs<OpenRegularFileError>({ type: 'NotRegularFile' }))
+  );
+});
+
+test.runIf(process.platform === 'linux')(
+  'a FIFO is not a regular file, and does not block',
+  async () => {
+    const path = join(makeTemporaryDirectory(), 'fifo');
+    execFileSync('mkfifo', [path]);
+
+    expect(await openRegularFileForReading(path)).toEqual(
+      err(typedAs<OpenRegularFileError>({ type: 'NotRegularFile' }))
+    );
+  },
+  5000
+);
+
+test.runIf(existsSync('/dev/zero'))(
+  'a device is not a regular file',
+  async () => {
+    expect(await openRegularFileForReading('/dev/zero')).toEqual(
+      err(typedAs<OpenRegularFileError>({ type: 'NotRegularFile' }))
+    );
+  }
+);
+
+test('a descriptor whose type cannot be determined is an open failure', async () => {
+  const path = makeTemporaryFile({ content: 'contents' });
+  const realOpen = openFile.open;
+  vi.spyOn(openFile, 'open').mockImplementation(async (...args) => {
+    const result = await realOpen(...args);
+    if (result.isOk()) {
+      vi.spyOn(result.ok(), 'stat').mockRejectedValue(
+        Object.assign(new Error('EBADF: bad file descriptor, fstat'), {
+          code: 'EBADF',
+        })
+      );
+    }
+    return result;
+  });
+
+  expect(await openRegularFileForReading(path)).toEqual(
+    err(
+      typedAs<OpenRegularFileError>({
+        type: 'OpenFileError',
+        error: expect.objectContaining({ code: 'EBADF' }),
+      })
+    )
+  );
+});
+
+test('opens a file for writing, creating it', async () => {
+  const path = join(makeTemporaryDirectory(), 'new-file');
+
+  const file = (await openRegularFileForWriting(path)).unsafeUnwrap();
+  try {
+    await file.write(Buffer.from('contents'), 0, 8);
+  } finally {
+    await file.close();
+  }
+
+  expect(readFileSync(path, 'utf-8')).toEqual('contents');
+});
+
+test('truncates a file it opens for writing', async () => {
+  const path = makeTemporaryFile({ content: 'a much longer previous value' });
+
+  const file = (await openRegularFileForWriting(path)).unsafeUnwrap();
+  try {
+    await file.write(Buffer.from('short'), 0, 5);
+  } finally {
+    await file.close();
+  }
+
+  expect(readFileSync(path, 'utf-8')).toEqual('short');
+});
+
+test.runIf(existsSync('/dev/null'))(
+  'a device is not opened for writing',
+  async () => {
+    expect(await openRegularFileForWriting('/dev/null')).toEqual(
+      err(typedAs<OpenRegularFileError>({ type: 'NotRegularFile' }))
+    );
+  }
+);
+
+test.runIf(process.platform === 'linux')(
+  'a FIFO with nothing reading it fails the open rather than blocking',
+  async () => {
+    const path = join(makeTemporaryDirectory(), 'fifo');
+    execFileSync('mkfifo', [path]);
+
+    expect(await openRegularFileForWriting(path)).toEqual(
+      err(
+        typedAs<OpenRegularFileError>({
+          type: 'OpenFileError',
+          error: expect.objectContaining({ code: 'ENXIO' }),
+        })
+      )
+    );
+  },
+  5000
+);
+
+test('a directory cannot be opened for writing at all', async () => {
+  expect(await openRegularFileForWriting(makeTemporaryDirectory())).toEqual(
+    err(
+      typedAs<OpenRegularFileError>({
+        type: 'OpenFileError',
+        error: expect.objectContaining({ code: 'EISDIR' }),
+      })
+    )
+  );
+});

--- a/libs/fs/src/open_regular_file.ts
+++ b/libs/fs/src/open_regular_file.ts
@@ -1,0 +1,89 @@
+import { Result, err, ok } from '@votingworks/basics';
+import { Stats, constants } from 'node:fs';
+import { FileHandle } from 'node:fs/promises';
+import { open } from './open_file';
+
+/**
+ * Why {@link openRegularFileForReading} or {@link openRegularFileForWriting}
+ * would not hand back a file.
+ */
+export type OpenRegularFileError =
+  | { type: 'OpenFileError'; error: Error }
+  | { type: 'NotRegularFile' };
+
+/**
+ * Opens a path, refusing anything that is not a regular file.
+ *
+ * A path says nothing about what sits at the end of it, and on removable media
+ * what sits there is chosen by whoever handed us the drive. Two things follow,
+ * and this handles both:
+ *
+ * - `O_NONBLOCK`, because opening a FIFO blocks until something is attached to
+ *   the other end — forever, if nothing ever is. It blocks inside the syscall,
+ *   so no abort signal or timeout in the caller can reach it, and it holds a
+ *   libuv threadpool thread while it waits; four of them and the process does
+ *   no filesystem work at all. The flag makes the open return either way, and
+ *   has no effect on a regular file, which is the only kind that gets past the
+ *   check below.
+ * - An `fstat` of the descriptor we actually opened, rather than a `stat` of
+ *   the path we asked for, so nothing can be swapped in between the two.
+ *   Checking the opened descriptor is also what makes a symlink harmless
+ *   without refusing symlinks: whatever it pointed at is what got opened, and
+ *   that is what gets checked.
+ */
+async function openRegularFile(
+  path: string,
+  flags: number
+): Promise<Result<FileHandle, OpenRegularFileError>> {
+  const openResult = await open(path, flags);
+  if (openResult.isErr()) {
+    return err({ type: 'OpenFileError', error: openResult.err() });
+  }
+
+  const file = openResult.ok();
+  let stats: Stats;
+  try {
+    stats = await file.stat();
+  } catch (error) {
+    await file.close();
+    return err({ type: 'OpenFileError', error: error as Error });
+  }
+
+  if (!stats.isFile()) {
+    await file.close();
+    return err({ type: 'NotRegularFile' });
+  }
+
+  return ok(file);
+}
+
+/**
+ * Opens a regular file for reading. See {@link openRegularFile}.
+ */
+export function openRegularFileForReading(
+  path: string
+): Promise<Result<FileHandle, OpenRegularFileError>> {
+  // eslint-disable-next-line no-bitwise
+  return openRegularFile(path, constants.O_RDONLY | constants.O_NONBLOCK);
+}
+
+/**
+ * Opens a regular file for writing, creating it if it isn't there and
+ * truncating it if it is. See {@link openRegularFile}.
+ *
+ * The check earns its keep on the path that was already taken: `O_CREAT` opens
+ * whatever is there rather than creating anything, so a device node left at a
+ * destination would otherwise be written to as if it were the file.
+ */
+export function openRegularFileForWriting(
+  path: string
+): Promise<Result<FileHandle, OpenRegularFileError>> {
+  return openRegularFile(
+    path,
+    // eslint-disable-next-line no-bitwise
+    constants.O_WRONLY |
+      constants.O_CREAT |
+      constants.O_TRUNC |
+      constants.O_NONBLOCK
+  );
+}

--- a/libs/fs/src/read_file.test.ts
+++ b/libs/fs/src/read_file.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
 import { writeFileSync } from 'node:fs';
 import { err, ok, typedAs } from '@votingworks/basics';
@@ -8,8 +8,13 @@ import {
   makeTemporaryPath,
 } from '@votingworks/fixtures';
 import fc from 'fast-check';
+import * as openRegularFile from './open_regular_file';
 import { ReadFileError, readFile } from './read_file';
 import { READ_CHUNK_SIZE } from './read_chunks';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 test('file open error', async () => {
   const path = makeTemporaryPath();
@@ -23,22 +28,39 @@ test('file open error', async () => {
   );
 });
 
-test('file read error after a successful open', async () => {
-  // A directory opens fine and then fails the read itself, with EISDIR. Before
-  // the try/finally around the read this threw past the `Result` contract and
-  // leaked the file descriptor.
-  const path = makeTemporaryDirectory();
+test('a path that is not a regular file is refused', async () => {
+  // A directory used to get as far as the first read and fail with EISDIR.
+  // It is now turned away at the open, along with the FIFOs and devices that
+  // would not have failed at all.
+  expect(
+    await readFile(makeTemporaryDirectory(), { maxSize: 1024 * 1024 })
+  ).toEqual(err(typedAs<ReadFileError>({ type: 'NotRegularFile' })));
+});
 
-  // Comfortably above the size a directory inode stats at, so the size check
-  // passes and the read itself is what fails.
-  const result = await readFile(path, { maxSize: 1024 * 1024 });
-  expect(result).toEqual(
-    err({
-      type: 'ReadFileError',
-      error: expect.objectContaining({
-        message: expect.stringContaining('EISDIR'),
-      }),
-    })
+test('file read error after a successful open', async () => {
+  // Before the try/finally around the read this threw past the `Result`
+  // contract and leaked the file descriptor.
+  const path = makeTemporaryFile({ content: 'contents' });
+  const realOpen = openRegularFile.openRegularFileForReading;
+  vi.spyOn(openRegularFile, 'openRegularFileForReading').mockImplementation(
+    async (filePath) => {
+      const result = await realOpen(filePath);
+      if (result.isOk()) {
+        vi.spyOn(result.ok(), 'read').mockRejectedValue(
+          Object.assign(new Error('EIO: i/o error, read'), { code: 'EIO' })
+        );
+      }
+      return result;
+    }
+  );
+
+  expect(await readFile(path, { maxSize: 1024 * 1024 })).toEqual(
+    err(
+      typedAs<ReadFileError>({
+        type: 'ReadFileError',
+        error: expect.objectContaining({ code: 'EIO' }),
+      })
+    )
   );
 });
 

--- a/libs/fs/src/read_file.ts
+++ b/libs/fs/src/read_file.ts
@@ -1,6 +1,6 @@
 import { assert, Result, err, ok } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
-import { open } from './open_file';
+import { openRegularFileForReading } from './open_regular_file';
 import { FileExceedsMaxSizeError } from './file_exceeds_max_size_error';
 import { ReadChunkError } from './read_chunk_error';
 import { readChunksWithinLimit } from './read_chunks';
@@ -10,6 +10,7 @@ import { readChunksWithinLimit } from './read_chunks';
  */
 export type ReadFileError =
   | { type: 'OpenFileError'; error: globalThis.Error }
+  | { type: 'NotRegularFile' }
   | { type: 'FileExceedsMaxSize'; maxSize: number }
   | { type: 'ReadFileError'; error: globalThis.Error };
 
@@ -51,10 +52,15 @@ export async function readFile(
     throw new Error('maxSize must be non-negative');
   }
 
-  const openResult = await open(path);
+  const openResult = await openRegularFileForReading(path);
 
   if (openResult.isErr()) {
-    return err({ type: 'OpenFileError', error: openResult.err() });
+    const error = openResult.err();
+    return err(
+      error.type === 'NotRegularFile'
+        ? { type: 'NotRegularFile' }
+        : { type: 'OpenFileError', error: error.error }
+    );
   }
 
   const fd = openResult.ok();

--- a/libs/fs/src/write_file.test.ts
+++ b/libs/fs/src/write_file.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { existsSync, readdirSync, readFileSync, readlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { err, ok, typedAs } from '@votingworks/basics';
+import {
+  makeTemporaryDirectory,
+  makeTemporaryFile,
+  makeTemporaryPath,
+} from '@votingworks/fixtures';
+import fc from 'fast-check';
+import * as openRegularFile from './open_regular_file';
+import { WriteFileError, writeFile } from './write_file';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('file open error', async () => {
+  const path = join(makeTemporaryPath(), 'file');
+  expect(await writeFile(path, 'contents')).toEqual(
+    err(
+      typedAs<WriteFileError>({
+        type: 'OpenFileError',
+        error: expect.objectContaining({ code: 'ENOENT' }),
+      })
+    )
+  );
+});
+
+test('a path that is not a regular file is refused', async () => {
+  expect(await writeFile(makeTemporaryDirectory(), 'contents')).toEqual(
+    err(
+      typedAs<WriteFileError>({
+        type: 'OpenFileError',
+        error: expect.objectContaining({ code: 'EISDIR' }),
+      })
+    )
+  );
+});
+
+test.runIf(existsSync('/dev/null'))(
+  'a device that opens for writing is refused',
+  async () => {
+    expect(await writeFile('/dev/null', 'contents')).toEqual(
+      err(typedAs<WriteFileError>({ type: 'NotRegularFile' }))
+    );
+  }
+);
+
+test('file write error after a successful open', async () => {
+  const path = makeTemporaryFile({ content: 'contents' });
+  const realOpen = openRegularFile.openRegularFileForWriting;
+  const closes: Array<Promise<void>> = [];
+  vi.spyOn(openRegularFile, 'openRegularFileForWriting').mockImplementation(
+    async (filePath) => {
+      const result = await realOpen(filePath);
+      if (result.isOk()) {
+        vi.spyOn(result.ok(), 'writeFile').mockRejectedValue(
+          Object.assign(new Error('ENOSPC: no space left on device, write'), {
+            code: 'ENOSPC',
+          })
+        );
+        const file = result.ok();
+        const realClose = file.close.bind(file);
+        vi.spyOn(file, 'close').mockImplementation(() => {
+          const close = realClose();
+          closes.push(close);
+          return close;
+        });
+      }
+      return result;
+    }
+  );
+
+  expect(await writeFile(path, 'contents')).toEqual(
+    err(
+      typedAs<WriteFileError>({
+        type: 'WriteFileError',
+        error: expect.objectContaining({ code: 'ENOSPC' }),
+      })
+    )
+  );
+  // A failed write must still not leak the descriptor.
+  expect(closes).toHaveLength(1);
+});
+
+test('success', async () => {
+  const path = makeTemporaryPath();
+
+  expect(await writeFile(path, 'file contents')).toEqual(ok());
+  expect(readFileSync(path, 'utf-8')).toEqual('file contents');
+
+  // An existing file is truncated rather than written over in place, so no
+  // part of what was there before survives a shorter write.
+  expect(await writeFile(path, 'short')).toEqual(ok());
+  expect(readFileSync(path, 'utf-8')).toEqual('short');
+
+  await fc.assert(
+    fc.asyncProperty(fc.uint8Array(), async (contents) => {
+      expect(await writeFile(path, contents)).toEqual(ok());
+      expect(readFileSync(path)).toEqual(Buffer.from(contents));
+    })
+  );
+});
+
+test.runIf(existsSync('/proc/self/fd'))(
+  'closes the file it wrote',
+  async () => {
+    const path = makeTemporaryPath();
+
+    expect(await writeFile(path, 'contents')).toEqual(ok());
+
+    const openFiles = readdirSync('/proc/self/fd').flatMap((fd) => {
+      try {
+        return [readlinkSync(join('/proc/self/fd', fd))];
+      } catch {
+        // The descriptor used to read the directory is gone by the time we
+        // get to it.
+        return [];
+      }
+    });
+    expect(openFiles).not.toContain(path);
+  }
+);

--- a/libs/fs/src/write_file.ts
+++ b/libs/fs/src/write_file.ts
@@ -1,0 +1,48 @@
+import { Result, err, ok } from '@votingworks/basics';
+import { openRegularFileForWriting } from './open_regular_file';
+
+/**
+ * Possible errors that can occur when writing a file.
+ */
+export type WriteFileError =
+  | { type: 'OpenFileError'; error: globalThis.Error }
+  | { type: 'NotRegularFile' }
+  | { type: 'WriteFileError'; error: globalThis.Error };
+
+/**
+ * Writes the entire contents of a file, creating it if it is not there and
+ * truncating it if it is. The counterpart to {@link readFile}, and like it
+ * refuses a path holding anything but a regular file: see
+ * {@link openRegularFileForWriting}.
+ *
+ * @param path The path to the file to write.
+ * @param contents What to write to it.
+ */
+export async function writeFile(
+  path: string,
+  contents: string | Uint8Array
+): Promise<Result<void, WriteFileError>> {
+  const openResult = await openRegularFileForWriting(path);
+
+  if (openResult.isErr()) {
+    const error = openResult.err();
+    return err(
+      error.type === 'NotRegularFile'
+        ? { type: 'NotRegularFile' }
+        : { type: 'OpenFileError', error: error.error }
+    );
+  }
+
+  const fd = openResult.ok();
+
+  try {
+    await fd.writeFile(contents);
+  } catch (error) {
+    return err({ type: 'WriteFileError', error: error as globalThis.Error });
+  } finally {
+    // However this ended, the descriptor must not leak.
+    await fd.close();
+  }
+
+  return ok();
+}


### PR DESCRIPTION
## Overview

Refs #7897

`open(2)` on a FIFO blocks until something attaches to the other end, inside the syscall where no abort signal or timeout can reach it. A signed manifest doesn't help: it names paths, and on removable media the drive decides what each path *is* — the manifest can itself be the FIFO, hanging a restore before any signature is checked. The mount options don't either, since `nosymfollow` and `nodev` stop symlinks and device nodes but a FIFO is neither.

Reads and writes now go through `openRegularFile`, which opens with `O_NONBLOCK` and refuses anything that isn't a regular file, checking the descriptor it opened rather than the path it asked for. Writing needs this too: `O_CREAT` opens whatever is already there, so a device node left where a backup file was going would have been written *to*.

`open()` itself is unchanged — `syncFilesystem` opens directories with it and mark-scan opens sysfs files.

## Testing Plan

New automated tests, against real FIFOs and devices. Mutation-tested both halves: removing the type check fails 5 tests, removing `O_NONBLOCK` makes the FIFO test time out — i.e. reproduces the hang.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
