### PR TITLE
Add coverage-check code coverage reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1329,6 +1329,46 @@ jobs:
                 paths:
                   - .turbo/cache
 
+  # @votingworks/coverage-check
+  test-libs-coverage-check:
+    executor: nodejs
+    resource_class: xlarge
+    steps:
+      - checkout-and-install:
+          is_node_package: true
+      - run:
+          name: Build
+          command: |
+            pnpm --dir libs/coverage-check build
+      - run:
+          name: Lint
+          command: |
+            pnpm --dir libs/coverage-check lint
+      - run:
+          name: Test
+          command: |
+            pnpm --dir libs/coverage-check test:run
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: ./reports/
+      - store_test_results:
+          path: libs/coverage-check/reports/
+      - when:
+          condition:
+            or:
+              - equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Prune Turbo Cache
+                when: always
+                command: |
+                  ./script/prune-turbo-cache
+            - save_cache:
+                name: Save Turbo Cache
+                when: always
+                key: turbo-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-main-{{ .Revision }}
+                paths:
+                  - .turbo/cache
+
   # @votingworks/custom-paper-handler
   test-libs-custom-paper-handler:
     executor: nodejs
@@ -2645,6 +2685,9 @@ workflows:
           context:
             - screenshots-publishing
       - test-libs-cdf-schema-builder:
+          context:
+            - screenshots-publishing
+      - test-libs-coverage-check:
           context:
             - screenshots-publishing
       - test-libs-custom-paper-handler:

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,8 @@ pnpm-lock.yaml
 libs/logging-utils/index.d.ts
 libs/logging-utils/index.js
 libs/logging/VotingWorksLoggingDocumentation.md
+
+# Coverage-check fixtures: position-sensitive test sources whose exact layout
+# the snapshots depend on; coverage output is machine-generated.
+libs/coverage-check/fixtures/src/**
+libs/coverage-check/fixtures/coverage/**

--- a/libs/coverage-check/README.md
+++ b/libs/coverage-check/README.md
@@ -1,4 +1,4 @@
-# coverage-check
+# ☂️ coverage-check
 
 A custom coverage reporter that enforces our approach to code coverage:
 

--- a/libs/coverage-check/README.md
+++ b/libs/coverage-check/README.md
@@ -1,0 +1,58 @@
+# coverage-check
+
+A custom coverage reporter that enforces our approach to code coverage:
+
+> Every uncovered statement, function, and branch must be explicitly marked as
+> either deferred or excluded from code coverage.
+
+The checker is an istanbul coverage reporter. It receives the coverage map
+produced by vitest and checks it against inline source code comments known as
+"directives," which mark code as deferred or excluded from coverage.
+
+This approach has some advantages over traditional threshold-based reporting:
+
+- When code changes, you can easily see a _diff_ of which specific pieces of
+  code changed in their coverage
+- Coverage exceptions are colocated with the code, so if the code moves, the
+  exception moves with it
+
+The checker also uses the TypeScript compiler to find unreachable code (e.g. the
+`default` arm of an exhaustive `switch`) and automatically excludes it from
+coverage requirements.
+
+Note: This package is a devDependency of every tested package, so it cannot
+depend on any other package.
+
+## Usage
+
+The checker runs automatically whenever vitest collects coverage. The shared
+`vitest.config.shared.mts` registers `vitest_coverage_reporter.cjs` as an
+istanbul coverage reporter. Coverage is on in CI (`CI=true`) and off locally by
+default. To run it locally from a package directory:
+
+```sh
+pnpm test:run --coverage
+```
+
+## Directives
+
+- `@coverage-exclude`: Marks code that is intentionally not covered by tests
+  (e.g. code that's impossible to cover)
+- `@coverage-defer`: Marks code that is temporarily not covered by tests but
+  should gain coverage in the future (e.g. prototype code)
+
+Each directive may be followed by an optional reason.
+
+```ts
+// Binds to the next item in the code
+// @coverage-exclude: <reason>
+// @coverage-defer: <reason>
+
+// Place at the top of the file to exclude/defer the entire file
+// @coverage-exclude-file: <reason>
+// @coverage-defer-file: <reason>
+
+// Place above an if-statement to exclude/defer an implicit else arm
+// @coverage-exclude-else: <reason>
+// @coverage-defer-else: <reason>
+```

--- a/libs/coverage-check/eslint.config.mjs
+++ b/libs/coverage-check/eslint.config.mjs
@@ -1,0 +1,6 @@
+// eslint-plugin-vx tests itself under coverage-check, so coverage-check cannot
+// depend on it as a package (Turbo rejects the cycle). The plugin is imported
+// from its build directly; `lint:self` builds it first.
+import { recommended } from '../eslint-plugin-vx/build/index.js';
+
+export default [...recommended, { ignores: ['fixtures/**', '*.cjs'] }];

--- a/libs/coverage-check/fixtures/README.md
+++ b/libs/coverage-check/fixtures/README.md
@@ -1,0 +1,21 @@
+# Fixtures
+
+Each file in `src/` is a small TypeScript source file modeling cases found in
+the repo.
+
+Each fixture opens with a `Driver:` comment — the exact calls `fixture_tests.ts`
+makes, which determine what is covered. Inline comments beside the code describe
+the behavior each construct is testing.
+
+## How they run
+
+`test/global_setup.ts` runs `fixture_tests.ts` with vitest to produce a coverage
+report: `coverage/coverage-final.json`. `../src/reporter.test.ts` then analyzes
+every fixture against that report and snapshots the resulting coverage report.
+
+## Adding a case
+
+1. Add a function (or file) under `src/`, with directives as the case requires,
+   and update the fixture's header.
+2. Call it from `fixture_tests.ts` so exactly the documented paths execute.
+3. Run `pnpm test:run -u` and review the snapshot diff.

--- a/libs/coverage-check/fixtures/fixture_tests.ts
+++ b/libs/coverage-check/fixtures/fixture_tests.ts
@@ -1,0 +1,116 @@
+// Executes exactly the paths each fixture's header documents. The resulting
+// coverage-final.json is the fixtures' coverage report.
+
+import { expect, test } from 'vitest';
+import {
+  positiveOnly,
+  staleFlag,
+  unflaggedDebt,
+  unknownLabel,
+  wrappedReason,
+} from './src/statement_form';
+import { Config, Partial } from './src/declaration_form';
+import './src/file_exclude';
+import './src/misplaced_file';
+import {
+  appendIfVerbose,
+  orDefault,
+  requirePositive,
+  signOf,
+  sumNonNegative,
+} from './src/implicit_else';
+import {
+  andGuard,
+  nullishInline,
+  nullishOwnLine,
+  ternaryInline,
+} from './src/ternary_logical';
+import { StatusPanel } from './src/jsx_container';
+import { renderButton } from './src/styled_interpolation';
+import { transformEmpty } from './src/method_chain';
+import { describeMode, isEditable } from './src/switch_cases';
+import { greet, makeConfig, pluralize } from './src/expression_args';
+import { PersonSchema } from './src/cdf_zlazy';
+import { beforeReturn, elseMisuse, noIf } from './src/orphans';
+import {
+  blockDefault,
+  closure,
+  defeated,
+  guard,
+  kinds,
+  redundantDirective,
+} from './src/unreachable_types';
+
+test('statement_form', () => {
+  expect(positiveOnly(3)).toEqual(6);
+  expect(wrappedReason(1)).toEqual(1);
+  expect(unflaggedDebt(2)).toEqual(1);
+  expect(staleFlag(1)).toEqual(2);
+  expect(unknownLabel(1)).toEqual(1);
+});
+
+test('declaration_form', () => {
+  expect(new Partial().used()).toEqual(7);
+  expect(new Config().name).toEqual('config');
+});
+
+test('implicit_else', () => {
+  expect(appendIfVerbose(true, 'hi')).toEqual('log:hi');
+  expect(orDefault(true)).toEqual(2);
+  expect(sumNonNegative([-1, -2])).toEqual(0);
+  expect(() => requirePositive(-1)).toThrow('not positive');
+  expect(signOf(1)).toEqual(1);
+  expect(signOf(-1)).toEqual(-1);
+});
+
+test('ternary_logical', () => {
+  expect(ternaryInline(true)).toEqual('yes');
+  expect(nullishInline('x')).toEqual('x');
+  expect(nullishOwnLine('x')).toEqual('x');
+  expect(andGuard(undefined)).toEqual(0);
+});
+
+test('jsx_container', () => {
+  expect(StatusPanel({}).tag).toEqual('div');
+});
+
+test('styled_interpolation', () => {
+  expect(renderButton({ compact: false })).toContain('8px');
+});
+
+test('method_chain', () => {
+  expect(transformEmpty([])).toEqual([]);
+});
+
+test('switch_cases', () => {
+  expect(describeMode('read')).toEqual('reader');
+  expect(describeMode('admin')).toEqual('administrator');
+  expect(isEditable('write')).toEqual(false);
+  expect(isEditable('admin')).toEqual(true);
+});
+
+test('expression_args', () => {
+  expect(greet('hi', '?')).toEqual('hi?');
+  expect(makeConfig({ retries: 2 })).toEqual({ retries: 2 });
+  expect(pluralize(1)).toEqual('1 item');
+});
+
+test('cdf_zlazy', () => {
+  expect(typeof PersonSchema.read).toEqual('function');
+});
+
+test('orphans', () => {
+  expect(beforeReturn()).toEqual(42);
+  expect(elseMisuse(true)).toEqual(1);
+  expect(elseMisuse(false)).toEqual(2);
+  expect(noIf()).toEqual(3);
+});
+
+test('unreachable_types', () => {
+  expect(guard(1)).toEqual(1);
+  expect(closure('a')).toEqual(1);
+  expect(blockDefault('a')).toEqual(1);
+  expect(kinds({ kind: 'a' })).toEqual(1);
+  expect(redundantDirective('a')).toEqual(1);
+  expect(() => defeated('zzz' as unknown as 'a')).toThrow('unexpected: zzz');
+});

--- a/libs/coverage-check/fixtures/src/cdf_zlazy.ts
+++ b/libs/coverage-check/fixtures/src/cdf_zlazy.ts
@@ -1,0 +1,20 @@
+// Driver: imports PersonSchema but never calls .read().
+
+export interface SchemaShape {
+  name: string;
+}
+
+function lazyLike<T>(factory: () => T): { read: () => T } {
+  return { read: factory };
+}
+
+// An inline directive on a thunk argument inside a call expression (the CDF
+// generator's z.lazy emission shape).
+export const PersonSchema = lazyLike(
+  /* @coverage-exclude: CDF generated thunk */ () => buildPersonSchema()
+);
+
+// @coverage-exclude: CDF generated builder
+function buildPersonSchema(): SchemaShape {
+  return { name: 'Person' };
+}

--- a/libs/coverage-check/fixtures/src/declaration_form.ts
+++ b/libs/coverage-check/fixtures/src/declaration_form.ts
@@ -1,0 +1,38 @@
+// Driver: new Partial().used(), new Config().
+
+// A directive on a function declaration binds the whole body.
+// @coverage-exclude: dev-only helper, never called from tests
+export function debugDump(value: unknown): string {
+  const serialized = JSON.stringify(value);
+  return serialized.toUpperCase();
+}
+
+// A directive on a class declaration binds every member.
+// @coverage-defer: widget rendering not yet tested
+export class Widget {
+  label = 'widget';
+
+  render(): string {
+    return this.label;
+  }
+}
+
+export class Partial {
+  // A directive on a method binds just that method. used() stays checked.
+  // @coverage-exclude: error-path formatting only
+  describe(): string {
+    return 'partial';
+  }
+
+  used(): number {
+    return 7;
+  }
+}
+
+export class Config {
+  // A directive on a class field binds its arrow-function initializer.
+  // @coverage-exclude: lazily evaluated default thunk
+  fallback = (): string => 'default';
+
+  name = 'config';
+}

--- a/libs/coverage-check/fixtures/src/expression_args.ts
+++ b/libs/coverage-check/fixtures/src/expression_args.ts
@@ -1,0 +1,29 @@
+// Driver: greet('hi', '?'), makeConfig({ retries: 2 }), pluralize(1).
+
+// An inline directive in a default-parameter initializer.
+export function greet(
+  name: string,
+  punctuation = /* @coverage-exclude: default punctuation */ '!'
+): string {
+  return `${name}${punctuation}`;
+}
+
+// @coverage-defer: see makeConfig
+function defaultRetries(): number {
+  return 3;
+}
+
+// An inline directive on the ?? arm of an object property value.
+export function makeConfig(overrides: { retries?: number }): {
+  retries: number;
+} {
+  return {
+    retries:
+      overrides.retries ?? /* @coverage-defer: default plumbing untested */ defaultRetries(),
+  };
+}
+
+// An inline directive on a ternary arm inside a template-literal span.
+export function pluralize(count: number): string {
+  return `${count} item${count === 1 ? '' : /* @coverage-exclude: plural suffix */ 's'}`;
+}

--- a/libs/coverage-check/fixtures/src/file_defer_unimported.ts
+++ b/libs/coverage-check/fixtures/src/file_defer_unimported.ts
@@ -1,0 +1,11 @@
+// @coverage-defer-file: no tests yet for the retry planner
+// Driver: never imported; coverage still reports every included file, and
+// the file directive defers every counter in it.
+
+export function planRetries(budget: number): number[] {
+  const plan: number[] = [];
+  for (let i = 0; i < budget; i += 1) {
+    plan.push(2 ** i);
+  }
+  return plan;
+}

--- a/libs/coverage-check/fixtures/src/file_exclude.ts
+++ b/libs/coverage-check/fixtures/src/file_exclude.ts
@@ -1,0 +1,10 @@
+// @coverage-exclude-file: exercised only via the manual QA harness
+// Driver: imported, nothing called; the file directive excludes every counter.
+
+export function bootHardware(): string {
+  return initDriver('usb');
+}
+
+function initDriver(kind: string): string {
+  return `driver:${kind}`;
+}

--- a/libs/coverage-check/fixtures/src/implicit_else.ts
+++ b/libs/coverage-check/fixtures/src/implicit_else.ts
@@ -1,0 +1,64 @@
+// Driver: appendIfVerbose(true, 'hi'), orDefault(true), sumNonNegative([-1,
+// -2]), requirePositive(-1) (catching the throw), signOf(1), signOf(-1).
+//
+// Where an `if` with no `else` puts its implicit else arm, and how a directive
+// claims it: a NON-terminating then-arm keeps the arm at the `if`, where an
+// -else directive claims just the arm (a plain directive would claim the whole
+// if); a terminating then-arm moves it to the first statement after the if.
+
+export function appendIfVerbose(verbose: boolean, message: string): string {
+  let out = 'log:';
+  // The then-arm falls through, so the arm stays at the `if`; an -else
+  // directive claims the arm without also claiming the `if` itself.
+  // @coverage-exclude-else: quiet path exercised in integration tests
+  if (verbose) {
+    out += message;
+  }
+  // @coverage-exclude: trailing newline is a display concern
+  if (out.length > 40) out += '\n';
+  return out;
+}
+
+// The same non-terminating shape without a directive is reported at the `if`.
+export function orDefault(flag: boolean): number {
+  let value = 0;
+  if (flag) {
+    value = 1;
+  }
+  return value + 1;
+}
+
+// A terminating (continue) then-arm moves the implicit else to the first
+// statement after the if, so that statement's directive claims the arm with
+// no separate -else directive.
+export function sumNonNegative(items: number[]): number {
+  let sum = 0;
+  for (const item of items) {
+    if (item < 0) {
+      continue;
+    }
+    // @coverage-defer: positive accumulation untested
+    sum += item;
+  }
+  return sum;
+}
+
+// The throw variant of a terminating then-arm.
+export function requirePositive(n: number): number {
+  if (n <= 0) {
+    throw new Error('not positive');
+  }
+  // @coverage-exclude: happy path covered by integration tests only
+  return n;
+}
+
+// For an `else if` chain, the implicit else moves past the whole chain.
+export function signOf(n: number): number {
+  if (n > 0) {
+    return 1;
+  } else if (n < 0) {
+    return -1;
+  }
+  // @coverage-defer: zero path untested; also claims the chain's implicit else
+  return 0;
+}

--- a/libs/coverage-check/fixtures/src/jsx_container.tsx
+++ b/libs/coverage-check/fixtures/src/jsx_container.tsx
@@ -1,0 +1,23 @@
+/** @jsx h */
+// Driver: StatusPanel({}).
+
+export interface VNode {
+  tag: string;
+  children: unknown[];
+}
+
+export function h(tag: string, _props: unknown, ...children: unknown[]): VNode {
+  return { tag, children };
+}
+
+export function StatusPanel(props: { error?: string }): VNode {
+  // A directive inside a JSX expression container binds the logical expression
+  // that follows it (smart_cards_screen.tsx pattern).
+  return (
+    <div>
+      <span>ready</span>
+      {/* @coverage-exclude: error banner exercised in integration tests */ props.error !==
+        undefined && <strong>{props.error}</strong>}
+    </div>
+  );
+}

--- a/libs/coverage-check/fixtures/src/method_chain.ts
+++ b/libs/coverage-check/fixtures/src/method_chain.ts
@@ -1,0 +1,10 @@
+// Driver: transformEmpty([]) — no callback ever runs.
+
+// An inline directive on one step of a method chain stays tight. The arrow
+// with the directive is excluded; the two without a directive are reported.
+export function transformEmpty(items: number[]): number[] {
+  return items
+    .map((n) => n * 2)
+    .filter(/* @coverage-exclude: sentinel filter, driver sends [] */ (n) => n < 0)
+    .map((n) => n + 1);
+}

