### PR TITLE
refactor: pass the QR payload into `BmdPaperBallot`

### DIFF
--- a/apps/mark-scan/backend/package.json
+++ b/apps/mark-scan/backend/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
+    "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/ballot-interpreter": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/bmd-ballot-fixtures": "workspace:*",

--- a/apps/mark-scan/backend/src/util/render_ballot.tsx
+++ b/apps/mark-scan/backend/src/util/render_ballot.tsx
@@ -5,6 +5,7 @@ import {
 } from '@votingworks/printing';
 import {
   BallotStyleId,
+  BallotType,
   Election,
   ElectionDefinition,
   getBallotStyle,
@@ -12,6 +13,7 @@ import {
   HmpbBallotPaperSize,
   VotesDict,
 } from '@votingworks/types';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 
 import { assertDefined } from '@votingworks/basics';
 import { randomUUID } from 'node:crypto';
@@ -75,6 +77,7 @@ export async function renderTestModeBallotWithoutLanguageContext(
     ballotStyle,
   });
 
+  const ballotAuditId = randomUUID();
   const ballot = (
     <BmdPaperBallot
       binarize
@@ -88,8 +91,19 @@ export async function renderTestModeBallotWithoutLanguageContext(
       machineType={MACHINE_TYPE}
       pageNumber={1}
       totalPages={1}
-      ballotAuditId={randomUUID()}
       contestsForPage={contests}
+      encodedBallot={encodeSummaryBallotPage(electionDefinition.election, {
+        ballotHash: electionDefinition.ballotHash,
+        ballotStyleId,
+        precinctId,
+        votes,
+        isTestMode: true,
+        ballotType: BallotType.Precinct,
+        pageNumber: 1,
+        totalPages: 1,
+        ballotAuditId,
+        contests,
+      })}
     />
   );
 
@@ -154,8 +168,19 @@ export async function renderBallot({
           machineType={MACHINE_TYPE}
           pageNumber={1}
           totalPages={1}
-          ballotAuditId={ballotAuditId}
           contestsForPage={contests}
+          encodedBallot={encodeSummaryBallotPage(electionDefinition.election, {
+            ballotHash: electionDefinition.ballotHash,
+            ballotStyleId,
+            precinctId,
+            votes,
+            isTestMode: !isLiveMode,
+            ballotType: BallotType.Precinct,
+            pageNumber: 1,
+            totalPages: 1,
+            ballotAuditId,
+            contests,
+          })}
         />
       </BackendLanguageContextProvider>
     );

--- a/apps/mark-scan/backend/tsconfig.build.json
+++ b/apps/mark-scan/backend/tsconfig.build.json
@@ -11,6 +11,7 @@
     "declarationMap": true
   },
   "references": [
+    { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/bmd-ballot-fixtures/tsconfig.build.json" },

--- a/apps/mark-scan/backend/tsconfig.json
+++ b/apps/mark-scan/backend/tsconfig.json
@@ -19,6 +19,7 @@
     "noPropertyAccessFromIndexSignature": false
   },
   "references": [
+    { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/bmd-ballot-fixtures/tsconfig.build.json" },

--- a/apps/mark/backend/package.json
+++ b/apps/mark/backend/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@votingworks/auth": "workspace:*",
     "@votingworks/backend": "workspace:*",
+    "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/db": "workspace:*",
     "@votingworks/dev-dock-backend": "workspace:*",

--- a/apps/mark/backend/src/util/print_ballot.test.tsx
+++ b/apps/mark/backend/src/util/print_ballot.test.tsx
@@ -28,14 +28,24 @@ import {
   filterVotesForContests,
 } from '@votingworks/ui';
 import { UiStringsStore } from '@votingworks/backend';
-import { ok } from '@votingworks/basics';
+import { assertDefined, ok } from '@votingworks/basics';
 import { mockConstructor } from '@votingworks/test-utils';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import { type Store } from '../store.js';
 import { closeLayoutRenderer, printBallot } from './print_ballot.js';
 
 vi.mock('@votingworks/hmpb');
 vi.mock('@votingworks/printing');
 vi.mock('@votingworks/ui');
+// Spy on the encoder without changing what it produces: rendered ballots are
+// compared against image snapshots elsewhere in this suite.
+vi.mock(import('@votingworks/ballot-encoder'), async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    encodeSummaryBallotPage: vi.fn(actual.encodeSummaryBallotPage),
+  };
+});
 
 const electionDefBase = electionGeneralFixtures.readElectionDefinition();
 
@@ -124,7 +134,9 @@ describe(`printMode === "summary"`, () => {
     ));
 
     const mockUiStrings: UiStringsPackage = { 'es-US': { hello: 'hola' } };
-    const mockPrecinctId = 'precinct-one';
+    // Must be a precinct this ballot style actually covers: the encoder
+    // rejects an unknown precinct rather than guessing at an index.
+    const mockPrecinctId = assertDefined(ballotStyle.precincts[0]);
     const mockPdf = Uint8Array.of(0xca, 0xfe);
     vi.mocked(renderToPdf).mockImplementation((spec) => {
       expect(spec).toEqual<RenderSpec>({
@@ -142,8 +154,8 @@ describe(`printMode === "summary"`, () => {
               machineType="mark"
               pageNumber={1}
               totalPages={1}
-              ballotAuditId={expect.any(String)}
               contestsForPage={allContests}
+              encodedBallot={expect.any(Uint8Array)}
             />
           </BackendLanguageContextProvider>
         ),
@@ -178,6 +190,24 @@ describe(`printMode === "summary"`, () => {
       }),
       votes: mockVotes,
     });
+
+    // The QR payload is built here rather than inside BmdPaperBallot, so this
+    // is where the ballot data reaching the encoder gets checked.
+    expect(encodeSummaryBallotPage).toHaveBeenCalledWith(
+      electionDefinition.election,
+      expect.objectContaining({
+        ballotHash: electionDefinition.ballotHash,
+        ballotStyleId: ballotStyle.id,
+        precinctId: mockPrecinctId,
+        votes: mockVotes,
+        isTestMode: false,
+        ballotType: BallotType.Precinct,
+        pageNumber: 1,
+        totalPages: 1,
+        ballotAuditId: expect.any(String),
+        contests: allContests,
+      })
+    );
 
     // Single-page: should NOT initialize SummaryBallotLayoutRenderer
     expect(SummaryBallotLayoutRenderer).not.toHaveBeenCalled();
@@ -328,7 +358,6 @@ describe(`printMode === "summary"`, () => {
     const page1Props = page1BmdElement.props;
     expect(page1Props.pageNumber).toEqual(1);
     expect(page1Props.totalPages).toEqual(2);
-    expect(page1Props.ballotAuditId).toBeDefined();
     expect(
       page1Props.contestsForPage?.map((c: { id: string }) => c.id).sort()
     ).toEqual([...page1ContestIds].sort());
@@ -338,10 +367,20 @@ describe(`printMode === "summary"`, () => {
     const page2Props = page2BmdElement.props;
     expect(page2Props.pageNumber).toEqual(2);
     expect(page2Props.totalPages).toEqual(2);
-    expect(page2Props.ballotAuditId).toBeDefined();
 
-    // Same ballotAuditId should be used across both pages
-    expect(page1Props.ballotAuditId).toEqual(page2Props.ballotAuditId);
+    // The audit id now travels in the encoded payload rather than as a prop.
+    // Both pages must carry the same one so they can be correlated after they
+    // are physically separated by scanning.
+    // The first call is the optimistic single-page attempt that gets discarded
+    // once it turns out not to fit; the multi-page render follows it.
+    const encodedPages = vi
+      .mocked(encodeSummaryBallotPage)
+      .mock.calls.slice(-2);
+    const [[, firstPage], [, secondPage]] = encodedPages;
+    expect(firstPage.ballotAuditId).toBeDefined();
+    expect(firstPage.ballotAuditId).toEqual(secondPage.ballotAuditId);
+    expect(firstPage.pageNumber).toEqual(1);
+    expect(secondPage.pageNumber).toEqual(2);
 
     expect(
       page2Props.contestsForPage?.map((c: { id: string }) => c.id).sort()

--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -12,10 +12,13 @@ import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { generateMarkOverlay } from '@votingworks/hmpb';
 import {
   BallotStyleId,
+  BallotType,
+  Contest,
   Election,
   getBallotStyle,
   getContests,
 } from '@votingworks/types';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import {
   BmdPaperBallot,
   BackendLanguageContextProvider,
@@ -77,6 +80,25 @@ export async function printBallot(p: PrintBallotProps): Promise<void> {
   const allContests = getContests({ ballotStyle, election });
   const ballotAuditId = uuid();
 
+  function encodePage(
+    pageNumber: number,
+    totalPages: number,
+    contestsForPage: readonly Contest[]
+  ) {
+    return encodeSummaryBallotPage(election, {
+      ballotHash: electionDefinition.ballotHash,
+      ballotStyleId,
+      precinctId,
+      votes,
+      isTestMode: !isLiveMode,
+      ballotType: BallotType.Precinct,
+      pageNumber,
+      totalPages,
+      ballotAuditId,
+      contests: contestsForPage,
+    });
+  }
+
   // Optimistically render as a single-page-equivalent ballot (totalPages: 1)
   const singlePageBallot = (
     <BackendLanguageContextProvider
@@ -93,8 +115,8 @@ export async function printBallot(p: PrintBallotProps): Promise<void> {
         machineType="mark"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId={ballotAuditId}
         contestsForPage={allContests}
+        encodedBallot={encodePage(1, 1, allContests)}
       />
     </BackendLanguageContextProvider>
   );
@@ -158,8 +180,12 @@ export async function printBallot(p: PrintBallotProps): Promise<void> {
               machineType="mark"
               pageNumber={pageBreak.pageNumber}
               totalPages={pageBreaks.length}
-              ballotAuditId={ballotAuditId}
               contestsForPage={pageContests}
+              encodedBallot={encodePage(
+                pageBreak.pageNumber,
+                pageBreaks.length,
+                pageContests
+              )}
               layout={pageBreak.layout}
             />
           </BackendLanguageContextProvider>

--- a/apps/mark/backend/src/util/print_test_page.tsx
+++ b/apps/mark/backend/src/util/print_test_page.tsx
@@ -1,5 +1,10 @@
 import { BmdPaperBallot } from '@votingworks/ui';
-import { ElectionDefinition, HmpbBallotPaperSize } from '@votingworks/types';
+import {
+  BallotType,
+  ElectionDefinition,
+  HmpbBallotPaperSize,
+} from '@votingworks/types';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import { DateWithoutTime, assertDefined } from '@votingworks/basics';
 import { Printer, renderToPdf } from '@votingworks/printing';
 import { LogEventId, Logger } from '@votingworks/logging';
@@ -93,6 +98,21 @@ export async function printTestPage({
   logger: Logger;
 }): Promise<void> {
   const mockElectionDefinition = getMockElectionDefinition();
+  const encodedBallot = encodeSummaryBallotPage(
+    mockElectionDefinition.election,
+    {
+      ballotHash: mockElectionDefinition.ballotHash,
+      ballotStyleId: 'ballot-style-0',
+      precinctId: 'precinct-0',
+      votes: {},
+      isTestMode: true,
+      ballotType: BallotType.Precinct,
+      pageNumber: 1,
+      totalPages: 1,
+      ballotAuditId: 'test-page-audit-id',
+      contests: mockElectionDefinition.election.contests,
+    }
+  );
 
   const ballot = (
     <BmdPaperBallot
@@ -104,8 +124,8 @@ export async function printTestPage({
       machineType="mark"
       pageNumber={1}
       totalPages={1}
-      ballotAuditId="test-page-audit-id"
       contestsForPage={mockElectionDefinition.election.contests}
+      encodedBallot={encodedBallot}
     />
   );
 

--- a/apps/mark/backend/tsconfig.build.json
+++ b/apps/mark/backend/tsconfig.build.json
@@ -11,6 +11,7 @@
     "declarationMap": true
   },
   "references": [
+    { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },

--- a/apps/mark/backend/tsconfig.json
+++ b/apps/mark/backend/tsconfig.json
@@ -19,6 +19,7 @@
     "noPropertyAccessFromIndexSignature": false
   },
   "references": [
+    { "path": "../../../libs/ballot-encoder/tsconfig.build.json" },
     { "path": "../../../libs/auth/tsconfig.build.json" },
     { "path": "../../../libs/backend/tsconfig.build.json" },
     { "path": "../../../libs/basics/tsconfig.build.json" },

--- a/libs/bmd-ballot-fixtures/package.json
+++ b/libs/bmd-ballot-fixtures/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@types/tmp": "0.2.4",
+    "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/fs": "workspace:*",

--- a/libs/bmd-ballot-fixtures/src/bmd_ballot_fixtures.tsx
+++ b/libs/bmd-ballot-fixtures/src/bmd_ballot_fixtures.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderToPdf } from '@votingworks/printing';
 import tmp from 'tmp';
 import {
+  BallotType,
   ElectionDefinition,
   VotesDict,
   BallotStyleId,
@@ -10,6 +11,7 @@ import {
   getContests,
   vote,
 } from '@votingworks/types';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import { BmdPaperBallot } from '@votingworks/ui';
 
 import {
@@ -82,6 +84,19 @@ export async function renderBmdBallotFixture(
     }
   }
 
+  const encodedBallot = encodeSummaryBallotPage(electionDefinition.election, {
+    ballotHash: electionDefinition.ballotHash,
+    ballotStyleId: ballotStyle.id,
+    precinctId: resolvedPrecinctId,
+    votes: votesForPage,
+    isTestMode: !isLiveMode,
+    ballotType: BallotType.Precinct,
+    pageNumber,
+    totalPages,
+    ballotAuditId,
+    contests: contestsForPage,
+  });
+
   const ballot = (
     <React.Fragment>
       <BmdPaperBallot
@@ -93,8 +108,8 @@ export async function renderBmdBallotFixture(
         votes={votesForPage}
         pageNumber={pageNumber}
         totalPages={totalPages}
-        ballotAuditId={ballotAuditId}
         contestsForPage={contestsForPage}
+        encodedBallot={encodedBallot}
       />
       {!frontPageOnly && <div style={{ pageBreakAfter: 'always' }} />}
     </React.Fragment>

--- a/libs/bmd-ballot-fixtures/tsconfig.build.json
+++ b/libs/bmd-ballot-fixtures/tsconfig.build.json
@@ -10,6 +10,7 @@
     "declaration": true
   },
   "references": [
+    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
     { "path": "../image-utils/tsconfig.build.json" },
     { "path": "../printing/tsconfig.build.json" },

--- a/libs/bmd-ballot-fixtures/tsconfig.json
+++ b/libs/bmd-ballot-fixtures/tsconfig.json
@@ -13,6 +13,7 @@
   "include": ["src", "test"],
   "exclude": [],
   "references": [
+    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },
     { "path": "../printing/tsconfig.build.json" },

--- a/libs/printing/package.json
+++ b/libs/printing/package.json
@@ -49,6 +49,7 @@
     "@types/styled-components": "^5.1.26",
     "@types/tmp": "0.2.4",
     "@vitest/coverage-istanbul": "^4.1.6",
+    "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/image-utils": "workspace:*",
     "esbuild": "0.28.1",

--- a/libs/printing/src/summary_ballot_layout.test.tsx
+++ b/libs/printing/src/summary_ballot_layout.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
-import { ElectionDefinition, VotesDict } from '@votingworks/types';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
+import { BallotType, ElectionDefinition, VotesDict } from '@votingworks/types';
 import {
   BmdPaperBallot,
   filterVotesForContests,
@@ -194,7 +195,6 @@ describe('Multi-page summary ballot visual snapshots', () => {
     votes: VotesDict
   ): Promise<Uint8Array[]> {
     const { election } = electionDefinition;
-    const ballotAuditId = 'test-ballot-audit-id';
     const pdfs: Uint8Array[] = [];
 
     for (const pageBreak of pageBreaks) {
@@ -215,8 +215,19 @@ describe('Multi-page summary ballot visual snapshots', () => {
             machineType="mark"
             pageNumber={pageBreak.pageNumber}
             totalPages={pageBreaks.length}
-            ballotAuditId={ballotAuditId}
             contestsForPage={pageContests}
+            encodedBallot={encodeSummaryBallotPage(election, {
+              ballotHash: electionDefinition.ballotHash,
+              ballotStyleId: 'ballot-style-1',
+              precinctId: 'precinct-1',
+              votes: pageVotes,
+              isTestMode: true,
+              ballotType: BallotType.Precinct,
+              pageNumber: pageBreak.pageNumber,
+              totalPages: pageBreaks.length,
+              ballotAuditId: 'test-ballot-audit-id',
+              contests: pageContests,
+            })}
             layout={pageBreak.layout}
           />
         </VxThemeProvider>
@@ -417,7 +428,6 @@ describe('Medium-large election summary ballot test deck', () => {
     }
 
     const { election } = electionDefinition;
-    const ballotAuditId = 'test-ballot-audit-id';
     const pdfs: Uint8Array[] = [];
 
     for (const pageBreak of pageBreaks) {
@@ -438,8 +448,19 @@ describe('Medium-large election summary ballot test deck', () => {
             machineType="mark"
             pageNumber={pageBreak.pageNumber}
             totalPages={pageBreaks.length}
-            ballotAuditId={ballotAuditId}
             contestsForPage={pageContests}
+            encodedBallot={encodeSummaryBallotPage(election, {
+              ballotHash: electionDefinition.ballotHash,
+              ballotStyleId: 'ballot-style-1',
+              precinctId: 'precinct-1',
+              votes: pageVotes,
+              isTestMode: true,
+              ballotType: BallotType.Precinct,
+              pageNumber: pageBreak.pageNumber,
+              totalPages: pageBreaks.length,
+              ballotAuditId: 'test-ballot-audit-id',
+              contests: pageContests,
+            })}
             layout={pageBreak.layout}
           />
         </VxThemeProvider>

--- a/libs/printing/src/summary_ballot_layout.tsx
+++ b/libs/printing/src/summary_ballot_layout.tsx
@@ -35,6 +35,12 @@ export interface SummaryBallotPageLayout {
   layout: Layout;
 }
 
+// This render exists only to measure height. The QR code sits in a
+// fixed-size box, so its contents cannot affect the measurement, and encoding
+// a real payload here would mean depending on the ballot encoder from a
+// package that frontends list as a dependency.
+const MEASUREMENT_ENCODED_BALLOT = new Uint8Array([0, 0, 0, 0]);
+
 const PLAYWRIGHT_PIXELS_PER_INCH = 96;
 const CONTENT_WRAPPER_ID = 'summary-ballot-measure';
 
@@ -125,8 +131,8 @@ async function measureBallotHeight(
       layout={layout}
       pageNumber={pageNumber}
       totalPages={totalPages}
-      ballotAuditId="measurement-ballot"
       contestsForPage={contests}
+      encodedBallot={MEASUREMENT_ENCODED_BALLOT}
     />
   );
 

--- a/libs/printing/tsconfig.build.json
+++ b/libs/printing/tsconfig.build.json
@@ -11,6 +11,7 @@
     "declarationMap": true
   },
   "references": [
+    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../backend/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },

--- a/libs/printing/tsconfig.json
+++ b/libs/printing/tsconfig.json
@@ -18,6 +18,7 @@
     "noUncheckedIndexedAccess": false
   },
   "references": [
+    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },

--- a/libs/test-decks/package.json
+++ b/libs/test-decks/package.json
@@ -26,6 +26,7 @@
     "type-check": "tsc --build"
   },
   "dependencies": {
+    "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/hmpb": "workspace:*",
     "@votingworks/printing": "workspace:*",

--- a/libs/test-decks/src/summary_ballots.test.ts
+++ b/libs/test-decks/src/summary_ballots.test.ts
@@ -12,6 +12,7 @@ import {
   createTestElection,
   mockConstructor,
 } from '@votingworks/test-utils';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import { createSummaryBallotTestDeck } from './summary_ballots.js';
 import { generateTestDeckBallots } from './test_decks.js';
 
@@ -52,6 +53,16 @@ vi.mock('@votingworks/hmpb', async (importActual) => {
 
 // The summary ballot test deck generates a random ballot audit ID per ballot,
 // which is encoded into the QR code. Pin it so the PDF snapshots are stable.
+// Spy on the encoder without changing what it produces: rendered ballots are
+// compared against image snapshots elsewhere in this suite.
+vi.mock(import('@votingworks/ballot-encoder'), async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    encodeSummaryBallotPage: vi.fn(actual.encodeSummaryBallotPage),
+  };
+});
+
 vi.mock('node:crypto', async (importActual) => ({
   ...(await importActual<typeof import('node:crypto')>()),
   // eslint-disable-next-line vx/gts-identifiers
@@ -169,7 +180,6 @@ describe('createSummaryBallotTestDeck - multi-page flow', () => {
     const page1Props = documents[0].document.props;
     expect(page1Props.pageNumber).toEqual(1);
     expect(page1Props.totalPages).toEqual(2);
-    expect(page1Props.ballotAuditId).toBeDefined();
     expect(
       page1Props.contestsForPage.map((c: { id: string }) => c.id).sort()
     ).toEqual([...page1ContestIds].sort());
@@ -178,10 +188,16 @@ describe('createSummaryBallotTestDeck - multi-page flow', () => {
     const page2Props = documents[1].document.props;
     expect(page2Props.pageNumber).toEqual(2);
     expect(page2Props.totalPages).toEqual(2);
-    expect(page2Props.ballotAuditId).toBeDefined();
 
-    // Same ballotAuditId across both pages
-    expect(page1Props.ballotAuditId).toEqual(page2Props.ballotAuditId);
+    // The audit id now travels in the encoded payload rather than as a prop.
+    // Both pages must carry the same one so they can be correlated after they
+    // are physically separated by scanning.
+    const [[, firstPage], [, secondPage]] = vi.mocked(encodeSummaryBallotPage)
+      .mock.calls;
+    expect(firstPage.ballotAuditId).toBeDefined();
+    expect(firstPage.ballotAuditId).toEqual(secondPage.ballotAuditId);
+    expect(firstPage.pageNumber).toEqual(1);
+    expect(secondPage.pageNumber).toEqual(2);
 
     expect(
       page2Props.contestsForPage.map((c: { id: string }) => c.id).sort()

--- a/libs/test-decks/src/summary_ballots.ts
+++ b/libs/test-decks/src/summary_ballots.ts
@@ -1,4 +1,9 @@
-import { BallotStyleId, ElectionDefinition } from '@votingworks/types';
+import {
+  BallotStyleId,
+  BallotType,
+  ElectionDefinition,
+} from '@votingworks/types';
+import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import { assertDefined } from '@votingworks/basics';
 import {
   renderToPdf,
@@ -87,8 +92,19 @@ export async function createSummaryBallotTestDeck({
             machineType: 'mark' as const,
             pageNumber: pageBreak.pageNumber,
             totalPages: pageBreaks.length,
-            ballotAuditId,
             contestsForPage: pageContests,
+            encodedBallot: encodeSummaryBallotPage(election, {
+              ballotHash: electionDefinition.ballotHash,
+              ballotStyleId: ballotSpec.ballotStyleId,
+              precinctId: ballotSpec.precinctId,
+              votes: filterVotesForContests(ballotSpec.votes, pageContests),
+              isTestMode: !isLiveMode,
+              ballotType: BallotType.Precinct,
+              pageNumber: pageBreak.pageNumber,
+              totalPages: pageBreaks.length,
+              ballotAuditId,
+              contests: pageContests,
+            }),
             layout: pageBreak.layout,
           }),
         });

--- a/libs/test-decks/tsconfig.build.json
+++ b/libs/test-decks/tsconfig.build.json
@@ -11,6 +11,7 @@
     "declarationMap": true
   },
   "references": [
+    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },

--- a/libs/test-decks/tsconfig.json
+++ b/libs/test-decks/tsconfig.json
@@ -18,6 +18,7 @@
     "noUncheckedIndexedAccess": false
   },
   "references": [
+    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },
     { "path": "../fixtures/tsconfig.build.json" },

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -36,7 +36,6 @@
     "@fortawesome/react-fontawesome": "3.5.0",
     "@testing-library/react": "^15.0.7",
     "@votingworks/backend": "workspace:*",
-    "@votingworks/ballot-encoder": "workspace:*",
     "@votingworks/basics": "workspace:*",
     "@votingworks/grout": "workspace:*",
     "@votingworks/logging": "workspace:*",

--- a/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.dual_language.test.tsx
@@ -34,6 +34,8 @@ vi.mock(import('./ui_strings/ui_string.js'), async (importActual) => ({
   UiString: vi.fn(),
 }));
 
+const MOCK_ENCODED_BALLOT = new Uint8Array([0, 1, 2, 3]);
+
 const mockUiStringRenderer = vi.mocked(UiString);
 
 const electionGeneralDefinition = readElectionGeneralDefinition();
@@ -141,7 +143,7 @@ describe('non-English ballot style', () => {
         machineType="markScan"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId="test-audit-id"
+        encodedBallot={MOCK_ENCODED_BALLOT}
         contestsForPage={contests}
       />
     );
@@ -181,7 +183,7 @@ describe('non-English ballot style', () => {
         machineType="markScan"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId="test-audit-id"
+        encodedBallot={MOCK_ENCODED_BALLOT}
         contestsForPage={[contest]}
       />
     );
@@ -233,7 +235,7 @@ describe('non-English ballot style', () => {
         machineType="markScan"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId="test-audit-id"
+        encodedBallot={MOCK_ENCODED_BALLOT}
         contestsForPage={[contest]}
       />
     );
@@ -262,7 +264,7 @@ describe('non-English ballot style', () => {
         machineType="markScan"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId="test-audit-id"
+        encodedBallot={MOCK_ENCODED_BALLOT}
         contestsForPage={[contest]}
       />
     );
@@ -300,7 +302,7 @@ describe('non-English ballot style', () => {
         machineType="markScan"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId="test-audit-id"
+        encodedBallot={MOCK_ENCODED_BALLOT}
         contestsForPage={[contest]}
       />
     );
@@ -349,7 +351,7 @@ describe('English ballot style', () => {
         machineType="markScan"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId="test-audit-id"
+        encodedBallot={MOCK_ENCODED_BALLOT}
         contestsForPage={contests}
       />
     );
@@ -389,7 +391,7 @@ describe('English ballot style', () => {
         machineType="markScan"
         pageNumber={1}
         totalPages={1}
-        ballotAuditId="test-audit-id"
+        encodedBallot={MOCK_ENCODED_BALLOT}
         contestsForPage={contests}
       />
     );

--- a/libs/ui/src/bmd_paper_ballot.stories.tsx
+++ b/libs/ui/src/bmd_paper_ballot.stories.tsx
@@ -188,7 +188,7 @@ const initialArgs: BmdPaperBallotProps = {
   sheetSize: 'letter',
   pageNumber: 1,
   totalPages: 1,
-  ballotAuditId: 'storybook-audit-id',
+  encodedBallot: new Uint8Array([0, 1, 2, 3]),
   contestsForPage: election.contests,
 };
 

--- a/libs/ui/src/bmd_paper_ballot.test.tsx
+++ b/libs/ui/src/bmd_paper_ballot.test.tsx
@@ -1,7 +1,6 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import {
   BallotStyleId,
-  BallotType,
   Candidate,
   CandidateContest,
   ElectionDefinition,
@@ -20,7 +19,6 @@ import {
   electionStraightPartyFixtures,
 } from '@votingworks/fixtures';
 
-import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import { hasTextAcrossElements } from '@votingworks/test-utils';
 import { fromByteArray } from 'base64-js';
 import { assertDefined, find } from '@votingworks/basics';
@@ -54,19 +52,7 @@ const electionFamousNamesDefinition =
 const electionStraightPartyDefinition =
   electionStraightPartyFixtures.readElectionDefinition();
 
-vi.mock(import('@votingworks/ballot-encoder'), async (importActual) => ({
-  ...(await importActual()),
-  // mock encoded ballot so BMD ballot QR code does not change with every change to election definition
-  encodeSummaryBallotPage: vi.fn(),
-}));
-
-const encodeSummaryBallotPageMock = vi.mocked(encodeSummaryBallotPage);
 const mockEncodedBallotData = new Uint8Array([0, 1, 2, 3]);
-
-beforeEach(() => {
-  encodeSummaryBallotPageMock.mockReset();
-  encodeSummaryBallotPageMock.mockReturnValue(mockEncodedBallotData);
-});
 
 function renderBmdPaperBallot({
   electionDefinition,
@@ -110,8 +96,8 @@ function renderBmdPaperBallot({
       layout={layout}
       pageNumber={1}
       totalPages={1}
-      ballotAuditId="test-audit-id"
       contestsForPage={contests}
+      encodedBallot={mockEncodedBallotData}
     />
   );
 }
@@ -282,8 +268,8 @@ test('BmdPaperBallot treats missing entries in the votes dict as undervotes', ()
       machineType="markScan"
       pageNumber={1}
       totalPages={1}
-      ballotAuditId="test-audit-id"
       contestsForPage={contests}
+      encodedBallot={mockEncodedBallotData}
     />
   );
 
@@ -381,7 +367,7 @@ test('BmdPaperBallot renders seal', () => {
   screen.getByTestId('seal');
 });
 
-test('BmdPaperBallot passes expected data to encodeSummaryBallotPage for use in QR code', () => {
+test('BmdPaperBallot renders the encoded ballot it is given in the QR code', () => {
   const QrCodeSpy = vi.spyOn(QrCodeModule, 'QrCode');
 
   renderBmdPaperBallot({
@@ -395,23 +381,6 @@ test('BmdPaperBallot passes expected data to encodeSummaryBallotPage for use in 
       'question-b': ['question-b-option-no'],
     },
   });
-
-  expect(encodeSummaryBallotPage).toBeCalledWith(
-    electionGeneralDefinition.election,
-    expect.objectContaining({
-      ballotStyleId: '5' as BallotStyleId,
-      precinctId: '21',
-      ballotType: BallotType.Precinct,
-      ballotHash: electionGeneralDefinition.ballotHash,
-      isTestMode: true,
-      votes: expect.objectContaining({
-        president: [expect.objectContaining({ id: 'barchi-hallaren' })],
-        'lieutenant-governor': [expect.objectContaining({ id: 'norberg' })],
-        'question-a': ['question-a-option-yes'],
-        'question-b': ['question-b-option-no'],
-      }),
-    })
-  );
 
   expect(QrCodeSpy).toBeCalledWith(
     expect.objectContaining<QrCodeModule.QrCodeProps>({

--- a/libs/ui/src/bmd_paper_ballot.tsx
+++ b/libs/ui/src/bmd_paper_ballot.tsx
@@ -2,11 +2,9 @@ import { fromByteArray } from 'base64-js';
 import React from 'react';
 import styled from 'styled-components';
 
-import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import {
   BallotStyle,
   BallotStyleId,
-  BallotType,
   CandidateContest,
   CandidateVote,
   Contest,
@@ -667,13 +665,10 @@ export interface BmdPaperBallotProps {
   pageNumber: number;
   /** The total number of pages in the ballot */
   totalPages: number;
-  /**
-   * Ballot audit ID used to correlate physically separated pages after
-   * scanning
-   */
-  ballotAuditId: string;
   /** The subset of contests to render on this page */
   contestsForPage: readonly Contest[];
+  /** The QR code payload for this page, from `encodeSummaryBallotPage`. */
+  encodedBallot: Uint8Array;
 }
 
 /**
@@ -723,7 +718,6 @@ export function BmdPaperBallot({
   machineType,
   pageNumber,
   totalPages,
-  ballotAuditId,
   /**
    * The contests included on this page
    * TODO: Change this to a list of contest IDs rather than contest objects
@@ -731,6 +725,7 @@ export function BmdPaperBallot({
    * objects via the election def for the given ballot style ID.
    */
   contestsForPage,
+  encodedBallot,
 }: BmdPaperBallotProps): JSX.Element {
   const {
     election,
@@ -758,19 +753,6 @@ export function BmdPaperBallot({
     ? electionStrings.precinctSplitName(precinctOrSplit.split)
     : electionStrings.precinctName(precinctOrSplit.precinct);
   const party = getPartyForBallotStyle({ ballotStyleId, election });
-
-  const encodedBallot = encodeSummaryBallotPage(election, {
-    ballotHash,
-    precinctId,
-    ballotStyleId,
-    votes,
-    isTestMode: !isLiveMode,
-    ballotType: BallotType.Precinct,
-    pageNumber,
-    totalPages,
-    ballotAuditId,
-    contests: contestsForPageInCanonicalOrder,
-  });
 
   const ballotLayout =
     layout ??

--- a/libs/ui/tsconfig.build.json
+++ b/libs/ui/tsconfig.build.json
@@ -16,7 +16,6 @@
   },
   "references": [
     { "path": "../backend/tsconfig.build.json" },
-    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../backend/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -15,7 +15,6 @@
   "exclude": [],
   "references": [
     { "path": "../backend/tsconfig.build.json" },
-    { "path": "../ballot-encoder/tsconfig.build.json" },
     { "path": "../backend/tsconfig.build.json" },
     { "path": "../basics/tsconfig.build.json" },
     { "path": "../eslint-plugin-vx/tsconfig.build.json" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1220,6 +1220,9 @@ importers:
       '@votingworks/backend':
         specifier: workspace:*
         version: link:../../../libs/backend
+      '@votingworks/ballot-encoder':
+        specifier: workspace:*
+        version: link:../../../libs/ballot-encoder
       '@votingworks/ballot-interpreter':
         specifier: workspace:*
         version: link:../../../libs/ballot-interpreter
@@ -1589,6 +1592,9 @@ importers:
       '@votingworks/backend':
         specifier: workspace:*
         version: link:../../../libs/backend
+      '@votingworks/ballot-encoder':
+        specifier: workspace:*
+        version: link:../../../libs/ballot-encoder
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../../../libs/basics
@@ -3415,6 +3421,9 @@ importers:
       '@types/tmp':
         specifier: 0.2.4
         version: 0.2.4
+      '@votingworks/ballot-encoder':
+        specifier: workspace:*
+        version: link:../ballot-encoder
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
@@ -4860,6 +4869,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
+      '@votingworks/ballot-encoder':
+        specifier: workspace:*
+        version: link:../ballot-encoder
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
@@ -4887,6 +4899,9 @@ importers:
 
   libs/test-decks:
     dependencies:
+      '@votingworks/ballot-encoder':
+        specifier: workspace:*
+        version: link:../ballot-encoder
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics
@@ -5109,9 +5124,6 @@ importers:
       '@votingworks/backend':
         specifier: workspace:*
         version: link:../backend
-      '@votingworks/ballot-encoder':
-        specifier: workspace:*
-        version: link:../ballot-encoder
       '@votingworks/basics':
         specifier: workspace:*
         version: link:../basics


### PR DESCRIPTION
## Overview
Keeps the `@votingworks/ballot-encoder` imports out of `libs/ui` so we can replace the ballot encoder with a Rust version without breaking all the frontends.

## Testing Plan
Updates to existing automated tests.