### PR TITLE
feat(admin): discard a workspace an interrupted restore left behind

### DIFF
--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -42,6 +42,7 @@ import {
   ADMIN_WORKSPACE_DATABASE_NAME,
   createWorkspace,
   openWorkspace,
+  RESTORE_IN_PROGRESS_MARKER_FILENAME,
   Workspace,
 } from '../../util/workspace.js';
 import { createBackup } from '../create/index.js';
@@ -53,7 +54,7 @@ import {
   BackupManifestStruct,
   BackupManifestStructSchema,
 } from '../backup_manifest.js';
-import { restoreBackup, RESTORE_IN_PROGRESS_MARKER_FILENAME } from './index.js';
+import { restoreBackup } from './index.js';
 import { ProgressEvent } from '../progress.js';
 
 vi.setConfig({ testTimeout: 30_000 });
@@ -970,13 +971,21 @@ test('an interrupted restore can be recovered by restoring again', async () => {
   // The configured election is half-restored debris, not data to protect, so
   // this must restore rather than refuse — refusing would leave the operator
   // with no way forward.
+  const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   expect(
     await restoreBackup({
       backup: backup.path,
       workspace: restorable(workspacePath),
-      logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+      logger,
     })
   ).toEqual(ok());
+
+  expect(logger.logAsCurrentRole).toHaveBeenCalledWith(
+    LogEventId.BackupRestoreInterrupted,
+    expect.objectContaining({
+      message: expect.stringContaining('unfinished'),
+    })
+  );
 
   await expect(exists(markerPath)).resolves.toBeFalsy();
   using workspace = openWorkspace(

--- a/apps/admin/backend/src/backup/restore/index.ts
+++ b/apps/admin/backend/src/backup/restore/index.ts
@@ -16,8 +16,6 @@ import {
   verifyRestoredWorkspace,
 } from './verify_step.js';
 
-export { RESTORE_IN_PROGRESS_MARKER_FILENAME } from './prepare_step.js';
-
 /**
  * Restores a backup from disk, typically an external USB drive. Includes the
  * database, ballot images, and election packages.
@@ -72,7 +70,7 @@ async function tryRestoreBackup(
     return err(CANCELLED_ERROR);
   }
 
-  const checkResult = checkWorkspaceIsRestorable(workspace);
+  const checkResult = await checkWorkspaceIsRestorable(workspace, logger);
   if (checkResult.isErr()) {
     return checkResult;
   }

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -1,10 +1,13 @@
-import { existsSync } from 'node:fs';
 import { rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import { emptydir } from 'fs-extra';
 import { err, iter, ok, Result } from '@votingworks/basics';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
-import { Workspace } from '../../util/workspace.js';
+import { Logger, LogEventId } from '@votingworks/logging';
+import {
+  getRestoreInProgressMarkerPath,
+  hasInterruptedRestore,
+  Workspace,
+} from '../../util/workspace.js';
 import { BackupManifest } from '../backup_manifest.js';
 import { checkWorkspaceIsHostMode } from '../host_mode.js';
 import { RestoreError } from './types.js';
@@ -12,25 +15,15 @@ import { RestoreError } from './types.js';
 const DEFAULT_MIN_AVAILABLE_STORAGE_BYTES = 50_000_000; // 50 MB
 
 /**
- * Dropped into the workspace while a restore is running and removed only on
- * success. Its presence afterwards means a restore was interrupted, so what
- * the workspace holds is half-restored debris rather than data to protect.
- */
-export const RESTORE_IN_PROGRESS_MARKER_FILENAME = 'restore-in-progress';
-
-function getMarkerPath(workspacePath: string): string {
-  return join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME);
-}
-
-/**
  * Checks that the workspace is one a restore may take over: a host machine's,
  * not being written to, and either unconfigured or left behind by an
  * interrupted restore (per the marker), in which case the restore is what
  * recovers it.
  */
-export function checkWorkspaceIsRestorable(
-  workspace: Workspace
-): Result<void, RestoreError> {
+export async function checkWorkspaceIsRestorable(
+  workspace: Workspace,
+  logger: Logger
+): Promise<Result<void, RestoreError>> {
   const hostModeResult = checkWorkspaceIsHostMode(workspace);
   if (hostModeResult.isErr()) {
     return hostModeResult;
@@ -49,7 +42,12 @@ export function checkWorkspaceIsRestorable(
     });
   }
 
-  if (existsSync(getMarkerPath(workspace.path))) {
+  if (hasInterruptedRestore(workspace.path)) {
+    await logger.logAsCurrentRole(LogEventId.BackupRestoreInterrupted, {
+      message:
+        'Restoring over a workspace an earlier restore left unfinished; ' +
+        'whatever it holds now is being replaced.',
+    });
     return ok();
   }
 
@@ -100,7 +98,7 @@ export async function checkWorkspaceHasSufficientSpace({
  */
 export async function claimWorkspace(workspacePath: string): Promise<void> {
   await emptydir(workspacePath);
-  await writeFile(getMarkerPath(workspacePath), '');
+  await writeFile(getRestoreInProgressMarkerPath(workspacePath), '');
 }
 
 /**
@@ -117,5 +115,5 @@ export async function abandonFailedRestore(
  * Removes the in-progress marker, declaring the restore complete.
  */
 export async function completeRestore(workspacePath: string): Promise<void> {
-  await rm(getMarkerPath(workspacePath), { force: true });
+  await rm(getRestoreInProgressMarkerPath(workspacePath), { force: true });
 }

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { assert } from '@votingworks/basics';
+import { readdirSync, writeFileSync } from 'node:fs';
 import { AddressInfo } from 'node:net';
+import { join } from 'node:path';
 import { LogEventId, mockLogger } from '@votingworks/logging';
 import { Server } from 'node:http';
 import {
@@ -22,7 +24,10 @@ import {
 } from '@votingworks/usb-drive';
 import { createMockPrinterHandler } from '@votingworks/printing';
 import { start } from './server.js';
-import { createWorkspace } from './util/workspace.js';
+import {
+  createWorkspace,
+  RESTORE_IN_PROGRESS_MARKER_FILENAME,
+} from './util/workspace.js';
 import { importCastVoteRecords } from './cast_vote_records.js';
 import { startHostNetworking, startClientNetworking } from './networking.js';
 
@@ -136,6 +141,27 @@ test('errors on start with no workspace', async () => {
       }
     );
   }
+});
+
+test('discards a workspace an interrupted restore left behind', async () => {
+  const logger = mockLogger({ fn: vi.fn });
+  const workspacePath = makeTemporaryDirectory();
+  writeFileSync(join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME), '');
+  writeFileSync(join(workspacePath, 'half-copied-file'), 'partial');
+
+  const startedServer = await start({ logger, workspacePath });
+
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.BackupRestoreInterrupted,
+    'system',
+    { message: expect.stringContaining(workspacePath) }
+  );
+  expect(readdirSync(workspacePath)).not.toContain('half-copied-file');
+  expect(readdirSync(workspacePath)).not.toContain(
+    RESTORE_IN_PROGRESS_MARKER_FILENAME
+  );
+
+  startedServer.close();
 });
 
 test('logs device attach/un-attach events', async () => {

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { emptydir } from 'fs-extra';
 import {
   LogEventId,
   BaseLogger,
@@ -33,6 +34,7 @@ import { PEER_PORT, PORT } from './globals.js';
 import {
   createWorkspace,
   createClientWorkspace,
+  hasInterruptedRestore,
   resolveWorkspacePath,
 } from './util/workspace.js';
 import { buildApp } from './app.js';
@@ -106,6 +108,15 @@ export async function start(options: StartOptions = {}): Promise<Server> {
 
   const workspacePath =
     options.workspacePath ?? resolveWorkspacePath(baseLogger);
+  if (hasInterruptedRestore(workspacePath)) {
+    await emptydir(workspacePath);
+    baseLogger.log(LogEventId.BackupRestoreInterrupted, 'system', {
+      message:
+        `A restore of ${workspacePath} was interrupted before it finished; ` +
+        `discarded what it left behind and starting unconfigured.`,
+    });
+  }
+
   const machineMode =
     options.machineMode ??
     FileBackedMachineModeController.forWorkspace(workspacePath);

--- a/apps/admin/backend/src/util/workspace.ts
+++ b/apps/admin/backend/src/util/workspace.ts
@@ -1,4 +1,4 @@
-import { statSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
 import { getDiskSpaceSummaries, getNodeEnv } from '@votingworks/backend';
@@ -11,6 +11,27 @@ import { ClientStore } from '../client_store.js';
  * Base name of the VxAdmin SQLite database.
  */
 export const ADMIN_WORKSPACE_DATABASE_NAME = 'data.db';
+
+/**
+ * Dropped into a workspace while a restore is running and removed only once it
+ * succeeds. Its presence afterwards means a restore was interrupted partway
+ * through, so the workspace holds nothing worth keeping.
+ */
+export const RESTORE_IN_PROGRESS_MARKER_FILENAME = 'restore-in-progress';
+
+/**
+ * Path of the marker described by {@link RESTORE_IN_PROGRESS_MARKER_FILENAME}.
+ */
+export function getRestoreInProgressMarkerPath(workspacePath: string): string {
+  return join(resolve(workspacePath), RESTORE_IN_PROGRESS_MARKER_FILENAME);
+}
+
+/**
+ * Whether a restore was interrupted, implying the workspace data is incomplete.
+ */
+export function hasInterruptedRestore(workspacePath: string): boolean {
+  return existsSync(getRestoreInProgressMarkerPath(workspacePath));
+}
 
 /**
  * Shared workspace interface for both host and client machines.

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -386,6 +386,10 @@ IDs are logged with each log to identify the log being written.
 **Type:** [user-action](#user-action)
 **Description:** Restoring from a backup completed, success or failure is indicated by the disposition.
 **Machines:** vx-admin
+### backup-restore-interrupted
+**Type:** [system-status](#system-status)
+**Description:** A restore was interrupted before it finished, leaving the workspace holding neither the data it had nor the data it was being given. What it left behind is discarded, since a restore only ever claims a workspace that held nothing worth keeping.
+**Machines:** vx-admin
 ### backup-restore-machine-mismatch
 **Type:** [user-action](#user-action)
 **Description:** User is restoring a backup whose machine ID differs from the current machine's ID.

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -647,6 +647,12 @@ eventType = "user-action"
 documentationMessage = "Restoring from a backup completed, success or failure is indicated by the disposition."
 restrictInDocumentationToApps = ["vx-admin"]
 
+[Events.BackupRestoreInterrupted]
+eventId = "backup-restore-interrupted"
+eventType = "system-status"
+documentationMessage = "A restore was interrupted before it finished, leaving the workspace holding neither the data it had nor the data it was being given. What it left behind is discarded, since a restore only ever claims a workspace that held nothing worth keeping."
+restrictInDocumentationToApps = ["vx-admin"]
+
 [Events.BackupRestoreMachineMismatch]
 eventId = "backup-restore-machine-mismatch"
 eventType = "user-action"

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -159,6 +159,7 @@ export enum LogEventId {
   BackupCreateComplete = 'backup-create-complete',
   BackupRestoreInit = 'backup-restore-init',
   BackupRestoreComplete = 'backup-restore-complete',
+  BackupRestoreInterrupted = 'backup-restore-interrupted',
   BackupRestoreMachineMismatch = 'backup-restore-machine-mismatch',
   ClearingBallotData = 'clear-ballot-data-init',
   ClearedBallotData = 'clear-ballot-data-complete',
@@ -909,6 +910,14 @@ const BackupRestoreComplete: LogDetails = {
   eventType: LogEventType.UserAction,
   documentationMessage:
     'Restoring from a backup completed, success or failure is indicated by the disposition.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const BackupRestoreInterrupted: LogDetails = {
+  eventId: LogEventId.BackupRestoreInterrupted,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage:
+    'A restore was interrupted before it finished, leaving the workspace holding neither the data it had nor the data it was being given. What it left behind is discarded, since a restore only ever claims a workspace that held nothing worth keeping.',
   restrictInDocumentationToApps: [AppName.VxAdmin],
 };
 
@@ -1790,6 +1799,8 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return BackupRestoreInit;
     case LogEventId.BackupRestoreComplete:
       return BackupRestoreComplete;
+    case LogEventId.BackupRestoreInterrupted:
+      return BackupRestoreInterrupted;
     case LogEventId.BackupRestoreMachineMismatch:
       return BackupRestoreMachineMismatch;
     case LogEventId.ClearingBallotData:

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -301,6 +301,8 @@ pub enum EventId {
     BackupRestoreInit,
     #[serde(rename = "backup-restore-complete")]
     BackupRestoreComplete,
+    #[serde(rename = "backup-restore-interrupted")]
+    BackupRestoreInterrupted,
     #[serde(rename = "backup-restore-machine-mismatch")]
     BackupRestoreMachineMismatch,
     #[serde(rename = "clear-ballot-data-init")]


### PR DESCRIPTION
## Overview

Refs #7897

Wipes a workspace that contains an incomplete restore. Uses the existing marker file (`restore-in-progress`) to detect an incomplete restore. This fixes two issues:
1. VxAdmin would try to serve an incomplete restore, which might mean e.g. a full database but missing ballot images.
2. A subsequent restore would bail early because it would see the marker file.

## Testing Plan

New automated tests.