--- a/libs/coverage-check/fixtures/src/misplaced_file.ts
+++ b/libs/coverage-check/fixtures/src/misplaced_file.ts
@@ -1,0 +1,6 @@
+// Driver: imported, nothing called.
+
+export const version = 1;
+
+// A -file directive after the first statement is misplaced.
+// @coverage-exclude-file: too late — must precede the first statement

--- a/libs/coverage-check/fixtures/src/orphans.ts
+++ b/libs/coverage-check/fixtures/src/orphans.ts
@@ -1,0 +1,28 @@
+// Driver: beforeReturn(), elseMisuse(true), elseMisuse(false), noIf() —
+// everything covered; the failures here are directive errors, not coverage.
+
+export function beforeReturn(): number {
+  const value = 41;
+  return value + 1;
+  // An orphan at the end of a block.
+  // @coverage-defer: nothing bindable follows inside this block
+}
+
+export function elseMisuse(flag: boolean): number {
+  // An -else directive misused on an if that has an explicit else.
+  // @coverage-exclude-else: misuse — this if has an explicit else
+  if (flag) {
+    return 1;
+  } else {
+    return 2;
+  }
+}
+
+export function noIf(): number {
+  // An -else directive with no if to bind.
+  // @coverage-defer-else: no if follows
+  return 3;
+}
+
+// An orphan at the end of the file.
+// @coverage-exclude: trailing orphan at end of file

--- a/libs/coverage-check/fixtures/src/statement_form.ts
+++ b/libs/coverage-check/fixtures/src/statement_form.ts
@@ -1,0 +1,48 @@
+// Driver: positiveOnly(3), wrappedReason(1), unflaggedDebt(2), staleFlag(1),
+// unknownLabel(1).
+
+// Simple directives binding to statements.
+// Also the defer gets implicit-else attribution from the `if` above it.
+export function positiveOnly(n: number): number {
+  if (n > 0) {
+    return n * 2;
+  }
+  // @coverage-defer: negative path untested
+  const flipped = n * -2;
+  // @coverage-exclude
+  return flipped + 1;
+}
+
+// A block-comment directive whose reason wraps onto a second line.
+export function wrappedReason(n: number): number {
+  if (n > 0) {
+    return n;
+  }
+  /* @coverage-exclude: the reason for a block-comment directive may wrap
+     onto further lines */
+  return -n;
+}
+
+// Uncovered code without a directive is reported.
+export function unflaggedDebt(n: number): number {
+  if (n > 0) {
+    return 1;
+  }
+  return -1;
+}
+
+// A directive on covered code is stale.
+export function staleFlag(n: number): number {
+  // @coverage-exclude: thought unreachable, but the driver covers it
+  return n + 1;
+}
+
+// A comment that starts like a directive but breaks the grammar is a parse
+// error, so a typo cannot silently do nothing.
+export function unknownLabel(n: number): number {
+  if (n > 0) {
+    return n;
+  }
+  // @coverage-skip: not a recognized action, reported as a parse error
+  return -n;
+}

--- a/libs/coverage-check/fixtures/src/styled_interpolation.ts
+++ b/libs/coverage-check/fixtures/src/styled_interpolation.ts
@@ -1,0 +1,38 @@
+// Driver: renderButton({ compact: false }).
+
+export interface StyleProps {
+  compact: boolean;
+}
+
+type Interpolation = (props: StyleProps) => string;
+
+// Mimics a styled-components tagged template, but only ever invokes the first
+// interpolation, so the second arrow below is wholly uncovered.
+function css(
+  strings: TemplateStringsArray,
+  ...interpolations: Interpolation[]
+): (props: StyleProps) => string {
+  return (props) => {
+    const first = interpolations[0];
+    // The '' case below is deliberately uncovered, producing a cond-expr branch in the report.
+    return `${strings.raw.join('*')}${first === undefined ? '' : first(props)}`;
+  };
+}
+
+export const buttonStyle = css`
+  padding: ${
+    // An inline directive on a ternary arm inside a template interpolation.
+    (props) =>
+      props.compact ? /* @coverage-exclude: compact padding is visual-only */ '2px' : '8px'
+  };
+  margin: ${
+    // A line-level directive inside an interpolation binds the whole arrow
+    // (segmented_button.tsx pattern).
+    // @coverage-defer: margin interpolation untested
+    (props) => (props.compact ? '0' : '4px')
+  };
+`;
+
+export function renderButton(props: StyleProps): string {
+  return buttonStyle(props);
+}

--- a/libs/coverage-check/fixtures/src/switch_cases.ts
+++ b/libs/coverage-check/fixtures/src/switch_cases.ts
@@ -1,0 +1,30 @@
+// Driver: describeMode('read'), describeMode('admin'), isEditable('write'),
+// isEditable('admin').
+
+type Mode = 'read' | 'write' | 'admin';
+
+// The empty fall-through `case 'read':` arm is never entered and is reported
+// at its own label (the arm it falls into decides its reachability).
+export function isEditable(mode: Mode): boolean {
+  switch (mode) {
+    case 'read':
+    case 'write':
+      return false;
+    default:
+      return true;
+  }
+}
+
+export function describeMode(mode: Mode): string {
+  switch (mode) {
+    case 'read':
+      return 'reader';
+    // A directive before a `case X:` clause binds the whole clause (arm +
+    // body).
+    // @coverage-exclude: write mode disabled in this product
+    case 'write':
+      return 'writer';
+    default:
+      return 'administrator';
+  }
+}

--- a/libs/coverage-check/fixtures/src/ternary_logical.ts
+++ b/libs/coverage-check/fixtures/src/ternary_logical.ts
@@ -1,0 +1,33 @@
+// Driver: ternaryInline(true), nullishInline('x'), nullishOwnLine('x'),
+// andGuard(undefined).
+
+// An inline directive on a ternary arm in expression position.
+export function ternaryInline(flag: boolean): string {
+  return flag ? 'yes' : /* @coverage-exclude: failure label, hardware only */ 'no';
+}
+
+// An inline directive (with no reason) on a ?? arm.
+export function nullishInline(value: string | undefined): string {
+  return value ?? /* @coverage-defer */ 'fallback';
+}
+
+// A line-level directive binding a ?? arm on its own line.
+export function nullishOwnLine(value: string | undefined): string {
+  return (
+    value ??
+    // @coverage-exclude: exhausted-iterator fallback
+    buildFallback()
+  );
+}
+
+// @coverage-exclude: see nullishOwnLine
+function buildFallback(): string {
+  return 'generated';
+}
+
+// Inline directives on && and ternary arms in the same expression.
+export function andGuard(n: number | undefined): number {
+  return n !== undefined && /* @coverage-exclude */ n > 10
+    ? /* @coverage-defer */ 1
+    : 0;
+}

--- a/libs/coverage-check/fixtures/src/unreachable_types.ts
+++ b/libs/coverage-check/fixtures/src/unreachable_types.ts
@@ -1,0 +1,104 @@
+// Driver: guard(1), closure('a'), blockDefault('a'), kinds({ kind: 'a' }),
+// redundantDirective('a'), defeated('zzz' as unknown as 'a') (catching the
+// throw); declared() is never called.
+//
+// The unreachable-by-type rule: an uncovered statement is excused only when it
+// holds a value reference narrowed to `never`.
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unexpected: ${String(value)}`);
+}
+
+// A never-returning call on a reachable error path is not excused: `fail` is
+// uncovered here and needs a test or a directive.
+export function guard(x: number): number {
+  if (x < 0) {
+    fail('negative');
+  }
+  return x;
+}
+
+// A never-typed variable's declaration is not excused; the later use of it is.
+export function declared(): void {
+  const impossible: never = undefined as never;
+  void impossible;
+}
+
+// A reference inside a nested closure counts for the closure's statement, not
+// the enclosing one.
+export function closure(k: 'a' | 'b'): number {
+  switch (k) {
+    case 'a':
+      return 1;
+    case 'b':
+      return 2;
+    default: {
+      const cb = () => assertNever(k);
+      return cb();
+    }
+  }
+}
+
+// An excused statement excuses its enclosing `default` arm, including the
+// block-wrapped `default: { ... }` form.
+export function blockDefault(k: 'a' | 'b'): number {
+  switch (k) {
+    case 'a':
+      return 1;
+    case 'b':
+      return 2;
+    default: {
+      assertNever(k);
+    }
+  }
+}
+
+interface A {
+  kind: 'a';
+}
+interface B {
+  kind: 'b';
+}
+
+// `switch (x.kind)` excuses the default arm because `x` itself is `never`
+// there, even though `x.kind` is the switched expression.
+export function kinds(x: A | B): number {
+  switch (x.kind) {
+    case 'a':
+      return 1;
+    case 'b':
+      return 2;
+    default:
+      return assertNever(x);
+  }
+}
+
+// Unreachability takes precedence over a directive, which then goes stale.
+export function redundantDirective(k: 'a' | 'b'): number {
+  switch (k) {
+    case 'a':
+      return 1;
+    case 'b':
+      return 2;
+    // @coverage-defer: unreachable anyway, so this is stale
+    default:
+      return assertNever(k);
+  }
+}
+
+// An executed never-reference site is simply covered — the type rule excuses
+// only uncovered code. The driver forces the impossible value through.
+export function defeated(k: 'a' | 'b'): number {
+  switch (k) {
+    case 'a':
+      return 1;
+    case 'b':
+      return 2;
+    default:
+      return assertNever(k);
+  }
+}

--- a/libs/coverage-check/fixtures/tsconfig.json
+++ b/libs/coverage-check/fixtures/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
+    "types": []
+  },
+  "include": ["src"]
+}

--- a/libs/coverage-check/fixtures/vitest.config.mts
+++ b/libs/coverage-check/fixtures/vitest.config.mts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  oxc: {
+    jsx: {
+      runtime: 'classic',
+      pragma: 'h',
+      pragmaFrag: 'Fragment',
+    },
+  },
+  test: {
+    include: ['fixture_tests.ts'],
+    coverage: {
+      provider: 'istanbul',
+      include: ['src/**/*.{ts,tsx}'],
+      reporter: ['json'],
+      reportsDirectory: './coverage',
+    },
+  },
+});

--- a/libs/coverage-check/package.json
+++ b/libs/coverage-check/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@votingworks/coverage-check",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Code coverage reporter that checks that every uncovered statement/branch carries an @coverage directive",
+  "license": "GPL-3.0-only",
+  "type": "module",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "pnpm -w vx-task build $npm_package_name",
+    "build:lint-plugin": "pnpm --filter eslint-plugin-vx build:self",
+    "build:self": "tsc --build tsconfig.build.json",
+    "clean": "pnpm -w vx-task clean $npm_package_name",
+    "clean:self": "rm -rf build",
+    "lint": "pnpm -w vx-task lint $npm_package_name",
+    "lint:fix": "pnpm build:lint-plugin && pnpm type-check && eslint --cache . --fix",
+    "lint:self": "pnpm build:lint-plugin && pnpm type-check && eslint --cache .",
+    "test": "pnpm -w vx-task build $npm_package_name && vitest",
+    "test:run": "pnpm -w vx-task test:run $npm_package_name",
+    "test:run:self": "vitest run",
+    "type-check": "tsc --build"
+  },
+  "dependencies": {
+    "@typescript/native": "npm:typescript@7.0.2"
+  },
+  "devDependencies": {
+    "@types/istanbul-lib-report": "^3.0.0",
+    "@types/node": "24.13.3",
+    "@vitest/coverage-istanbul": "^4.1.6",
+    "sort-package-json": "^1.50.0",
+    "vitest": "^4.1.6"
+  },
+  "packageManager": "pnpm@10.34.5"
+}

--- a/libs/coverage-check/src/__snapshots__/reporter.test.ts.snap
+++ b/libs/coverage-check/src/__snapshots__/reporter.test.ts.snap
@@ -10,7 +10,7 @@ exports[`the fixtures report 1`] = `
     ·        ╰── else branch not covered
  26 │     value = 1;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
    ╭─[src/method_chain.ts:7:17]
@@ -20,7 +20,7 @@ exports[`the fixtures report 1`] = `
    ·                    ╰── not covered
  8 │     .filter(/* @coverage-exclude: sentinel filter, driver sends [] */ (n) => n < 0)
    ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/method_chain.ts:9:17]
@@ -30,7 +30,7 @@ exports[`the fixtures report 1`] = `
     ·                    ╰── not covered
  10 │ }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-function): function is never called in tests
    ╭─[src/method_chain.ts:7:17]
@@ -40,7 +40,7 @@ exports[`the fixtures report 1`] = `
    ·                    ╰── not covered
  8 │     .filter(/* @coverage-exclude: sentinel filter, driver sends [] */ (n) => n < 0)
    ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-function): function is never called in tests
     ╭─[src/method_chain.ts:9:17]
@@ -50,7 +50,7 @@ exports[`the fixtures report 1`] = `
     ·                    ╰── not covered
  10 │ }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(misplaced-file-directive): directive must appear before the first statement
    ╭─[src/misplaced_file.ts:6:1]
@@ -130,7 +130,7 @@ exports[`the fixtures report 1`] = `
     ·        ╰── not covered
  32 │ }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/statement_form.ts:47:3]
@@ -140,7 +140,7 @@ exports[`the fixtures report 1`] = `
     ·        ╰── not covered
  48 │ }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): the \`if\` condition is never false in tests
     ╭─[src/statement_form.ts:31:3]
@@ -150,7 +150,7 @@ exports[`the fixtures report 1`] = `
     ·        ╰── else branch not covered
  32 │ }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): the \`if\` condition is never false in tests
     ╭─[src/statement_form.ts:47:3]
@@ -160,7 +160,7 @@ exports[`the fixtures report 1`] = `
     ·        ╰── else branch not covered
  48 │ }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (cond-expr) is never taken in tests
     ╭─[src/styled_interpolation.ts:18:61]
@@ -170,7 +170,7 @@ exports[`the fixtures report 1`] = `
     ·                                                                       ╰── not covered
  19 │   };
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
     ╭─[src/switch_cases.ts:10:5]
@@ -180,7 +180,7 @@ exports[`the fixtures report 1`] = `
     ·           ╰── not covered
  11 │     case 'write':
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   ⚠ coverage(stale-directive): everything this @coverage-defer directive marks is covered
     ╭─[src/unreachable_types.ts:87:5]
@@ -200,7 +200,7 @@ exports[`the fixtures report 1`] = `
     ·               ╰── not covered
  10 │ }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:20:5]
@@ -210,7 +210,7 @@ exports[`the fixtures report 1`] = `
     ·             ╰── not covered
  21 │   }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:27:29]
@@ -220,7 +220,7 @@ exports[`the fixtures report 1`] = `
     ·                                      ╰── not covered
  28 │   void impossible;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:38:7]
@@ -230,7 +230,7 @@ exports[`the fixtures report 1`] = `
     ·           ╰── not covered
  39 │     default: {
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:40:13]
@@ -240,7 +240,7 @@ exports[`the fixtures report 1`] = `
     ·                          ╰── not covered
  41 │       return cb();
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:40:24]
@@ -250,7 +250,7 @@ exports[`the fixtures report 1`] = `
     ·                               ╰── not covered
  41 │       return cb();
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:41:7]
@@ -260,7 +260,7 @@ exports[`the fixtures report 1`] = `
     ·             ╰── not covered
  42 │     }
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:53:7]
@@ -270,7 +270,7 @@ exports[`the fixtures report 1`] = `
     ·           ╰── not covered
  54 │     default: {
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:74:7]
@@ -280,7 +280,7 @@ exports[`the fixtures report 1`] = `
     ·           ╰── not covered
  75 │     default:
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:86:7]
@@ -290,7 +290,7 @@ exports[`the fixtures report 1`] = `
     ·           ╰── not covered
  87 │     // @coverage-defer: unreachable anyway, so this is stale
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
     ╭─[src/unreachable_types.ts:98:7]
@@ -300,7 +300,7 @@ exports[`the fixtures report 1`] = `
     ·           ╰── not covered
  99 │     case 'b':
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-statement): statement is never executed in tests
      ╭─[src/unreachable_types.ts:100:7]
@@ -310,7 +310,7 @@ exports[`the fixtures report 1`] = `
      ·           ╰── not covered
  101 │     default:
      ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-function): function is never called in tests
    ╭─[src/unreachable_types.ts:8:39]
@@ -320,7 +320,7 @@ exports[`the fixtures report 1`] = `
    ·                                       ╰── not covered
  9 │   throw new Error(message);
    ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-function): function is never called in tests
     ╭─[src/unreachable_types.ts:26:34]
@@ -330,7 +330,7 @@ exports[`the fixtures report 1`] = `
     ·                                  ╰── not covered
  27 │   const impossible: never = undefined as never;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-function): function is never called in tests
     ╭─[src/unreachable_types.ts:40:24]
@@ -340,7 +340,7 @@ exports[`the fixtures report 1`] = `
     ·                               ╰── not covered
  41 │       return cb();
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (if) is never taken in tests
     ╭─[src/unreachable_types.ts:19:3]
@@ -350,7 +350,7 @@ exports[`the fixtures report 1`] = `
     ·         ╰── not covered
  20 │     fail('negative');
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
     ╭─[src/unreachable_types.ts:37:5]
@@ -360,7 +360,7 @@ exports[`the fixtures report 1`] = `
     ·         ╰── not covered
  38 │       return 2;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
     ╭─[src/unreachable_types.ts:39:5]
@@ -370,7 +370,7 @@ exports[`the fixtures report 1`] = `
     ·          ╰── not covered
  40 │       const cb = () => assertNever(k);
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
     ╭─[src/unreachable_types.ts:52:5]
@@ -380,7 +380,7 @@ exports[`the fixtures report 1`] = `
     ·         ╰── not covered
  53 │       return 2;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
     ╭─[src/unreachable_types.ts:73:5]
@@ -390,7 +390,7 @@ exports[`the fixtures report 1`] = `
     ·         ╰── not covered
  74 │       return 2;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
     ╭─[src/unreachable_types.ts:85:5]
@@ -400,7 +400,7 @@ exports[`the fixtures report 1`] = `
     ·         ╰── not covered
  86 │       return 2;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
     ╭─[src/unreachable_types.ts:97:5]
@@ -410,7 +410,7 @@ exports[`the fixtures report 1`] = `
     ·         ╰── not covered
  98 │       return 1;
     ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
   × coverage(uncovered-branch): branch arm (switch) is never taken in tests
      ╭─[src/unreachable_types.ts:99:5]
@@ -420,7 +420,7 @@ exports[`the fixtures report 1`] = `
      ·         ╰── not covered
  100 │       return 2;
      ╰────
-  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
 coverage summary: 34 uncovered, 2 stale, 6 errors (24 deferred, 35 excluded)
 

--- a/libs/coverage-check/src/__snapshots__/reporter.test.ts.snap
+++ b/libs/coverage-check/src/__snapshots__/reporter.test.ts.snap
@@ -422,7 +422,7 @@ exports[`the fixtures report 1`] = `
      ╰────
   help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude
 
-coverage summary: 34 uncovered, 2 stale, 6 errors (24 deferred, 35 excluded)
+☂️ coverage summary: 34 uncovered, 2 stale, 6 errors (24 deferred, 35 excluded)
 
 "
 `;

--- a/libs/coverage-check/src/__snapshots__/reporter.test.ts.snap
+++ b/libs/coverage-check/src/__snapshots__/reporter.test.ts.snap
@@ -1,0 +1,428 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`the fixtures report 1`] = `
+"
+  × coverage(uncovered-branch): the \`if\` condition is never false in tests
+    ╭─[src/implicit_else.ts:25:3]
+ 24 │   let value = 0;
+ 25 │   if (flag) {
+    ·   ─────┬─────
+    ·        ╰── else branch not covered
+ 26 │     value = 1;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+   ╭─[src/method_chain.ts:7:17]
+ 6 │   return items
+ 7 │     .map((n) => n * 2)
+   ·                 ───┬──
+   ·                    ╰── not covered
+ 8 │     .filter(/* @coverage-exclude: sentinel filter, driver sends [] */ (n) => n < 0)
+   ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/method_chain.ts:9:17]
+  8 │     .filter(/* @coverage-exclude: sentinel filter, driver sends [] */ (n) => n < 0)
+  9 │     .map((n) => n + 1);
+    ·                 ───┬───
+    ·                    ╰── not covered
+ 10 │ }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-function): function is never called in tests
+   ╭─[src/method_chain.ts:7:17]
+ 6 │   return items
+ 7 │     .map((n) => n * 2)
+   ·                 ───┬──
+   ·                    ╰── not covered
+ 8 │     .filter(/* @coverage-exclude: sentinel filter, driver sends [] */ (n) => n < 0)
+   ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-function): function is never called in tests
+    ╭─[src/method_chain.ts:9:17]
+  8 │     .filter(/* @coverage-exclude: sentinel filter, driver sends [] */ (n) => n < 0)
+  9 │     .map((n) => n + 1);
+    ·                 ───┬───
+    ·                    ╰── not covered
+ 10 │ }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(misplaced-file-directive): directive must appear before the first statement
+   ╭─[src/misplaced_file.ts:6:1]
+ 5 │ // A -file directive after the first statement is misplaced.
+ 6 │ // @coverage-exclude-file: too late — must precede the first statement
+   · ───────────────────────────────────┬──────────────────────────────────
+   ·                                    ╰── code precedes this directive
+ 7 │ 
+   ╰────
+  help: move it to the top of the file, or use a plain directive for a single node
+
+  × coverage(orphaned-directive): directive has no code to bind to
+   ╭─[src/orphans.ts:8:3]
+ 7 │   // An orphan at the end of a block.
+ 8 │   // @coverage-defer: nothing bindable follows inside this block
+   ·   ───────────────────────────────┬──────────────────────────────
+   ·                                  ╰── nothing bindable before the end of this scope
+ 9 │ }
+   ╰────
+  help: delete it, or move it directly above the code it should mark
+
+  × coverage(misplaced-else-directive): directive targets an \`if\` with an explicit \`else\`
+    ╭─[src/orphans.ts:13:3]
+ 12 │   // An -else directive misused on an if that has an explicit else.
+ 13 │   // @coverage-exclude-else: misuse — this if has an explicit else
+    ·   ────────────────────────────────┬───────────────────────────────
+    ·                                   ╰── the next \`if\` has an explicit else arm
+ 14 │   if (flag) {
+    ╰────
+  help: mark the else arm itself with a plain directive instead
+
+  × coverage(orphaned-directive): directive has no \`if\` to bind to
+    ╭─[src/orphans.ts:23:3]
+ 22 │   // An -else directive with no if to bind.
+ 23 │   // @coverage-defer-else: no if follows
+    ·   ───────────────────┬──────────────────
+    ·                      ╰── no \`if\` follows before the end of this scope
+ 24 │   return 3;
+    ╰────
+  help: delete it, or move it directly above the \`if\` whose implicit else it should mark
+
+  × coverage(orphaned-directive): directive has no code to bind to
+    ╭─[src/orphans.ts:28:1]
+ 27 │ // An orphan at the end of the file.
+ 28 │ // @coverage-exclude: trailing orphan at end of file
+    · ──────────────────────────┬─────────────────────────
+    ·                           ╰── nothing bindable before the end of this scope
+ 29 │ 
+    ╰────
+  help: delete it, or move it directly above the code it should mark
+
+  ⚠ coverage(stale-directive): everything this @coverage-exclude directive marks is covered
+    ╭─[src/statement_form.ts:36:3]
+ 35 │ export function staleFlag(n: number): number {
+ 36 │   // @coverage-exclude: thought unreachable, but the driver covers it
+    ·   ─────────────────────────────────┬─────────────────────────────────
+    ·                                    ╰── no longer needed
+ 37 │   return n + 1;
+    ╰────
+  help: delete this directive
+
+  × coverage(directive-parse-error): comment starts like a coverage directive but does not parse
+    ╭─[src/statement_form.ts:46:3]
+ 45 │   }
+ 46 │   // @coverage-skip: not a recognized action, reported as a parse error
+    ·   ──────────────────────────────────┬──────────────────────────────────
+    ·                                     ╰── not a valid directive
+ 47 │   return -n;
+    ╰────
+  help: write @coverage-exclude or @coverage-defer, optionally followed by -file or -else, optionally followed by a colon and a reason
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/statement_form.ts:31:3]
+ 30 │   }
+ 31 │   return -1;
+    ·   ─────┬────
+    ·        ╰── not covered
+ 32 │ }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/statement_form.ts:47:3]
+ 46 │   // @coverage-skip: not a recognized action, reported as a parse error
+ 47 │   return -n;
+    ·   ─────┬────
+    ·        ╰── not covered
+ 48 │ }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): the \`if\` condition is never false in tests
+    ╭─[src/statement_form.ts:31:3]
+ 30 │   }
+ 31 │   return -1;
+    ·   ─────┬────
+    ·        ╰── else branch not covered
+ 32 │ }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): the \`if\` condition is never false in tests
+    ╭─[src/statement_form.ts:47:3]
+ 46 │   // @coverage-skip: not a recognized action, reported as a parse error
+ 47 │   return -n;
+    ·   ─────┬────
+    ·        ╰── else branch not covered
+ 48 │ }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (cond-expr) is never taken in tests
+    ╭─[src/styled_interpolation.ts:18:61]
+ 17 │     // The '' case below is deliberately uncovered, producing a cond-expr branch in the report.
+ 18 │     return \`\${strings.raw.join('*')}\${first === undefined ? '' : first(props)}\`;
+    ·                                                             ──────────┬─────────
+    ·                                                                       ╰── not covered
+ 19 │   };
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+    ╭─[src/switch_cases.ts:10:5]
+  9 │   switch (mode) {
+ 10 │     case 'read':
+    ·     ──────┬─────
+    ·           ╰── not covered
+ 11 │     case 'write':
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  ⚠ coverage(stale-directive): everything this @coverage-defer directive marks is covered
+    ╭─[src/unreachable_types.ts:87:5]
+ 86 │       return 2;
+ 87 │     // @coverage-defer: unreachable anyway, so this is stale
+    ·     ────────────────────────────┬───────────────────────────
+    ·                                 ╰── no longer needed
+ 88 │     default:
+    ╰────
+  help: delete this directive
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:9:3]
+  8 │ function fail(message: string): never {
+  9 │   throw new Error(message);
+    ·   ────────────┬────────────
+    ·               ╰── not covered
+ 10 │ }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:20:5]
+ 19 │   if (x < 0) {
+ 20 │     fail('negative');
+    ·     ────────┬────────
+    ·             ╰── not covered
+ 21 │   }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:27:29]
+ 26 │ export function declared(): void {
+ 27 │   const impossible: never = undefined as never;
+    ·                             ─────────┬─────────
+    ·                                      ╰── not covered
+ 28 │   void impossible;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:38:7]
+ 37 │     case 'b':
+ 38 │       return 2;
+    ·       ────┬────
+    ·           ╰── not covered
+ 39 │     default: {
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:40:13]
+ 39 │     default: {
+ 40 │       const cb = () => assertNever(k);
+    ·             ─────────────┬────────────
+    ·                          ╰── not covered
+ 41 │       return cb();
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:40:24]
+ 39 │     default: {
+ 40 │       const cb = () => assertNever(k);
+    ·                        ───────┬───────
+    ·                               ╰── not covered
+ 41 │       return cb();
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:41:7]
+ 40 │       const cb = () => assertNever(k);
+ 41 │       return cb();
+    ·       ──────┬─────
+    ·             ╰── not covered
+ 42 │     }
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:53:7]
+ 52 │     case 'b':
+ 53 │       return 2;
+    ·       ────┬────
+    ·           ╰── not covered
+ 54 │     default: {
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:74:7]
+ 73 │     case 'b':
+ 74 │       return 2;
+    ·       ────┬────
+    ·           ╰── not covered
+ 75 │     default:
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:86:7]
+ 85 │     case 'b':
+ 86 │       return 2;
+    ·       ────┬────
+    ·           ╰── not covered
+ 87 │     // @coverage-defer: unreachable anyway, so this is stale
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+    ╭─[src/unreachable_types.ts:98:7]
+ 97 │     case 'a':
+ 98 │       return 1;
+    ·       ────┬────
+    ·           ╰── not covered
+ 99 │     case 'b':
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-statement): statement is never executed in tests
+     ╭─[src/unreachable_types.ts:100:7]
+  99 │     case 'b':
+ 100 │       return 2;
+     ·       ────┬────
+     ·           ╰── not covered
+ 101 │     default:
+     ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-function): function is never called in tests
+   ╭─[src/unreachable_types.ts:8:39]
+ 7 │ 
+ 8 │ function fail(message: string): never {
+   ·                                       ┬
+   ·                                       ╰── not covered
+ 9 │   throw new Error(message);
+   ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-function): function is never called in tests
+    ╭─[src/unreachable_types.ts:26:34]
+ 25 │ // A never-typed variable's declaration is not excused; the later use of it is.
+ 26 │ export function declared(): void {
+    ·                                  ┬
+    ·                                  ╰── not covered
+ 27 │   const impossible: never = undefined as never;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-function): function is never called in tests
+    ╭─[src/unreachable_types.ts:40:24]
+ 39 │     default: {
+ 40 │       const cb = () => assertNever(k);
+    ·                        ───────┬───────
+    ·                               ╰── not covered
+ 41 │       return cb();
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (if) is never taken in tests
+    ╭─[src/unreachable_types.ts:19:3]
+ 18 │ export function guard(x: number): number {
+ 19 │   if (x < 0) {
+    ·   ──────┬─────
+    ·         ╰── not covered
+ 20 │     fail('negative');
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+    ╭─[src/unreachable_types.ts:37:5]
+ 36 │       return 1;
+ 37 │     case 'b':
+    ·     ────┬────
+    ·         ╰── not covered
+ 38 │       return 2;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+    ╭─[src/unreachable_types.ts:39:5]
+ 38 │       return 2;
+ 39 │     default: {
+    ·     ─────┬────
+    ·          ╰── not covered
+ 40 │       const cb = () => assertNever(k);
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+    ╭─[src/unreachable_types.ts:52:5]
+ 51 │       return 1;
+ 52 │     case 'b':
+    ·     ────┬────
+    ·         ╰── not covered
+ 53 │       return 2;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+    ╭─[src/unreachable_types.ts:73:5]
+ 72 │       return 1;
+ 73 │     case 'b':
+    ·     ────┬────
+    ·         ╰── not covered
+ 74 │       return 2;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+    ╭─[src/unreachable_types.ts:85:5]
+ 84 │       return 1;
+ 85 │     case 'b':
+    ·     ────┬────
+    ·         ╰── not covered
+ 86 │       return 2;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+    ╭─[src/unreachable_types.ts:97:5]
+ 96 │   switch (k) {
+ 97 │     case 'a':
+    ·     ────┬────
+    ·         ╰── not covered
+ 98 │       return 1;
+    ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+  × coverage(uncovered-branch): branch arm (switch) is never taken in tests
+     ╭─[src/unreachable_types.ts:99:5]
+  98 │       return 1;
+  99 │     case 'b':
+     ·     ────┬────
+     ·         ╰── not covered
+ 100 │       return 2;
+     ╰────
+  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude
+
+coverage summary: 34 uncovered, 2 stale, 6 errors (24 deferred, 35 excluded)
+
+"
+`;

--- a/libs/coverage-check/src/check.test.ts
+++ b/libs/coverage-check/src/check.test.ts
@@ -53,7 +53,11 @@ function mockTypescriptSession(
   function unavailable(): never {
     throw new Error('not available in a mock session');
   }
-  return { unreachableStatements, sourceFile: unavailable, close: unavailable };
+  return {
+    unreachableStatements,
+    sourceFile: unavailable,
+    [Symbol.dispose]: unavailable,
+  };
 }
 
 test('the tightest containing directive wins', () => {

--- a/libs/coverage-check/src/check.test.ts
+++ b/libs/coverage-check/src/check.test.ts
@@ -1,0 +1,200 @@
+import { expect, test } from 'vitest';
+import { join } from 'node:path';
+import { makeTempPackage, parseSnippet } from '../test/helpers.js';
+import type { IstanbulFileCoverageData, IstanbulRange } from './istanbul.js';
+import { checkFile, checkPackage } from './check.js';
+import type { TypescriptCompilerSession } from './typescript.js';
+
+test('a report file the project does not contain is a configuration error', () => {
+  const directory = makeTempPackage({ 'src/a.ts': 'export const a = 1;\n' });
+  const ghost: IstanbulFileCoverageData = {
+    path: join(directory, 'src/ghost.ts'),
+    statementMap: { '0': { start: { line: 1, column: 0 }, end: {} } },
+    s: { '0': 0 },
+    fnMap: {},
+    f: {},
+    branchMap: {},
+    b: {},
+  };
+  expect(() => checkPackage(directory, [ghost])).toThrow(
+    'is not in the project'
+  );
+});
+
+test('counters outside any node still count as failures', () => {
+  const directory = makeTempPackage({
+    'src/a.ts': 'export const a = 1;          \n',
+  });
+  const coverage: IstanbulFileCoverageData = {
+    path: join(directory, 'src/a.ts'),
+    statementMap: {
+      // Trailing whitespace: inside the file but inside no statement.
+      '0': { start: { line: 1, column: 25 }, end: {} },
+      // Past the end of the file: reported at the start of the file.
+      '1': { start: { line: 40, column: 0 }, end: {} },
+    },
+    s: { '0': 0, '1': 0 },
+    fnMap: {},
+    f: {},
+    branchMap: {},
+    b: {},
+  };
+  const result = checkPackage(directory, [coverage]);
+  expect(result.summary.uncoveredCounters).toEqual(2);
+  expect(result.issues.map((issue) => [issue.name, issue.span])).toEqual([
+    ['uncovered-statement', { start: 25, end: 29 }],
+    ['uncovered-statement', { start: 0, end: 0 }],
+  ]);
+});
+
+function mockTypescriptSession(
+  unreachableStatements: TypescriptCompilerSession['unreachableStatements']
+): TypescriptCompilerSession {
+  function unavailable(): never {
+    throw new Error('not available in a mock session');
+  }
+  return { unreachableStatements, sourceFile: unavailable, close: unavailable };
+}
+
+test('the tightest containing directive wins', () => {
+  const source = parseSnippet(
+    [
+      '// @coverage-defer-file: whole file',
+      'export function f(x: number): number {',
+      '  // @coverage-exclude: tight',
+      '  if (x > 0) {',
+      '    return 1;',
+      '  }',
+      '  return 2;',
+      '}',
+      '',
+    ].join('\n')
+  );
+
+  const coverage: IstanbulFileCoverageData = {
+    path: '/pkg/src/a.ts',
+    statementMap: {
+      '0': { start: { line: 4, column: 2 }, end: {} },
+      '1': { start: { line: 5, column: 4 }, end: {} },
+      '2': { start: { line: 7, column: 2 }, end: {} },
+      '3': { start: { line: 99, column: 0 }, end: {} },
+    },
+    s: { '0': 0, '1': 0, '2': 1, '3': 0 },
+    fnMap: {
+      '0': {
+        name: 'f',
+        decl: { start: { line: 2, column: 16 }, end: {} },
+        loc: { start: { line: 2, column: 37 }, end: {} },
+      },
+    },
+    f: { '0': 1 },
+    branchMap: {
+      '0': {
+        loc: { start: { line: 4, column: 2 }, end: {} },
+        type: 'if',
+        locations: [
+          { start: { line: 4, column: 2 }, end: {} },
+          { start: {}, end: {} },
+        ],
+      },
+    },
+    b: { '0': [0, 1] },
+  };
+  const result = checkFile(
+    source,
+    coverage,
+    mockTypescriptSession(() => new Set())
+  );
+  expect(result.counters.map((counter) => counter.status)).toEqual([
+    // The `if` and its body are claimed by the tight exclude, not the file defer.
+    'excluded', // s0: the if
+    'excluded', // s1: return 1
+    'covered', // s2: return 2
+    // A statement past the end of the file still lands in the whole-file range.
+    'deferred', // s3: line 99
+    'covered', // f0
+    'excluded', // b0.0: the then arm
+    // The covered implicit-else arm is matched against nothing and stays covered.
+    'covered', // b0.1
+  ]);
+  expect(
+    result.directives.map(({ bindingResult, isStale }) => [
+      'target' in bindingResult ? bindingResult.directive.scope : undefined,
+      isStale,
+    ])
+  ).toEqual([
+    ['file', false],
+    ['next', false],
+  ]);
+});
+
+test('when then-arm terminates, implicit-else coverage is attributed to the next statement', () => {
+  const source = parseSnippet(
+    [
+      'declare const x: number;',
+      '// @coverage-exclude: both implicit else arms are attributed within f',
+      'export function f(): number {',
+      '  if (x > 0) {',
+      '    return 1;',
+      '  } else if (x < 0) {',
+      '    return -1;',
+      '  }',
+      '  return 0;',
+      '}',
+      '// @coverage-exclude: with nothing following the if, the arm stays there',
+      'export function g(): void {',
+      '  if (x > 2) {',
+      '    return;',
+      '  }',
+      '}',
+      '',
+    ].join('\n')
+  );
+  // An `if` arm whose implicit else has no position, as istanbul emits for the
+  // innermost `if` of a chain (an explicit else arm carries a position).
+  function arm(atLine: number, column: number) {
+    const start: IstanbulRange['start'] = { line: atLine, column };
+    return {
+      loc: { start, end: {} },
+      type: 'if',
+      locations: [
+        { start, end: {} },
+        { start: {}, end: {} },
+      ],
+    };
+  }
+  const coverage: IstanbulFileCoverageData = {
+    path: '/pkg/src/a.ts',
+    statementMap: {},
+    s: {},
+    fnMap: {},
+    f: {},
+    branchMap: { '0': arm(6, 9), '1': arm(13, 2) },
+    b: { '0': [1, 0], '1': [1, 0] },
+  };
+  const result = checkFile(
+    source,
+    coverage,
+    mockTypescriptSession(() => new Set())
+  );
+  function line(offset?: number): number | undefined {
+    return offset === undefined
+      ? undefined
+      : source.getLineAndCharacterOfPosition(offset).line + 1;
+  }
+  expect(
+    result.counters
+      .filter(
+        ({ counter }) =>
+          counter.type === 'branch' && counter.implicitElseOffset !== undefined
+      )
+      .map(({ counter, status }) => [line(counter.offset), status])
+  ).toEqual([
+    // The `else if`'s missing else coverage is attributed to `return 0` — the
+    // statement following the outermost `if` of the chain.
+    [9, 'excluded'],
+    // The `if` in `g` has no following statement, so the missing else coverage
+    // stays attributed to the `if` itself.
+    [13, 'excluded'],
+  ]);
+});

--- a/libs/coverage-check/src/check.ts
+++ b/libs/coverage-check/src/check.ts
@@ -111,26 +111,22 @@ export function checkPackage(
   packageDir: string,
   fileCoverages: readonly IstanbulFileCoverageData[]
 ): PackageCheckResult {
-  const tsSession = startTypescriptCompilerSession(packageDir);
-  try {
-    const fileResults = fileCoverages
-      // To save time, only check files with uncovered code or directives
-      .filter(
-        (fileCoverage) =>
-          hasUncovered(fileCoverage) ||
-          maybeHasDirectives(readFileSync(fileCoverage.path, 'utf8'))
-      )
-      .map((fileCoverage) => {
-        const sourceFile = tsSession.sourceFile(fileCoverage.path);
-        return checkFile(sourceFile, fileCoverage, tsSession);
-      });
-    return {
-      issues: fileResults.flatMap((fileResult) => fileResult.issues),
-      summary: summarizeResults(fileResults),
-    };
-  } finally {
-    tsSession.close();
-  }
+  using tsSession = startTypescriptCompilerSession(packageDir);
+  const fileResults = fileCoverages
+    // To save time, only check files with uncovered code or directives
+    .filter(
+      (fileCoverage) =>
+        hasUncovered(fileCoverage) ||
+        maybeHasDirectives(readFileSync(fileCoverage.path, 'utf8'))
+    )
+    .map((fileCoverage) => {
+      const sourceFile = tsSession.sourceFile(fileCoverage.path);
+      return checkFile(sourceFile, fileCoverage, tsSession);
+    });
+  return {
+    issues: fileResults.flatMap((fileResult) => fileResult.issues),
+    summary: summarizeResults(fileResults),
+  };
 }
 
 function summarizeResults(
@@ -403,7 +399,7 @@ function counterIssue(
     span,
     severity: 'error',
     spanCaption: isImplicitElse ? 'else branch not covered' : 'not covered',
-    help: 'add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude',
+    help: 'add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude',
   } as const;
   switch (counter.type) {
     case 'function':

--- a/libs/coverage-check/src/check.ts
+++ b/libs/coverage-check/src/check.ts
@@ -1,0 +1,432 @@
+import type {
+  CaseBlock,
+  Node,
+  SourceFile,
+} from '@typescript/native/unstable/ast';
+import {
+  isBlock,
+  isCaseClause,
+  isDefaultClause,
+  isSourceFile,
+  isStatement,
+} from '@typescript/native/unstable/ast/is';
+import { readFileSync } from 'node:fs';
+import {
+  bindDirectives,
+  directiveToString,
+  isBoundDirective,
+  maybeHasDirectives,
+  type BoundDirective,
+  type DirectiveBindingResult,
+} from './directives.js';
+import {
+  collectIstanbulCoverageCounters,
+  hasUncovered,
+  type CoverageCounter,
+  type IstanbulFileCoverageData,
+} from './istanbul.js';
+import {
+  astClosestParentNodeForSpan,
+  startTypescriptCompilerSession,
+  astNodeStatements,
+  type TypescriptCompilerSession,
+  type Span,
+} from './typescript.js';
+import { throwIllegalValue } from './utils.js';
+
+interface CounterCheckResult {
+  readonly counter: CoverageCounter;
+  readonly status:
+    | 'covered'
+    | 'uncovered'
+    | 'excluded'
+    | 'deferred'
+    | 'unreachable';
+}
+
+interface DirectiveCheckResult {
+  readonly bindingResult: DirectiveBindingResult;
+  readonly isStale: boolean;
+}
+
+/**
+ * The result of checking coverage for a single file.
+ */
+export interface FileCheckResult {
+  readonly directives: DirectiveCheckResult[];
+  readonly counters: CounterCheckResult[];
+  readonly issues: Issue[];
+}
+
+type IssueName =
+  | 'uncovered-statement'
+  | 'uncovered-function'
+  | 'uncovered-branch'
+  | 'orphaned-directive'
+  | 'misplaced-else-directive'
+  | 'misplaced-file-directive'
+  | 'stale-directive'
+  | 'directive-parse-error';
+
+/**
+ * An issue found during coverage checking.
+ */
+export interface Issue {
+  readonly severity: 'error' | 'warning';
+  readonly name: IssueName;
+  readonly message: string;
+  readonly help: string;
+  /**
+   * Absolute; the reporter renders it relative to the package.
+   */
+  readonly filePath: string;
+  readonly sourceFileText: string;
+  readonly span: Span;
+  readonly spanCaption: string;
+}
+
+/**
+ * Counts summarizing the entire coverage check run.
+ */
+export interface SummaryCounts {
+  readonly uncoveredCounters: number;
+  readonly excludedCounters: number;
+  readonly deferredCounters: number;
+  readonly staleDirectives: number;
+  readonly directiveErrors: number;
+}
+
+/**
+ * The result of checking one package.
+ */
+export interface PackageCheckResult {
+  readonly issues: Issue[];
+  readonly summary: SummaryCounts;
+}
+
+/**
+ * Checks a package's coverage against its directives.
+ */
+export function checkPackage(
+  packageDir: string,
+  fileCoverages: readonly IstanbulFileCoverageData[]
+): PackageCheckResult {
+  const tsSession = startTypescriptCompilerSession(packageDir);
+  try {
+    const fileResults = fileCoverages
+      // To save time, only check files with uncovered code or directives
+      .filter(
+        (fileCoverage) =>
+          hasUncovered(fileCoverage) ||
+          maybeHasDirectives(readFileSync(fileCoverage.path, 'utf8'))
+      )
+      .map((fileCoverage) => {
+        const sourceFile = tsSession.sourceFile(fileCoverage.path);
+        return checkFile(sourceFile, fileCoverage, tsSession);
+      });
+    return {
+      issues: fileResults.flatMap((fileResult) => fileResult.issues),
+      summary: summarizeResults(fileResults),
+    };
+  } finally {
+    tsSession.close();
+  }
+}
+
+function summarizeResults(
+  fileResults: readonly FileCheckResult[]
+): SummaryCounts {
+  const counters = fileResults.flatMap((fileResult) => fileResult.counters);
+  const directives = fileResults.flatMap((fileResult) => fileResult.directives);
+  return {
+    uncoveredCounters: counters.filter(
+      (counter) => counter.status === 'uncovered'
+    ).length,
+    excludedCounters: counters.filter(
+      (counter) => counter.status === 'excluded'
+    ).length,
+    deferredCounters: counters.filter(
+      (counter) => counter.status === 'deferred'
+    ).length,
+    staleDirectives: directives.filter((directive) => directive.isStale).length,
+    directiveErrors: directives.filter(
+      (directive) => 'error' in directive.bindingResult
+    ).length,
+  };
+}
+
+/**
+ * The statement whose reachability decides the reachability of a counter at
+ * `offset`. Normally the closest statement containing the counter. For a
+ * `switch` arm's counter (which istanbul places at the `case`/`default`
+ * keyword) the arm's first statement.
+ */
+function statementDecidingReachability(
+  sourceFile: SourceFile,
+  offset: number
+): Node | undefined {
+  const closest = astClosestParentNodeForSpan(
+    { start: offset, end: offset + 1 },
+    sourceFile
+  );
+  if (
+    (isCaseClause(closest) || isDefaultClause(closest)) &&
+    closest.getStart(sourceFile) === offset
+  ) {
+    // The first statement that executes when the arm is taken (including for
+    // fall-through cases). Unwrap any blocks if necessary.
+    const { clauses } = closest.parent as CaseBlock;
+    for (let i = clauses.indexOf(closest); i < clauses.length; i += 1) {
+      let first = astNodeStatements(clauses[i] as Node)?.[0];
+      while (first && isBlock(first)) [first] = first.statements;
+      if (first) return first;
+    }
+  }
+  for (let node = closest; !isSourceFile(node); node = node.parent) {
+    if (isStatement(node)) return node;
+  }
+  return undefined;
+}
+
+/**
+ * Picks a statement for each counter to evaluate to see if the counter is
+ * unreachable, then asks the TypeScript compiler session which statements are
+ * actually unreachable.
+ */
+function findUnreachableCounters(
+  counters: readonly CoverageCounter[],
+  sourceFile: SourceFile,
+  session: TypescriptCompilerSession
+): Set<CoverageCounter> {
+  const counterStatements = new Map<CoverageCounter, Node>();
+  for (const counter of counters) {
+    if (counter.hits > 0) continue;
+    const statement = statementDecidingReachability(sourceFile, counter.offset);
+    if (statement) counterStatements.set(counter, statement);
+  }
+  const unreachableStatements = session.unreachableStatements([
+    ...counterStatements.values(),
+  ]);
+  return new Set(
+    [...counterStatements]
+      .filter(([, statement]) => unreachableStatements.has(statement))
+      .map(([counter]) => counter)
+  );
+}
+
+/**
+ * Analyzes one file against its coverage. Checks every counter from
+ * the Istanbul coverage report to see if it is covered, unreachable, or has a
+ * directive. Also detects stale directives.
+ */
+export function checkFile(
+  sourceFile: SourceFile,
+  fileCoverage: IstanbulFileCoverageData,
+  session: TypescriptCompilerSession
+): FileCheckResult {
+  const coverageCounters = collectIstanbulCoverageCounters(
+    fileCoverage,
+    sourceFile
+  );
+
+  const unreachableCounters = findUnreachableCounters(
+    coverageCounters,
+    sourceFile,
+    session
+  );
+
+  const directiveBindingResults = bindDirectives(sourceFile);
+  // Sort directives by how much code they apply to, so the most specific ones
+  // win when matching to counters
+  function targetWidth({ target }: BoundDirective): number {
+    return target.type === 'range' ? target.span.end - target.span.start : 0;
+  }
+  const boundDirectives = directiveBindingResults
+    .filter(isBoundDirective)
+    .sort((a, b) => targetWidth(a) - targetWidth(b));
+
+  const matchingDirectives = new Set<BoundDirective>();
+  const counterCheckResults = coverageCounters.map(
+    (counter): CounterCheckResult => {
+      if (counter.hits > 0) {
+        return { counter, status: 'covered' };
+      }
+      if (unreachableCounters.has(counter)) {
+        return { counter, status: 'unreachable' };
+      }
+      const matchingDirective = boundDirectives.find(({ target }) =>
+        target.type === 'range'
+          ? counter.offset >= target.span.start &&
+            counter.offset < target.span.end
+          : counter.type === 'branch' &&
+            counter.implicitElseOffset === target.ifSpan.start
+      );
+      if (!matchingDirective) {
+        return { counter, status: 'uncovered' };
+      }
+      matchingDirectives.add(matchingDirective);
+      return {
+        counter,
+        status:
+          matchingDirective.directive.action === 'exclude'
+            ? 'excluded'
+            : 'deferred',
+      };
+    }
+  );
+
+  const directiveCheckResults = directiveBindingResults.map(
+    (bindingResult): DirectiveCheckResult => ({
+      bindingResult,
+      isStale:
+        isBoundDirective(bindingResult) &&
+        !matchingDirectives.has(bindingResult),
+    })
+  );
+
+  const issues = [
+    ...directiveCheckResults.map(directiveIssue),
+    ...counterCheckResults.map((counter) =>
+      counterIssue(counter, sourceFile.text)
+    ),
+  ].flatMap((issueBody) =>
+    issueBody
+      ? [
+          {
+            ...issueBody,
+            filePath: sourceFile.fileName,
+            sourceFileText: sourceFile.text,
+          },
+        ]
+      : []
+  );
+  return {
+    directives: directiveCheckResults,
+    counters: counterCheckResults,
+    issues,
+  };
+}
+
+type IssueBody = Omit<Issue, 'filePath' | 'sourceFileText'>;
+
+function directiveIssue({
+  bindingResult,
+  isStale,
+}: DirectiveCheckResult): IssueBody | undefined {
+  const span = bindingResult.commentSpan;
+  if ('error' in bindingResult) {
+    switch (bindingResult.error) {
+      case 'parse-error':
+        return {
+          span,
+          severity: 'error',
+          name: 'directive-parse-error',
+          message:
+            'comment starts like a coverage directive but does not parse',
+          spanCaption: 'not a valid directive',
+          help: 'write @coverage-exclude or @coverage-defer, optionally followed by -file or -else, optionally followed by a colon and a reason',
+        };
+      case 'orphan':
+        return bindingResult.directive.scope === 'else'
+          ? {
+              span,
+              severity: 'error',
+              name: 'orphaned-directive',
+              message: 'directive has no `if` to bind to',
+              spanCaption: 'no `if` follows before the end of this scope',
+              help: 'delete it, or move it directly above the `if` whose implicit else it should mark',
+            }
+          : {
+              span,
+              severity: 'error',
+              name: 'orphaned-directive',
+              message: 'directive has no code to bind to',
+              spanCaption: 'nothing bindable before the end of this scope',
+              help: 'delete it, or move it directly above the code it should mark',
+            };
+      case 'misplaced-else':
+        return {
+          span,
+          severity: 'error',
+          name: 'misplaced-else-directive',
+          message: 'directive targets an `if` with an explicit `else`',
+          spanCaption: 'the next `if` has an explicit else arm',
+          help: 'mark the else arm itself with a plain directive instead',
+        };
+      case 'misplaced-file':
+        return {
+          span,
+          severity: 'error',
+          name: 'misplaced-file-directive',
+          message: 'directive must appear before the first statement',
+          spanCaption: 'code precedes this directive',
+          help: 'move it to the top of the file, or use a plain directive for a single node',
+        };
+      default:
+        throwIllegalValue(bindingResult);
+    }
+  }
+  if (isStale) {
+    return {
+      span,
+      severity: 'warning',
+      name: 'stale-directive',
+      message: `everything this ${directiveToString(
+        bindingResult.directive
+      )} directive marks is covered`,
+      spanCaption: 'no longer needed',
+      help: 'delete this directive',
+    };
+  }
+  return undefined;
+}
+
+function counterIssue(
+  { counter, status }: CounterCheckResult,
+  source: string
+): IssueBody | undefined {
+  if (status !== 'uncovered') return undefined;
+  // Underline from the counter to the end of its line (at least one character),
+  // since counter end positions are unreliable in remapped reports.
+  const { offset } = counter;
+  const newline = source.indexOf('\n', offset);
+  const lineEnd = newline === -1 ? source.length : newline;
+  const span: Span =
+    // A counter the report places past the end of the file is still reported at
+    // the start of the file.
+    offset >= source.length
+      ? { start: 0, end: 0 }
+      : { start: offset, end: Math.max(offset + 1, lineEnd) };
+  const isImplicitElse =
+    counter.type === 'branch' && counter.implicitElseOffset !== undefined;
+  const issueBase = {
+    span,
+    severity: 'error',
+    spanCaption: isImplicitElse ? 'else branch not covered' : 'not covered',
+    help: 'add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude',
+  } as const;
+  switch (counter.type) {
+    case 'function':
+      return {
+        ...issueBase,
+        name: 'uncovered-function',
+        message: 'function is never called in tests',
+      };
+    case 'branch':
+      return {
+        ...issueBase,
+        name: 'uncovered-branch',
+        message: isImplicitElse
+          ? 'the `if` condition is never false in tests'
+          : `branch arm (${counter.branchType}) is never taken in tests`,
+      };
+    case 'statement':
+      return {
+        ...issueBase,
+        name: 'uncovered-statement',
+        message: 'statement is never executed in tests',
+      };
+    default:
+      throwIllegalValue(counter);
+  }
+}

--- a/libs/coverage-check/src/directives.test.ts
+++ b/libs/coverage-check/src/directives.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from 'vitest';
+import { parseSnippet } from '../test/helpers.js';
+import type { Span } from './typescript.js';
+import { bindDirectives, parseDirective } from './directives.js';
+
+function bindingsOf(text: string, name?: string) {
+  const source = parseSnippet(text, name);
+  function sliceSpan(span: Span): string {
+    return source.text.slice(span.start, span.end);
+  }
+  return bindDirectives(source).map((bound) => {
+    if ('error' in bound) return bound.error;
+    const { target } = bound;
+    switch (target.type) {
+      case 'range':
+        return sliceSpan(target.span);
+      case 'else-arm':
+        return `else-arm:${sliceSpan(target.ifSpan).split('\n')[0]}`;
+      default:
+        return target;
+    }
+  });
+}
+
+test('a comment-only JSX expression container binds the next sibling', () => {
+  const text = [
+    'declare function h(...args: unknown[]): unknown;',
+    'export function App(): unknown {',
+    '  return (',
+    '    <div>',
+    '      {/* @coverage-exclude */}',
+    '      <button>Go</button>',
+    '    </div>',
+    '  );',
+    '}',
+    '',
+  ].join('\n');
+  expect(bindingsOf(text, 'src/a.tsx')).toEqual(['<button>Go</button>']);
+  // A comment inside an opening tag precedes no code of its own.
+  const inOpeningTag = [
+    'declare function h(...args: unknown[]): unknown;',
+    'export function App(): unknown {',
+    '  return (',
+    '    <div /* @coverage-exclude */>',
+    '      <button>Go</button>',
+    '    </div>',
+    '  );',
+    '}',
+    '',
+  ].join('\n');
+  expect(bindingsOf(inOpeningTag, 'src/a.tsx')).toEqual(['orphan']);
+});
+
+test('a comment that starts like a directive but breaks the grammar is a parse error', () => {
+  for (const text of [
+    '@coverage-excluded',
+    '@coverage-exclude soon',
+    '@coverage-exclude - reason',
+    '@coverage-skip',
+    '@coverage-exlcude: typo',
+    '@coverage-exclude-line',
+    '@coverage-defer-file-else',
+    '@coverage-',
+    '@Coverage-exclude',
+    '@COVERAGE-EXCLUDE: shouting',
+    '@coverage-exclude:',
+    '@coverage-exclude:   ',
+  ]) {
+    expect(parseDirective(text), text).toEqual('parse-error');
+  }
+});
+
+test('JSDoc-style block comments parse like plain ones', () => {
+  expect(parseDirective('* @coverage-exclude: reason ')).toEqual({
+    action: 'exclude',
+    scope: 'next',
+    reason: 'reason',
+  });
+  expect(parseDirective('*\n * @coverage-defer: two\n * lines\n ')).toEqual({
+    action: 'defer',
+    scope: 'next',
+    reason: 'two\nlines',
+  });
+  expect(parseDirective('* @coverage-exlcude')).toEqual('parse-error');
+  expect(
+    bindingsOf(
+      ['/** @coverage-exclude */', 'export const a = 1;', ''].join('\n')
+    )
+  ).toEqual(['export const a = 1;']);
+});
+
+test('comments that are not directive-shaped are not directives', () => {
+  for (const text of [
+    'coverage-exclude',
+    'prose mentioning @coverage-exclude later',
+    'TODO',
+  ]) {
+    expect(parseDirective(text), text).toBeUndefined();
+  }
+});

--- a/libs/coverage-check/src/directives.ts
+++ b/libs/coverage-check/src/directives.ts
@@ -1,0 +1,248 @@
+import {
+  SyntaxKind,
+  type Node,
+  type SourceFile,
+} from '@typescript/native/unstable/ast';
+import {
+  isIfStatement,
+  isJsxExpression,
+  isJsxText,
+  isTemplateSpan,
+} from '@typescript/native/unstable/ast/is';
+import {
+  astClosestParentNodeForSpan,
+  astNodeDescendants,
+  collectComments,
+  type Span,
+} from './typescript.js';
+import { throwIllegalValue } from './utils.js';
+
+/**
+ * How the coverage checker should treat the code a directive applies to
+ */
+type DirectiveAction = 'exclude' | 'defer';
+
+/**
+ * The scope a directive binds to
+ */
+type DirectiveScope = 'next' | 'file' | 'else';
+
+/**
+ * A parsed directive comment
+ */
+interface Directive {
+  readonly action: DirectiveAction;
+  readonly scope: DirectiveScope;
+  readonly reason?: string;
+}
+
+const PREFIX = '@coverage-';
+
+/**
+ * Checks if a source file's text might contain coverage directives.
+ */
+export function maybeHasDirectives(sourceFileText: string): boolean {
+  return sourceFileText.includes(PREFIX);
+}
+
+const DIRECTIVE_PATTERN =
+  /^@coverage-(exclude|defer)(?:-(file|else))?(?::\s*(.+))?$/s;
+
+/**
+ * Parses a comment's inner text as a directive. Returns `undefined` for a
+ * comment that is not directive-shaped at all (prose), and a parse error for
+ * one that starts with the `@coverage-` prefix (in any case) but does not
+ * follow the grammar. A JSDoc-style block comment (each line starting with
+ * `*`) reads the same as a plain one.
+ */
+export function parseDirective(
+  commentText: string
+): Directive | 'parse-error' | undefined {
+  const text = commentText
+    .split('\n')
+    .map((line) => line.replace(/^\s*\*+ ?/, ''))
+    .join('\n')
+    .trim();
+  if (!text.toLowerCase().startsWith(PREFIX)) return undefined;
+  const match = DIRECTIVE_PATTERN.exec(text);
+  if (!match) return 'parse-error';
+  const [, action, scope, reason] = match;
+  return {
+    action: action as DirectiveAction,
+    scope: (scope as 'file' | 'else' | undefined) ?? 'next',
+    ...(reason === undefined ? {} : { reason }),
+  };
+}
+
+/**
+ * Converts a directive to its string representation: `@coverage-<action>[-<scope>]`
+ * (not including the reason).
+ */
+export function directiveToString(directive: Directive): string {
+  const scopeSuffix = {
+    next: '',
+    file: '-file',
+    else: '-else',
+  }[directive.scope];
+  return `${PREFIX}${directive.action}${scopeSuffix}`;
+}
+
+/**
+ * The code a directive applies to: an offset range, or the implicit else arm of
+ * the `if` at `ifSpan`.
+ */
+type DirectiveTarget =
+  | { readonly type: 'range'; readonly span: Span }
+  | { readonly type: 'else-arm'; readonly ifSpan: Span };
+
+type DirectiveBindError = 'orphan' | 'misplaced-else' | 'misplaced-file';
+
+/**
+ * A directive comment bound to the code it applies to.
+ */
+export interface BoundDirective {
+  readonly commentSpan: Span;
+  readonly directive: Directive;
+  readonly target: DirectiveTarget;
+}
+
+/**
+ * Checks if a directive binding result is a successfully bound directive.
+ */
+export function isBoundDirective(
+  binding: DirectiveBindingResult
+): binding is BoundDirective {
+  return 'target' in binding;
+}
+
+/**
+ * The result of attempting to bind a directive comment: either a successful
+ * binding or an error.
+ */
+export type DirectiveBindingResult =
+  | BoundDirective
+  | {
+      readonly commentSpan: Span;
+      readonly error: 'parse-error';
+    }
+  | {
+      readonly commentSpan: Span;
+      readonly directive: Directive;
+      readonly error: DirectiveBindError;
+    };
+
+/**
+ * Attempts to parse and bind every directive comment in a file.
+ */
+export function bindDirectives(
+  sourceFile: SourceFile
+): DirectiveBindingResult[] {
+  const results: DirectiveBindingResult[] = [];
+  for (const comment of collectComments(sourceFile)) {
+    const parseResult = parseDirective(comment.text);
+    if (parseResult === undefined) continue;
+    const commentSpan = comment.span;
+    if (parseResult === 'parse-error') {
+      results.push({ commentSpan, error: parseResult });
+      continue;
+    }
+    const directive = parseResult;
+    const bindResult = bindScope(directive.scope, commentSpan, sourceFile);
+    results.push(
+      typeof bindResult === 'string'
+        ? { commentSpan, directive, error: bindResult }
+        : { commentSpan, directive, target: bindResult }
+    );
+  }
+  return results;
+}
+
+function bindScope(
+  scope: DirectiveScope,
+  comment: Span,
+  sourceFile: SourceFile
+): DirectiveTarget | DirectiveBindError {
+  switch (scope) {
+    case 'file':
+      return bindFile(comment, sourceFile);
+    case 'else':
+      return bindElse(comment, sourceFile);
+    case 'next':
+      return bindNextNode(comment, sourceFile);
+    default:
+      return throwIllegalValue(scope);
+  }
+}
+
+function isBindable(node: Node): boolean {
+  return (
+    // Skip whitespace inside JSX text nodes (e.g. newlines between JSX children)
+    !isJsxText(node) &&
+    // Skip TemplateSpan nodes in interpolated template strings, since they
+    // weirdly wrap an interpolated expression and some of the literal text
+    // after it
+    !isTemplateSpan(node) &&
+    // Don't bind to end of file marker
+    node.kind !== SyntaxKind.EndOfFile
+  );
+}
+
+/**
+ * A `-file` directive applies to the whole file. It must be at the top of the file.
+ */
+function bindFile(
+  comment: Span,
+  sourceFile: SourceFile
+): DirectiveTarget | DirectiveBindError {
+  const first = sourceFile.statements[0];
+  if (first !== undefined && comment.start >= first.getStart(sourceFile)) {
+    return 'misplaced-file';
+  }
+  return { type: 'range', span: { start: 0, end: Infinity } };
+}
+
+/**
+ * An `-else` directive applies to the implicit else arm of the next `if` within
+ * the comment's nearest parent node. That `if` must have no `else`.
+ */
+function bindElse(
+  comment: Span,
+  sourceFile: SourceFile
+): DirectiveTarget | DirectiveBindError {
+  const closest = astClosestParentNodeForSpan(comment, sourceFile);
+  for (const node of astNodeDescendants(closest)) {
+    if (!isIfStatement(node) || node.getStart(sourceFile) < comment.end) {
+      continue;
+    }
+    if (node.elseStatement) return 'misplaced-else';
+    return {
+      type: 'else-arm',
+      ifSpan: { start: node.getStart(sourceFile), end: node.end },
+    };
+  }
+  return 'orphan';
+}
+
+/**
+ * A plain directive applies to the first node starting after the comment
+ * within the comment's closest parent.
+ */
+function bindNextNode(
+  comment: Span,
+  sourceFile: SourceFile
+): DirectiveTarget | DirectiveBindError {
+  const closest = astClosestParentNodeForSpan(comment, sourceFile);
+  // A comment between JSX children must be wrapped in braces, making a
+  // JsxExpression that holds nothing but the comment, so we skip to the next
+  // parent in that case.
+  const container = isJsxExpression(closest) ? closest.parent : closest;
+  for (const node of astNodeDescendants(container)) {
+    if (isBindable(node) && node.getStart(sourceFile) >= comment.end) {
+      return {
+        type: 'range',
+        span: { start: node.getStart(sourceFile), end: node.end },
+      };
+    }
+  }
+  return 'orphan';
+}

--- a/libs/coverage-check/src/index.ts
+++ b/libs/coverage-check/src/index.ts
@@ -1,0 +1,1 @@
+export * from './reporter.js';

--- a/libs/coverage-check/src/istanbul.test.ts
+++ b/libs/coverage-check/src/istanbul.test.ts
@@ -1,0 +1,208 @@
+import { expect, test } from 'vitest';
+import { parseSnippet } from '../test/helpers.js';
+import {
+  collectIstanbulCoverageCounters,
+  hasUncovered,
+  type IstanbulFileCoverageData,
+  type IstanbulRange,
+} from './istanbul.js';
+
+function range(line: number, column: number | null = 0): IstanbulRange {
+  return { start: { line, column }, end: { line: null, column: null } };
+}
+
+test('report positions map to offsets, tolerating remapped-report quirks', () => {
+  const source = parseSnippet('ab\ncd\n\nefg');
+  const statementMap: IstanbulFileCoverageData['statementMap'] = {
+    '0': range(2, 1),
+    '1': range(4, 2),
+    // Negative or missing columns mean the start of the line.
+    '2': range(2, -2),
+    '3': range(2, null),
+    // Positions outside the file clamp to its end.
+    '4': range(1, 99),
+    '5': range(9, 0),
+  };
+  const counters = collectIstanbulCoverageCounters(
+    { path: 'a', statementMap, s: {}, fnMap: {}, f: {}, branchMap: {}, b: {} },
+    source
+  );
+  expect(
+    counters.map((counter) => counter.type === 'statement' && counter.offset)
+  ).toEqual([4, 9, 3, 3, 10, 10]);
+});
+
+test('collectIstanbulCoverageCounters flattens statements, functions, and branch arms in numeric key order', () => {
+  const source = parseSnippet(
+    [
+      'export function f(): number {',
+      '  return 5;',
+      '}',
+      'declare const flag: boolean;',
+      'export function g(): number {',
+      '  if (flag) {',
+      '    g();',
+      '  }',
+      '  return flag ? 1 : 2;',
+      '}',
+      '',
+    ].join('\n')
+  );
+  const coverage: IstanbulFileCoverageData = {
+    path: '/pkg/src/a.ts',
+    // Keys deliberately out of order: counters come out in numeric key order.
+    statementMap: { '10': range(9, 2), '2': range(2, 2) },
+    // No entry for statement '10': a missing hit entry means zero hits.
+    s: { '2': 5 },
+    fnMap: {
+      '0': { name: 'f', decl: range(1, 16), loc: range(1, 28) },
+      '1': { name: 'g', decl: range(5, 16), loc: range(5, 28) },
+    },
+    f: { '0': 1 },
+    branchMap: {
+      '0': {
+        loc: range(6, 2),
+        type: 'if',
+        // The second location has no position: an implicit else arm.
+        locations: [range(6, 2), { start: {}, end: {} }],
+      },
+      '1': {
+        loc: range(9, 9),
+        type: 'cond-expr',
+        locations: [range(9, 16), range(9, 20)],
+      },
+    },
+    // No entry for branch '1': a missing hit array means zero hits per arm.
+    b: { '0': [1, 0] },
+  };
+  const counters = collectIstanbulCoverageCounters(coverage, source);
+  function snippetAt(offset: number): string {
+    return source.text
+      .slice(offset)
+      .split(/\s+/)
+      .filter(Boolean)
+      .join(' ')
+      .slice(0, 13);
+  }
+  expect(
+    counters.map((counter) => [
+      counter.type,
+      counter.hits,
+      snippetAt(counter.offset),
+    ])
+  ).toEqual([
+    // Statements in numeric key order ('2' before '10'), then functions, then
+    // branch arms.
+    ['statement', 5, 'return 5; } d'],
+    ['statement', 0, 'return flag ?'],
+    // Functions land at the body (`loc`), not the declaration (`decl`), so
+    // that a directive on the function contains them.
+    ['function', 1, '{ return 5; }'],
+    ['function', 0, '{ if (flag) {'],
+    ['branch', 1, 'if (flag) { g'],
+    // The implicit else arm of a NON-terminating then stays at the `if`.
+    ['branch', 0, 'if (flag) { g'],
+    ['branch', 0, '1 : 2; }'],
+    ['branch', 0, '2; }'],
+  ]);
+  // The implicit else arm remembers its `if` so -else directives can claim it.
+  expect(counters[5]).toMatchObject({
+    branchType: 'if',
+    implicitElseOffset: counters[4]?.offset,
+  });
+});
+
+test('an implicit else whose `if` is not found stays at the reported position (remap drift)', () => {
+  const source = parseSnippet('export const a = 1;\n');
+  const coverage: IstanbulFileCoverageData = {
+    path: '/pkg/src/a.ts',
+    statementMap: {},
+    s: {},
+    fnMap: {},
+    f: {},
+    branchMap: {
+      // The report claims an `if` at 1:0, but the source has none there.
+      '0': {
+        loc: range(1, 0),
+        type: 'if',
+        locations: [range(1, 0), { start: {}, end: {} }],
+      },
+    },
+    b: { '0': [1, 0] },
+  };
+  const counters = collectIstanbulCoverageCounters(coverage, source);
+  expect(counters[1]).toMatchObject({ offset: 0, implicitElseOffset: 0 });
+});
+
+test('a counter without a position is a malformed report', () => {
+  const source = parseSnippet('export const a = 1;\n');
+  const base: IstanbulFileCoverageData = {
+    path: '/pkg/src/a.ts',
+    statementMap: {},
+    s: {},
+    fnMap: {},
+    f: {},
+    branchMap: {},
+    b: {},
+  };
+  const none: IstanbulRange = { start: {}, end: {} };
+  expect(() =>
+    collectIstanbulCoverageCounters(
+      { ...base, statementMap: { '0': { start: { line: null }, end: {} } } },
+      source
+    )
+  ).toThrow('reports statement 0 with no position');
+  // Istanbul lines are 1-based; line 0 can only come from a remapping bug.
+  expect(() =>
+    collectIstanbulCoverageCounters(
+      { ...base, statementMap: { '0': { start: { line: 0 }, end: {} } } },
+      source
+    )
+  ).toThrow('reports statement 0 with no position');
+  expect(() =>
+    collectIstanbulCoverageCounters(
+      { ...base, fnMap: { '0': { name: 'f', decl: range(1), loc: none } } },
+      source
+    )
+  ).toThrow('reports function 0 with no position');
+  // A non-`if` arm has no implicit else to fall back on.
+  expect(() =>
+    collectIstanbulCoverageCounters(
+      {
+        ...base,
+        branchMap: {
+          '1': { loc: range(1), type: 'cond-expr', locations: [none] },
+        },
+      },
+      source
+    )
+  ).toThrow('reports branch 1 arm 0 with no position');
+  // An implicit else needs its `if` to be placed.
+  expect(() =>
+    collectIstanbulCoverageCounters(
+      {
+        ...base,
+        branchMap: { '2': { loc: none, type: 'if', locations: [none] } },
+      },
+      source
+    )
+  ).toThrow('reports branch 2 with no position');
+});
+
+test('hasUncovered treats a missing hit entry as zero hits', () => {
+  const covered: IstanbulFileCoverageData = {
+    path: '/pkg/src/a.ts',
+    statementMap: { '0': range(1) },
+    s: { '0': 1 },
+    fnMap: { '0': { name: 'f', decl: range(1), loc: range(1) } },
+    f: { '0': 1 },
+    branchMap: {
+      '0': { type: 'if', loc: range(1), locations: [range(1), range(2)] },
+    },
+    b: { '0': [1, 1] },
+  };
+  expect(hasUncovered(covered)).toEqual(false);
+  expect(hasUncovered({ ...covered, s: {} })).toEqual(true);
+  expect(hasUncovered({ ...covered, f: {} })).toEqual(true);
+  expect(hasUncovered({ ...covered, b: { '0': [1] } })).toEqual(true);
+});

--- a/libs/coverage-check/src/istanbul.ts
+++ b/libs/coverage-check/src/istanbul.ts
@@ -1,0 +1,242 @@
+import type { SourceFile } from '@typescript/native/unstable/ast';
+import { isIfStatement } from '@typescript/native/unstable/ast/is';
+import {
+  astClosestParentNodeForSpan,
+  astNodeStatements,
+  astNodeTerminates,
+} from './typescript.js';
+
+/**
+ * A report position. Lines are 1-based, columns 0-based UTF-16 code units —
+ * the same units as source offsets. In remapped output (vitest + oxc +
+ * @vitest/coverage-istanbul) either field may be absent or null.
+ */
+interface IstanbulPosition {
+  readonly line?: number | null;
+  readonly column?: number | null;
+}
+
+/**
+ * A report range. Only `start` is ever trusted: remapped output has
+ * `end.column: null` everywhere.
+ */
+export interface IstanbulRange {
+  readonly start: IstanbulPosition;
+  readonly end: IstanbulPosition;
+}
+
+/**
+ * A `fnMap` entry: the function's declaration (`decl`) and body (`loc`).
+ */
+interface IstanbulFunction {
+  readonly name: string;
+  readonly decl: IstanbulRange;
+  readonly loc: IstanbulRange;
+}
+
+/**
+ * A `branchMap` entry. `type` is istanbul's branch kind (`if`, `cond-expr`,
+ * `binary-expr`, `switch`, `default-arg`, …); `locations` has one range per
+ * arm, parallel to the `b` hit array.
+ */
+interface IstanbulBranch {
+  readonly loc: IstanbulRange;
+  readonly type: string;
+  readonly locations: IstanbulRange[];
+}
+
+/**
+ * One file's coverage: the value shape of `coverage-final.json` (also
+ * `FileCoverage.data` from an in-memory `CoverageMap`).
+ *
+ * Each `*Map` is keyed by the counter's index in source order as a decimal
+ * string (`"0"`, `"1"`, … — istanbul numbers statements, functions, and
+ * branches separately as it instruments the file); the parallel `s`/`f`/`b`
+ * hit records use the same keys.
+ */
+export interface IstanbulFileCoverageData {
+  readonly path: string;
+  /**
+   * Statement ranges by statement index.
+   */
+  readonly statementMap: Record<string, IstanbulRange>;
+  /**
+   * Hits per statement, keyed like `statementMap`.
+   */
+  readonly s: Record<string, number>;
+  /**
+   * Functions by function index.
+   */
+  readonly fnMap: Record<string, IstanbulFunction>;
+  /**
+   * Hits per function, keyed like `fnMap`.
+   */
+  readonly f: Record<string, number>;
+  /**
+   * Branches by branch index.
+   */
+  readonly branchMap: Record<string, IstanbulBranch>;
+  /**
+   * Hits per branch arm, keyed like `branchMap`; each array is parallel to
+   * the branch's `locations`.
+   */
+  readonly b: Record<string, number[]>;
+}
+
+/**
+ * A single checkable unit of coverage: one of istanbul's counters, located
+ * by the UTF-16 offset where its code starts.
+ */
+export type CoverageCounter =
+  | {
+      readonly type: 'statement';
+      readonly hits: number;
+      readonly offset: number;
+    }
+  | {
+      readonly type: 'function';
+      readonly hits: number;
+      readonly offset: number;
+    }
+  | {
+      readonly type: 'branch';
+      /**
+       * istanbul's branch type (`if`, `cond-expr`, `binary-expr`, …).
+       */
+      readonly branchType: string;
+      readonly hits: number;
+      readonly offset: number;
+      /**
+       * For the implicit else arm of an `if` with no `else`, that `if`'s
+       * offset.
+       */
+      readonly implicitElseOffset?: number;
+    };
+
+/**
+ * The offset of a report range's start, if it has one.
+ */
+function startOffset(
+  range: IstanbulRange,
+  file: SourceFile
+): number | undefined {
+  const { line, column } = range.start;
+  if (line === undefined || line === null || line <= 0) return undefined;
+  const lineStart = file.getLineStarts()[line - 1];
+  // Positions can be past the end of the file, clamp to the end of the file
+  if (lineStart === undefined) return file.text.length;
+  // Columns can be negative or missing, clamp to the start of the line.
+  return Math.min(lineStart + Math.max(0, column ?? 0), file.text.length);
+}
+
+/**
+ * Converts a file's istanbul coverage data into a list of {@link CoverageCounter}s.
+ */
+export function collectIstanbulCoverageCounters(
+  fileCoverageData: IstanbulFileCoverageData,
+  file: SourceFile
+): CoverageCounter[] {
+  function requireOffset(range: IstanbulRange, what: string): number {
+    const offset = startOffset(range, file);
+    if (offset === undefined) {
+      throw new Error(
+        `coverage-check: ${fileCoverageData.path} reports ${what} with no position`
+      );
+    }
+    return offset;
+  }
+
+  const counters: CoverageCounter[] = [];
+  for (const [key, range] of Object.entries(fileCoverageData.statementMap)) {
+    counters.push({
+      type: 'statement',
+      hits: fileCoverageData.s[key] ?? 0,
+      offset: requireOffset(range, `statement ${key}`),
+    });
+  }
+  for (const [key, functionMeta] of Object.entries(fileCoverageData.fnMap)) {
+    counters.push({
+      type: 'function',
+      hits: fileCoverageData.f[key] ?? 0,
+      // A function has two ranges: `decl` (its name, or for an arrow the arrow
+      // token) and `loc` (its body). A directive claims the counter when the
+      // counter's offset is inside the directive's node, so the offset must be
+      // inside the function, so we use `functionMeta.loc`. We've seen `decl.start` drift
+      // to an earlier position outside the arrow function.
+      offset: requireOffset(functionMeta.loc, `function ${key}`),
+    });
+  }
+  for (const [key, branch] of Object.entries(fileCoverageData.branchMap)) {
+    const hitsByArm = fileCoverageData.b[key] ?? [];
+    for (const [arm, range] of branch.locations.entries()) {
+      const armCounter = {
+        type: 'branch',
+        branchType: branch.type,
+        hits: hitsByArm[arm] ?? 0,
+      } as const;
+      const offset = startOffset(range, file);
+      if (offset !== undefined) {
+        counters.push({ ...armCounter, offset });
+      } else if (branch.type === 'if') {
+        // An `if` arm with no position is an implicit else
+        const ifOffset = requireOffset(branch.loc, `branch ${key}`);
+        counters.push({
+          ...armCounter,
+          offset: implicitElseOffset(ifOffset, file),
+          implicitElseOffset: ifOffset,
+        });
+      } else {
+        throw new Error(
+          `coverage-check: ${fileCoverageData.path} reports branch ${key} arm ${arm} with no position`
+        );
+      }
+    }
+  }
+  return counters;
+}
+
+/**
+ * Where the implicit else arm of the `if` at `ifOffset` is located. When the
+ * then-arm terminates (return/throw/break/continue), the implicit else is
+ * really "the code after the if", so it is attributed to the following
+ * statement. For an `else if`, "after the if" means after the outermost `if`
+ * of the chain. When nothing follows, it stays at the `if`.
+ */
+function implicitElseOffset(ifOffset: number, file: SourceFile): number {
+  const ifStatement = astClosestParentNodeForSpan(
+    { start: ifOffset, end: ifOffset + 1 },
+    file
+  );
+  if (
+    !isIfStatement(ifStatement) ||
+    !astNodeTerminates(ifStatement.thenStatement)
+  ) {
+    return ifOffset;
+  }
+  // For an `else if`, hop to the outermost `if` of the chain — an IfStatement
+  // is never a statement-list container itself.
+  let node = ifStatement;
+  while (isIfStatement(node.parent)) {
+    node = node.parent;
+  }
+  const statements = astNodeStatements(node.parent);
+  const following = statements?.[statements.indexOf(node) + 1];
+  return following ? following.getStart(file) : ifOffset;
+}
+
+/**
+ * Whether any counter in the file has zero hits. As in
+ * `collectIstanbulCoverageCounters`, a counter with no hit entry has zero hits.
+ */
+export function hasUncovered(
+  fileCoverageData: IstanbulFileCoverageData
+): boolean {
+  const { statementMap, s, fnMap, f, branchMap, b } = fileCoverageData;
+  return (
+    Object.keys(statementMap).some((key) => (s[key] ?? 0) === 0) ||
+    Object.keys(fnMap).some((key) => (f[key] ?? 0) === 0) ||
+    Object.entries(branchMap).some(([key, branch]) =>
+      branch.locations.some((_, arm) => (b[key]?.[arm] ?? 0) === 0)
+    )
+  );
+}

--- a/libs/coverage-check/src/reporter.test.ts
+++ b/libs/coverage-check/src/reporter.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import {
+  captureStdout,
+  FIXTURES_DIR,
+  fixtureReport,
+  makeTempPackage,
+} from '../test/helpers.js';
+import type { IstanbulFileCoverageData } from './istanbul.js';
+import { checkPackage, type SummaryCounts } from './check.js';
+import {
+  CoverageCheckReporter,
+  printResult,
+  formatIssue,
+  formatSummary,
+} from './reporter.js';
+
+interface MockContext {
+  getTree(): {
+    visit(visitor: {
+      onDetail(node: {
+        getFileCoverage(): { data: IstanbulFileCoverageData };
+      }): void;
+    }): void;
+  };
+}
+
+const ESC = '\u001b['; // ESC [ — the terminal styling (SGR) introducer
+const BOLD_RED = `${ESC}31;1m`;
+const BOLD_GREEN = `${ESC}32;1m`;
+const RESET = `${ESC}0m`;
+
+function stripStyling(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('the fixtures report', () => {
+  const out = captureStdout();
+  printResult(checkPackage(FIXTURES_DIR, fixtureReport()), FIXTURES_DIR);
+  expect(stripStyling(out.text())).toMatchSnapshot();
+});
+
+test('the istanbul reporter collects file coverage, prints, and fails the run', () => {
+  const out = captureStdout();
+  const report = fixtureReport();
+  const reporter = new CoverageCheckReporter({ projectRoot: FIXTURES_DIR });
+  const context: MockContext = {
+    getTree: () => ({
+      visit(visitor) {
+        for (const data of report)
+          visitor.onDetail({ getFileCoverage: () => ({ data }) });
+      },
+    }),
+  };
+  const before = process.exitCode;
+  process.exitCode = undefined;
+  try {
+    reporter.execute(context as never);
+    expect(process.exitCode).toEqual(1);
+    expect(out.text()).toContain('coverage summary:');
+  } finally {
+    process.exitCode = before;
+  }
+});
+
+test('the reporter leaves the exit code alone when the check passes', () => {
+  const directory = makeTempPackage({ 'src/a.ts': 'export const a = 1;\n' });
+  const out = captureStdout();
+  const before = process.exitCode;
+  process.exitCode = undefined;
+  try {
+    const context: MockContext = { getTree: () => ({ visit() {} }) };
+    new CoverageCheckReporter({ projectRoot: directory }).execute(
+      context as never
+    );
+    expect(process.exitCode).toBeUndefined();
+    expect(out.text()).toContain(`${BOLD_GREEN}coverage summary: 0 uncovered`);
+  } finally {
+    process.exitCode = before;
+  }
+});
+
+test('a multi-line span is underlined to the end of its first line', () => {
+  const sourceFileText =
+    'const a = 1;\n/* @coverage-exclude\n   spanning */\nconst b = 2;\n';
+  const text = formatIssue(
+    {
+      sourceFileText,
+      severity: 'error',
+      name: 'orphaned-directive',
+      message: 'm',
+      spanCaption: 'here',
+      help: 'h',
+      filePath: 'src/a.ts',
+      span: { start: 13, end: 45 },
+    },
+    ''
+  );
+  expect(text).toContain('src/a.ts:2:1');
+  expect(text).toContain('─┬─');
+  expect(text).toContain('╰── here');
+});
+
+test('formatSummary colors the verdict, hides zero counts, and pluralizes errors', () => {
+  const clean: SummaryCounts = {
+    uncoveredCounters: 0,
+    directiveErrors: 0,
+    staleDirectives: 0,
+    excludedCounters: 0,
+    deferredCounters: 0,
+  };
+  expect(formatSummary(clean)).toEqual(
+    `${BOLD_GREEN}coverage summary: 0 uncovered${RESET}`
+  );
+  expect(
+    formatSummary({ ...clean, deferredCounters: 2, excludedCounters: 1 })
+  ).toEqual(
+    `${BOLD_GREEN}coverage summary: 0 uncovered${RESET} (2 deferred, 1 excluded)`
+  );
+  expect(
+    formatSummary({
+      ...clean,
+      uncoveredCounters: 3,
+      staleDirectives: 1,
+      directiveErrors: 1,
+      excludedCounters: 1,
+    })
+  ).toEqual(
+    `${BOLD_RED}coverage summary: 3 uncovered, 1 stale, 1 error${RESET} (1 excluded)`
+  );
+  expect(formatSummary({ ...clean, directiveErrors: 2 })).toEqual(
+    `${BOLD_RED}coverage summary: 0 uncovered, 2 errors${RESET}`
+  );
+});

--- a/libs/coverage-check/src/reporter.test.ts
+++ b/libs/coverage-check/src/reporter.test.ts
@@ -78,7 +78,9 @@ test('the reporter leaves the exit code alone when the check passes', () => {
       context as never
     );
     expect(process.exitCode).toBeUndefined();
-    expect(out.text()).toContain(`${BOLD_GREEN}coverage summary: 0 uncovered`);
+    expect(out.text()).toContain(
+      `${BOLD_GREEN}☂️ coverage summary: 0 uncovered`
+    );
   } finally {
     process.exitCode = before;
   }
@@ -114,12 +116,12 @@ test('formatSummary colors the verdict, hides zero counts, and pluralizes errors
     deferredCounters: 0,
   };
   expect(formatSummary(clean)).toEqual(
-    `${BOLD_GREEN}coverage summary: 0 uncovered${RESET}`
+    `${BOLD_GREEN}☂️ coverage summary: 0 uncovered${RESET}`
   );
   expect(
     formatSummary({ ...clean, deferredCounters: 2, excludedCounters: 1 })
   ).toEqual(
-    `${BOLD_GREEN}coverage summary: 0 uncovered${RESET} (2 deferred, 1 excluded)`
+    `${BOLD_GREEN}☂️ coverage summary: 0 uncovered${RESET} (2 deferred, 1 excluded)`
   );
   expect(
     formatSummary({
@@ -130,9 +132,9 @@ test('formatSummary colors the verdict, hides zero counts, and pluralizes errors
       excludedCounters: 1,
     })
   ).toEqual(
-    `${BOLD_RED}coverage summary: 3 uncovered, 1 stale, 1 error${RESET} (1 excluded)`
+    `${BOLD_RED}☂️ coverage summary: 3 uncovered, 1 stale, 1 error${RESET} (1 excluded)`
   );
   expect(formatSummary({ ...clean, directiveErrors: 2 })).toEqual(
-    `${BOLD_RED}coverage summary: 0 uncovered, 2 errors${RESET}`
+    `${BOLD_RED}☂️ coverage summary: 0 uncovered, 2 errors${RESET}`
   );
 });

--- a/libs/coverage-check/src/reporter.ts
+++ b/libs/coverage-check/src/reporter.ts
@@ -1,0 +1,160 @@
+import type { Context, ReportNode } from 'istanbul-lib-report';
+import { relative } from 'node:path';
+import type { IstanbulFileCoverageData } from './istanbul.js';
+import {
+  checkPackage,
+  type PackageCheckResult,
+  type SummaryCounts,
+  type Issue,
+} from './check.js';
+import { assertDefined } from './utils.js';
+
+function lineAndColumn(
+  sourceText: string,
+  offset: number
+): { line: number; column: number } {
+  let line = 1;
+  let lineStart = 0;
+  for (let i = 0; i < offset && i < sourceText.length; i += 1) {
+    if (sourceText[i] === '\n') {
+      line += 1;
+      lineStart = i + 1;
+    }
+  }
+  return { line, column: offset - lineStart };
+}
+
+// \u001b[ is the terminal styling (SGR) introducer.
+const ESC = '\u001b[';
+const RESET = `${ESC}0m`;
+const DIM = `${ESC}2m`;
+const CYAN_UNDERLINE = `${ESC}36;1;4m`;
+const CYAN = `${ESC}36m`;
+const MAGENTA = `${ESC}35;1m`;
+const BOLD_RED = `${ESC}31;1m`;
+const BOLD_GREEN = `${ESC}32;1m`;
+
+/**
+ * Renders one issue as a snippet box, inspired by Rust's miette format.
+ */
+export function formatIssue(issue: Issue, projectRoot: string): string {
+  const filePath = relative(projectRoot, issue.filePath);
+  const { sourceFileText: source } = issue;
+  const color = issue.severity === 'error' ? `${ESC}31m` : `${ESC}33m`;
+  const glyph = issue.severity === 'error' ? '×' : '⚠';
+
+  const lines = source.split('\n');
+  const startPos = lineAndColumn(source, issue.span.start);
+  const endPos = lineAndColumn(source, issue.span.end);
+  const firstLine = Math.max(1, startPos.line - 1);
+  const lastLine = Math.min(lines.length, endPos.line + 1);
+  const gutter = String(lastLine).length;
+  const pad = ' '.repeat(gutter + 2);
+
+  const out: string[] = [];
+  out.push(
+    `  ${color}${glyph} coverage(${issue.name})${RESET}: ${issue.message}`
+  );
+  out.push(
+    `${pad}╭─[${CYAN_UNDERLINE}${filePath}:${startPos.line}:${
+      startPos.column + 1
+    }${RESET}]`
+  );
+  for (let lineNumber = firstLine; lineNumber <= lastLine; lineNumber += 1) {
+    const text = assertDefined(lines[lineNumber - 1]);
+    out.push(` ${DIM}${String(lineNumber).padStart(gutter)}${RESET} │ ${text}`);
+    if (lineNumber === startPos.line) {
+      const underlineStart = startPos.column;
+      const underlineLength = Math.max(
+        1,
+        (endPos.line === lineNumber ? endPos.column : text.length) -
+          underlineStart
+      );
+      const mid = Math.floor(underlineLength / 2);
+      const bar = `${'─'.repeat(mid)}┬${'─'.repeat(
+        Math.max(0, underlineLength - mid - 1)
+      )}`;
+      out.push(`${pad}· ${MAGENTA}${' '.repeat(underlineStart)}${bar}${RESET}`);
+      out.push(
+        `${pad}· ${' '.repeat(underlineStart + mid)}${MAGENTA}╰── ${
+          issue.spanCaption
+        }${RESET}`
+      );
+    }
+  }
+  out.push(`${pad}╰────`);
+  out.push(`${CYAN}  help: ${RESET}${issue.help}`);
+  return out.join('\n');
+}
+
+/**
+ * Whether the run satisfies the coverage invariant (warnings allowed).
+ */
+function passes(summary: SummaryCounts): boolean {
+  return summary.uncoveredCounters === 0 && summary.directiveErrors === 0;
+}
+
+/**
+ * The trailing summary line.
+ */
+export function formatSummary(summary: SummaryCounts): string {
+  const problems = [
+    `${summary.uncoveredCounters} uncovered`,
+    summary.staleDirectives > 0 && `${summary.staleDirectives} stale`,
+    summary.directiveErrors === 1 && '1 error',
+    summary.directiveErrors > 1 && `${summary.directiveErrors} errors`,
+  ];
+  const notes = [
+    summary.deferredCounters > 0 && `${summary.deferredCounters} deferred`,
+    summary.excludedCounters > 0 && `${summary.excludedCounters} excluded`,
+  ].filter(Boolean);
+  const parenthetical = notes.length > 0 ? ` (${notes.join(', ')})` : '';
+  const color = passes(summary) ? BOLD_GREEN : BOLD_RED;
+  return `${color}coverage summary: ${problems
+    .filter(Boolean)
+    .join(', ')}${RESET}${parenthetical}`;
+}
+
+/**
+ * Writes issues and summary to stdout.
+ */
+export function printResult(
+  result: PackageCheckResult,
+  projectRoot: string
+): void {
+  const blocks = [
+    ...result.issues.map((issue) => formatIssue(issue, projectRoot)),
+    formatSummary(result.summary),
+  ];
+  process.stdout.write(`\n${blocks.join('\n\n')}\n\n`);
+}
+
+/**
+ * Options istanbul passes to a custom reporter constructor.
+ */
+interface ReporterOptions {
+  readonly projectRoot: string;
+}
+
+/**
+ * The istanbul reporter that runs coverage-check.
+ */
+export class CoverageCheckReporter {
+  private readonly projectRoot: string;
+  private readonly fileCoverageData: IstanbulFileCoverageData[] = [];
+
+  constructor(options: ReporterOptions) {
+    this.projectRoot = options.projectRoot;
+  }
+
+  execute(context: Context): void {
+    context.getTree().visit(this, context);
+    const result = checkPackage(this.projectRoot, this.fileCoverageData);
+    printResult(result, this.projectRoot);
+    if (!passes(result.summary)) process.exitCode = 1;
+  }
+
+  onDetail(node: ReportNode): void {
+    this.fileCoverageData.push(node.getFileCoverage().data);
+  }
+}

--- a/libs/coverage-check/src/reporter.ts
+++ b/libs/coverage-check/src/reporter.ts
@@ -110,7 +110,7 @@ export function formatSummary(summary: SummaryCounts): string {
   ].filter(Boolean);
   const parenthetical = notes.length > 0 ? ` (${notes.join(', ')})` : '';
   const color = passes(summary) ? BOLD_GREEN : BOLD_RED;
-  return `${color}coverage summary: ${problems
+  return `${color}☂️ coverage summary: ${problems
     .filter(Boolean)
     .join(', ')}${RESET}${parenthetical}`;
 }

--- a/libs/coverage-check/src/typescript.test.ts
+++ b/libs/coverage-check/src/typescript.test.ts
@@ -1,0 +1,135 @@
+import { expect, test } from 'vitest';
+import { join } from 'node:path';
+import { isStatement } from '@typescript/native/unstable/ast/is';
+import {
+  makeTempPackage,
+  openTempPackage,
+  parseSnippet,
+} from '../test/helpers.js';
+import { assertDefined } from './utils.js';
+import {
+  astNodeDescendants,
+  astNodeStatements,
+  collectComments,
+  startTypescriptCompilerSession,
+} from './typescript.js';
+
+test('opening a directory without a tsconfig fails', () => {
+  const directory = makeTempPackage({});
+  expect(() => startTypescriptCompilerSession(join(directory, 'nope'))).toThrow(
+    /could not load/
+  );
+});
+
+test('comments are collected everywhere they can sit, minus JSX text', () => {
+  const source = parseSnippet(
+    [
+      'declare function h(...args: unknown[]): unknown;',
+      '/* leading block */ export const a = 1; // trailing line',
+      'export function f(): void {} // after a body',
+      'export function g(): void {',
+      '  // inside an otherwise-empty block',
+      '}',
+      'export const o = {',
+      '  // inside an object literal',
+      '};',
+      'export const j = (',
+      '  <div>',
+      '    // not a comment: JSX text',
+      '    {/* jsx comment */}',
+      '  </div>',
+      ');',
+      'export class A { /* class body */ }',
+      'export interface I { /* interface body */ }',
+      'export enum E { /* enum body */ }',
+      'export const arr = [/* array */];',
+      'export const call = arr.map(/* args */);',
+      'export function p(/* params */): void {}',
+      'export type T = { /* type literal */ };',
+      'export const tup: [/* tuple */] = [];',
+      'declare const flag: boolean;',
+      'export const tern = flag ? /* then arm */ 1 : /* else arm */ 2;',
+      'export const nullish = tup[0] ?? /* nullish arm */ 0;',
+      'export const guarded = flag && /* and arm */ 1;',
+      '/* unterminated at end of file',
+    ].join('\n'),
+    'src/a.tsx'
+  );
+  expect(collectComments(source).map((comment) => comment.text.trim())).toEqual(
+    [
+      'leading block',
+      'trailing line',
+      'after a body',
+      'inside an otherwise-empty block',
+      'inside an object literal',
+      'jsx comment',
+      'class body',
+      'interface body',
+      'enum body',
+      'array',
+      'args',
+      'params',
+      'type literal',
+      'tuple',
+      'then arm',
+      'else arm',
+      'nullish arm',
+      'and arm',
+      'unterminated at end of file',
+    ]
+  );
+});
+
+test('astNodeStatements lists a container node, and is undefined otherwise', () => {
+  const source = parseSnippet('export const a = 1;\n');
+  expect(astNodeStatements(source)).toEqual(source.statements);
+  // A statement is not itself a statement-list container.
+  expect(
+    astNodeStatements(assertDefined(source.statements[0]))
+  ).toBeUndefined();
+});
+
+test('a statement is unreachable when a value reference in it is narrowed to never', () => {
+  const { directory, session } = openTempPackage({
+    'src/a.ts': [
+      'type Shape = { kind: "a" } | { kind: "b" };',
+      'declare function unreachable(value: never): never;',
+      'declare function fail(): never;',
+      'declare const shape: Shape;',
+      'declare const box: { inner: Shape };',
+      'export function bySwitch(): number {',
+      '  switch (shape.kind) {',
+      '    case "a": return 1;',
+      '    case "b": return 2;',
+      '    default: return unreachable(shape);',
+      '  }',
+      '}',
+      'export function byPropertyChain(): number {',
+      '  switch (box.inner.kind) {',
+      '    case "a": return 1;',
+      '    case "b": return 2;',
+      '    default: return unreachable(box.inner);',
+      '  }',
+      '}',
+      'export function stillReachable(): number {',
+      '  // A never-returning call on a live path is not a never-typed reference.',
+      '  if (shape.kind === "a") return fail();',
+      '  // A declaration name and a type position are not value references.',
+      '  let pending: never;',
+      '  const widened = null as never;',
+      '  return 3;',
+      '}',
+      '',
+    ].join('\n'),
+  });
+  const source = session.sourceFile(join(directory, 'src/a.ts'));
+  const statements = [...astNodeDescendants(source)].filter(isStatement);
+  const unreachable = session.unreachableStatements(statements);
+  expect(
+    [...unreachable]
+      .map((statement) =>
+        source.text.slice(statement.getStart(source), statement.end)
+      )
+      .sort()
+  ).toEqual(['return unreachable(box.inner);', 'return unreachable(shape);']);
+});

--- a/libs/coverage-check/src/typescript.test.ts
+++ b/libs/coverage-check/src/typescript.test.ts
@@ -21,6 +21,16 @@ test('opening a directory without a tsconfig fails', () => {
   );
 });
 
+test('disposing a session stops the compiler', () => {
+  const { directory, session } = openTempPackage({
+    'src/a.ts': 'export const a = 1;\n',
+  });
+  const file = join(directory, 'src/a.ts');
+  session.sourceFile(file);
+  session[Symbol.dispose]();
+  expect(() => session.sourceFile(file)).toThrow(/closed/);
+});
+
 test('comments are collected everywhere they can sit, minus JSX text', () => {
   const source = parseSnippet(
     [

--- a/libs/coverage-check/src/typescript.ts
+++ b/libs/coverage-check/src/typescript.ts
@@ -60,14 +60,14 @@ export interface TypescriptCompilerSession {
   readonly unreachableStatements: (
     statements: readonly Node[]
   ) => ReadonlySet<Node>;
-  readonly close: () => void;
+  [Symbol.dispose](): void;
 }
 
 /**
  * Starts the TypeScript compiler using a package's `tsconfig.json`. This uses
- * the TS API to start an ongoing tsgo child process, which must be cleaned up
- * by calling `close()`.
- * */
+ * the TS API to start an ongoing tsgo child process, which is stopped when the
+ * session is disposed.
+ */
 export function startTypescriptCompilerSession(
   packageDir: string
 ): TypescriptCompilerSession {
@@ -91,7 +91,7 @@ export function startTypescriptCompilerSession(
       },
       unreachableStatements: (statements) =>
         findUnreachableStatements(checker, statements),
-      close: () => api.close(),
+      [Symbol.dispose]: () => api.close(),
     };
   } catch (error) {
     api.close();

--- a/libs/coverage-check/src/typescript.ts
+++ b/libs/coverage-check/src/typescript.ts
@@ -1,0 +1,370 @@
+import { API, TypeFlags, type Checker } from '@typescript/native/unstable/sync';
+import {
+  SyntaxKind,
+  type Node,
+  type SourceFile,
+  type Statement,
+} from '@typescript/native/unstable/ast';
+import {
+  isBlock,
+  isCaseClause,
+  isDefaultClause,
+  isIdentifier,
+  isJsxText,
+  isModuleBlock,
+  isPropertyAccessExpression,
+  isSourceFile,
+  isStatement,
+  isTypeNode,
+} from '@typescript/native/unstable/ast/is';
+import {
+  getLeadingCommentRanges,
+  getTrailingCommentRanges,
+  skipTrivia,
+} from '@typescript/native/unstable/ast/scanner';
+import { resolve } from 'node:path';
+
+/**
+ * A range of text in a source file, represented by start and end offsets. This
+ * does not include a node's "trivia" (comments and whitespace preceding the
+ * node).
+ */
+export interface Span {
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * A source file comment's location and text.
+ */
+interface Comment {
+  readonly span: Span;
+  /**
+   * Text with the comment markers removed
+   */
+  readonly text: string;
+}
+
+/**
+ * A TypeScript compiler session for a package.
+ */
+export interface TypescriptCompilerSession {
+  /**
+   * Gets the AST for a source file in the package.
+   */
+  readonly sourceFile: (fileName: string) => SourceFile;
+  /**
+   * Analyzes which of the given statements contain a value reference whose narrowed
+   * type is `never` (meaning the statement is unreachable).
+   */
+  readonly unreachableStatements: (
+    statements: readonly Node[]
+  ) => ReadonlySet<Node>;
+  readonly close: () => void;
+}
+
+/**
+ * Starts the TypeScript compiler using a package's `tsconfig.json`. This uses
+ * the TS API to start an ongoing tsgo child process, which must be cleaned up
+ * by calling `close()`.
+ * */
+export function startTypescriptCompilerSession(
+  packageDir: string
+): TypescriptCompilerSession {
+  const api = new API({ cwd: packageDir });
+  const tsconfig = resolve(packageDir, 'tsconfig.json');
+  try {
+    const project = api
+      .updateSnapshot({ openProjects: [tsconfig] })
+      .getProject(tsconfig);
+    if (!project) {
+      throw new Error(`coverage-check: could not load ${tsconfig}`);
+    }
+    const { program, checker } = project;
+    return {
+      sourceFile: (fileName) => {
+        const file = program.getSourceFile(fileName);
+        if (!file) {
+          throw new Error(`coverage-check: ${fileName} is not in the project`);
+        }
+        return file;
+      },
+      unreachableStatements: (statements) =>
+        findUnreachableStatements(checker, statements),
+      close: () => api.close(),
+    };
+  } catch (error) {
+    api.close();
+    throw error;
+  }
+}
+
+/**
+ * A node's direct children.
+ */
+function astNodeChildren(node: Node): Node[] {
+  const children: Node[] = [];
+  node.forEachChild((child) => {
+    children.push(child);
+  });
+  return children;
+}
+
+/**
+ * Every node below the given node in pre-order (a node before its children).
+ */
+export function* astNodeDescendants(root: Node): Generator<Node> {
+  const stack = astNodeChildren(root).reverse();
+  for (let node = stack.pop(); node; node = stack.pop()) {
+    yield node;
+    const children = astNodeChildren(node);
+    for (let i = children.length - 1; i >= 0; i -= 1) {
+      stack.push(children[i] as Node);
+    }
+  }
+}
+
+/**
+ * The smallest node whose range contains the given span (topping out at the
+ * source file root node).
+ */
+export function astClosestParentNodeForSpan(
+  span: Span,
+  sourceFile: SourceFile
+): Node {
+  let node: Node = sourceFile;
+  for (;;) {
+    const next = astNodeChildren(node).find(
+      (child) =>
+        child.getStart(sourceFile) <= span.start && child.end >= span.end
+    );
+    if (!next) return node;
+    node = next;
+  }
+}
+
+/**
+ * The statement list a node directly holds (provided it is a statement container).
+ */
+export function astNodeStatements(
+  node: Node
+): readonly Statement[] | undefined {
+  if (
+    isSourceFile(node) ||
+    isBlock(node) ||
+    isModuleBlock(node) ||
+    isCaseClause(node) ||
+    isDefaultClause(node)
+  ) {
+    return node.statements;
+  }
+  return undefined;
+}
+
+const TERMINATORS = new Set([
+  SyntaxKind.ReturnStatement,
+  SyntaxKind.ThrowStatement,
+  SyntaxKind.BreakStatement,
+  SyntaxKind.ContinueStatement,
+]);
+
+/**
+ * Whether a statement ends in return/throw/break/continue.
+ */
+export function astNodeTerminates(statement: Node): boolean {
+  if (TERMINATORS.has(statement.kind)) return true;
+  if (isBlock(statement)) {
+    const last = statement.statements[statement.statements.length - 1];
+    return last !== undefined && astNodeTerminates(last);
+  }
+  return false;
+}
+
+/**
+ * Every comment in a file, in order.
+ */
+export function collectComments(sourceFile: SourceFile): Comment[] {
+  const { text } = sourceFile;
+  const commentsByPosition = new Map<number, Comment>();
+  const jsxText: Span[] = [];
+
+  // Comments live in the gaps between tokens. Given a gap offset, scan for
+  // trailing comments from the previous node and leading comments for the next
+  // node.
+  function collectCommentsAt(gapPosition: number): void {
+    for (const range of [
+      ...(getTrailingCommentRanges(text, gapPosition) ?? []),
+      ...(getLeadingCommentRanges(text, gapPosition) ?? []),
+    ]) {
+      if (commentsByPosition.has(range.pos)) continue;
+      const fullCommentText = text.slice(range.pos, range.end);
+      const innerCommentText =
+        range.kind === SyntaxKind.SingleLineCommentTrivia
+          ? fullCommentText.slice(2)
+          : fullCommentText.slice(
+              2,
+              fullCommentText.endsWith('*/') ? -2 : undefined
+            );
+      commentsByPosition.set(range.pos, {
+        span: { start: range.pos, end: range.end },
+        text: innerCommentText,
+      });
+    }
+  }
+
+  // Scan the gap before and after each node. A comment that is the only thing
+  // inside a delimiter pair (e.g. `{ /* comment */ }`) has no node on
+  // either side, and the delimiters are not nodes, so also scan just past any
+  // opening delimiter that starts or follows a node.
+  function collectNodeComments(node: Node): void {
+    collectCommentsAt(node.getFullStart());
+    collectCommentsAt(node.end);
+    for (const offset of [
+      node.getStart(sourceFile),
+      skipTrivia(text, node.end),
+    ]) {
+      const character = text[offset];
+      if (character !== undefined && '{[('.includes(character)) {
+        collectCommentsAt(offset + 1);
+      }
+    }
+  }
+
+  collectNodeComments(sourceFile);
+  for (const node of astNodeDescendants(sourceFile)) {
+    if (isJsxText(node)) {
+      jsxText.push({ start: node.getStart(sourceFile), end: node.end });
+      continue;
+    }
+    collectNodeComments(node);
+  }
+
+  return (
+    [...commentsByPosition.values()]
+      // Text with comment syntax inside a JSX node doesn't actually parse as a comment.
+      // E.g.
+      //  <div>/* not a comment */</div>
+      // In this case, "/* not a comment */" is parsed as text to render in that div.
+      .filter(
+        (comment) =>
+          !jsxText.some(
+            (span) =>
+              comment.span.start >= span.start && comment.span.start < span.end
+          )
+      )
+      .sort((a, b) => a.span.start - b.span.start)
+  );
+}
+
+const FUNCTION_LIKE = new Set([
+  SyntaxKind.FunctionDeclaration,
+  SyntaxKind.FunctionExpression,
+  SyntaxKind.ArrowFunction,
+  SyntaxKind.MethodDeclaration,
+  SyntaxKind.Constructor,
+  SyntaxKind.GetAccessor,
+  SyntaxKind.SetAccessor,
+]);
+
+const NOT_VALUE_REFERENCE_PARENTS = new Set([
+  SyntaxKind.ImportSpecifier,
+  SyntaxKind.ImportClause,
+  SyntaxKind.NamespaceImport,
+  SyntaxKind.ExportSpecifier,
+  SyntaxKind.QualifiedName,
+  SyntaxKind.LabeledStatement,
+  SyntaxKind.BreakStatement,
+  SyntaxKind.ContinueStatement,
+]);
+
+/**
+ * Parents whose `name` child is a declaration or property name, not a value
+ * reference.
+ */
+const NAME_OWNERS = new Set([
+  SyntaxKind.PropertyAccessExpression,
+  SyntaxKind.PropertyAssignment,
+  SyntaxKind.MethodDeclaration,
+  SyntaxKind.PropertyDeclaration,
+  SyntaxKind.PropertySignature,
+  SyntaxKind.VariableDeclaration,
+  SyntaxKind.Parameter,
+  SyntaxKind.BindingElement,
+  SyntaxKind.FunctionDeclaration,
+  SyntaxKind.FunctionExpression,
+  SyntaxKind.ClassDeclaration,
+  SyntaxKind.TypeAliasDeclaration,
+  SyntaxKind.InterfaceDeclaration,
+  SyntaxKind.EnumDeclaration,
+  SyntaxKind.EnumMember,
+  SyntaxKind.ModuleDeclaration,
+  SyntaxKind.GetAccessor,
+  SyntaxKind.SetAccessor,
+]);
+
+/**
+ * Reference expressions used as values directly within `root`: identifiers
+ * and property-access chains (`x`, `x.y.z` — the references TypeScript
+ * narrows), excluding type positions, declaration names, property names, and
+ * labels. Nested statements and function bodies belong to their own
+ * statements.
+ */
+function valueReferences(root: Node): Node[] {
+  const references: Node[] = [];
+  function visit(node: Node, parent: Node): void {
+    if (isTypeNode(node)) return;
+    if (isStatement(node) || FUNCTION_LIKE.has(node.kind)) return;
+    if (isPropertyAccessExpression(node)) {
+      references.push(node);
+      visit(node.expression, node);
+      return;
+    }
+    if (isIdentifier(node)) {
+      const isDeclaredName =
+        NAME_OWNERS.has(parent.kind) &&
+        'name' in parent &&
+        parent.name === node;
+      if (!NOT_VALUE_REFERENCE_PARENTS.has(parent.kind) && !isDeclaredName) {
+        references.push(node);
+      }
+      return;
+    }
+    node.forEachChild((child) => {
+      visit(child, node);
+    });
+  }
+  root.forEachChild((child) => {
+    visit(child, root);
+  });
+  return references;
+}
+
+/**
+ * Given a list of statements, finds those that are deemed unreachable by the
+ * type checker due to referencing a value that is of type `never`.
+ */
+function findUnreachableStatements(
+  checker: Checker,
+  statements: readonly Node[]
+): ReadonlySet<Node> {
+  const candidates: Array<{ statement: Node; reference: Node }> = [];
+  for (const statement of new Set(statements)) {
+    for (const reference of valueReferences(statement)) {
+      candidates.push({ statement, reference });
+    }
+  }
+  if (candidates.length === 0) return new Set();
+  // Check the types in bulk since talking to the checker is expensive
+  const types = checker.getTypeAtLocation(
+    candidates.map((candidate) => candidate.reference)
+  );
+  const unreachable = new Set<Node>();
+  for (const [index, type] of types.entries()) {
+    const candidate = candidates[index];
+    // eslint-disable-next-line no-bitwise
+    if (candidate && type && type.flags & TypeFlags.Never) {
+      unreachable.add(candidate.statement);
+    }
+  }
+  return unreachable;
+}

--- a/libs/coverage-check/src/utils.test.ts
+++ b/libs/coverage-check/src/utils.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+import { assertDefined, throwIllegalValue } from './utils.js';
+
+test('throwIllegalValue throws with the value', () => {
+  expect(() => throwIllegalValue('oops' as never)).toThrow(
+    'Illegal value: oops'
+  );
+});
+
+test('assertDefined passes defined values through and rejects undefined', () => {
+  expect(assertDefined(0)).toEqual(0);
+  expect(() => assertDefined(undefined)).toThrow('Expected a defined value');
+});

--- a/libs/coverage-check/src/utils.ts
+++ b/libs/coverage-check/src/utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Throws; call it where TypeScript has narrowed `value` to `never`. A local
+ * stand-in for `@votingworks/basics`'s `throwIllegalValue`, since this package
+ * cannot depend on workspace libraries (see README).
+ */
+export function throwIllegalValue(value: never): never {
+  throw new Error(`Illegal value: ${String(value)}`);
+}
+
+/**
+ * Returns `value` unless it is `undefined`, in which case throws. A local
+ * stand-in for `@votingworks/basics`'s `assertDefined`.
+ */
+export function assertDefined<T>(value?: T): T {
+  if (value === undefined) throw new Error('Expected a defined value');
+  return value;
+}

--- a/libs/coverage-check/test/global_setup.ts
+++ b/libs/coverage-check/test/global_setup.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+/**
+ * vitest `globalSetup`: generates the fixtures' istanbul report before the
+ * suite runs by executing `fixtures/fixture_tests.ts` under vitest's coverage
+ * provider (the production pipeline, so the report has all the real remapping
+ * quirks) into the gitignored `fixtures/coverage/coverage-final.json`.
+ */
+export function setup(): void {
+  const packageDir = resolve(__dirname, '..');
+  try {
+    execFileSync(
+      'pnpm',
+      ['exec', 'vitest', 'run', '--root', 'fixtures', '--coverage'],
+      { cwd: packageDir, stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+  } catch (error) {
+    const { stdout, stderr } = error as { stdout?: Buffer; stderr?: Buffer };
+    throw new Error(
+      `generating the fixture coverage report failed:\n${stdout}\n${stderr}`
+    );
+  }
+}

--- a/libs/coverage-check/test/helpers.ts
+++ b/libs/coverage-check/test/helpers.ts
@@ -1,0 +1,94 @@
+import type { SourceFile } from '@typescript/native/unstable/ast';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { onTestFinished, vi } from 'vitest';
+import type { IstanbulFileCoverageData } from '../src/istanbul.js';
+import {
+  startTypescriptCompilerSession,
+  type TypescriptCompilerSession,
+} from '../src/typescript.js';
+
+/**
+ * The fixture project: `fixtures/src` holds small sources covering the
+ * repo's real patterns; `test/global_setup.ts` generates their istanbul report
+ * into `fixtures/coverage/coverage-final.json` before the suite runs.
+ */
+export const FIXTURES_DIR = resolve(__dirname, '../fixtures');
+
+/**
+ * The generated fixture report.
+ */
+export function fixtureReport(): IstanbulFileCoverageData[] {
+  return Object.values(
+    JSON.parse(
+      readFileSync(join(FIXTURES_DIR, 'coverage/coverage-final.json'), 'utf8')
+    ) as Record<string, IstanbulFileCoverageData>
+  );
+}
+
+/**
+ * Captures everything written to stdout until mocks are restored.
+ */
+export function captureStdout(): { text: () => string } {
+  const chunks: string[] = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  return { text: () => chunks.join('') };
+}
+
+/**
+ * A throwaway package directory with a tsconfig and the given files.
+ */
+export function makeTempPackage(files: Record<string, string>): string {
+  const directory = mkdtempSync(join(tmpdir(), 'coverage-check-'));
+  onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+  writeFileSync(
+    join(directory, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        strict: true,
+        noEmit: true,
+        jsx: 'react',
+        jsxFactory: 'h',
+        types: [],
+        lib: ['es2022'],
+      },
+      include: ['src'],
+    })
+  );
+  for (const [name, text] of Object.entries(files)) {
+    mkdirSync(dirname(join(directory, name)), { recursive: true });
+    writeFileSync(join(directory, name), text);
+  }
+  return directory;
+}
+
+/**
+ * Opens a session on a temp package; closed when the test finishes.
+ */
+export function openTempPackage(files: Record<string, string>): {
+  directory: string;
+  session: TypescriptCompilerSession;
+} {
+  const directory = makeTempPackage(files);
+  const session = startTypescriptCompilerSession(directory);
+  onTestFinished(() => session.close());
+  return { directory, session };
+}
+
+/**
+ * Parses one source file through a temp package.
+ */
+export function parseSnippet(text: string, name = 'src/a.ts'): SourceFile {
+  const { directory, session } = openTempPackage({ [name]: text });
+  return session.sourceFile(join(directory, name));
+}

--- a/libs/coverage-check/test/helpers.ts
+++ b/libs/coverage-check/test/helpers.ts
@@ -81,7 +81,7 @@ export function openTempPackage(files: Record<string, string>): {
 } {
   const directory = makeTempPackage(files);
   const session = startTypescriptCompilerSession(directory);
-  onTestFinished(() => session.close());
+  onTestFinished(() => session[Symbol.dispose]());
   return { directory, session };
 }
 

--- a/libs/coverage-check/tsconfig.build.json
+++ b/libs/coverage-check/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
+  "compilerOptions": {
+    "tsBuildInfoFile": "build/tsconfig.build.tsbuildinfo",
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "build",
+    "declaration": true
+  },
+  "references": []
+}

--- a/libs/coverage-check/tsconfig.json
+++ b/libs/coverage-check/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.shared.json",
+  "include": ["src", "test"],
+  "exclude": [],
+  "compilerOptions": {
+    "module": "node16",
+    "lib": ["esnext"],
+    "composite": true,
+    "noEmit": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "references": []
+}

--- a/libs/coverage-check/vitest.config.ts
+++ b/libs/coverage-check/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '../../vitest.config.shared.mjs';
+
+// Until the shared config registers coverage-check for every package, the
+// package checks its own coverage.
+const coverageCheckReporter = fileURLToPath(
+  new URL('./vitest_coverage_reporter.cjs', import.meta.url)
+);
+
+export default defineConfig({
+  test: {
+    globalSetup: ['test/global_setup.ts'],
+    coverage: {
+      reporter: ['json', [coverageCheckReporter, {}]],
+      // Remove after migration to coverage-check is complete
+      thresholds: {
+        lines: 0,
+        branches: 0,
+      },
+    },
+  },
+});

--- a/libs/coverage-check/vitest_coverage_reporter.cjs
+++ b/libs/coverage-check/vitest_coverage_reporter.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./build/index.js').CoverageCheckReporter;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3520,6 +3520,28 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@3.2.3))(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
 
+  libs/coverage-check:
+    dependencies:
+      '@typescript/native':
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
+    devDependencies:
+      '@types/istanbul-lib-report':
+        specifier: ^3.0.0
+        version: 3.0.0
+      '@types/node':
+        specifier: 24.13.3
+        version: 24.13.3
+      '@vitest/coverage-istanbul':
+        specifier: ^4.1.6
+        version: 4.1.6(vitest@4.1.6)
+      sort-package-json:
+        specifier: ^1.50.0
+        version: 1.53.1
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-istanbul@4.1.6)(jsdom@20.0.1(canvas@3.2.3))(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
+
   libs/custom-paper-handler:
     dependencies:
       '@votingworks/basics':


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Creates libs/coverage-check, a code coverage reporter that uses explicit inline directive comments instead of thresholds to manage uncovered code.

Motivation and overview (from the [coverage-check README](https://github.com/votingworks/vxsuite/blob/9f9ed1c0dcd4380101c44e9e5dc2be0b31d2e40c/libs/coverage-check/README.md)):

> coverage-check is a custom coverage reporter that enforces our approach to code coverage:
>
> Every uncovered statement, function, and branch must be explicitly marked as either deferred or excluded from code coverage.
>
> The checker is an istanbul coverage reporter. It receives the coverage map produced by vitest and checks it against inline source code comments known as "directives," which mark code as deferred or excluded from coverage.
>
> This approach has some advantages over traditional threshold-based reporting:
>
> - When code changes, you can easily see a _diff_ of which specific pieces of   code changed in their coverage
> - Coverage exceptions are colocated with the code, so if the code moves, the exception moves with it
>
> The checker also uses the TypeScript compiler to find unreachable code (e.g. the `default` arm of an exhaustive `switch`) and automatically excludes it from coverage requirements.

This PR introduces the tool itself, but does not integrate it into any workspace packages. That migration will be stacked on top as a separate PR.

## Demo Video or Screenshot

```
> pnpm test:run --coverage
... elided vitest output ... 

  ⚠ coverage(stale-directive): everything this @coverage-exclude directive marks is covered
     ╭─[src/check.ts:185:3]
 184 │   }
 185 │   // @coverage-exclude
     ·   ──────────┬─────────
     ·             ╰── no longer needed
 186 │   for (let node = closest; !isSourceFile(node); node = node.parent) {
     ╰────
  help: delete this directive

  × coverage(uncovered-branch): branch arm (if) is never taken in tests
    ╭─[src/typescript.ts:91:7]
 90 │       const file = program.getSourceFile(fileName);
 91 │       if (!file) {
    ·       ──────┬─────
    ·             ╰── not covered
 92 │         // @coverage-defer
    ╰────
  help: add a test that exercises this code, or mark it with @coverage-defer/@coverage-exclude

coverage summary: 1 uncovered, 1 stale (1 deferred)

 ELIFECYCLE  Command failed with exit code 1.
```

## Testing Plan

Added automated test coverage, the majority of which consists of a set of fixture TS files and a snapshotted coverage report. See the [fixtures README](https://github.com/votingworks/vxsuite/blob/9f9ed1c0dcd4380101c44e9e5dc2be0b31d2e40c/libs/coverage-check/fixtures/README.md) for details.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

