### PR TITLE
feat(admin): keep a restore and a machine using its workspace apart

### DIFF
--- a/apps/admin/backend/src/app.restore_mode.test.ts
+++ b/apps/admin/backend/src/app.restore_mode.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { readElectionGeneralDefinition } from '@votingworks/fixtures';
+import { LogEventId } from '@votingworks/logging';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
+import {
+  buildTestEnvironment,
+  configureMachine,
+  mockSystemAdministratorAuth,
+} from '../test/app.js';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+let env: ReturnType<typeof buildTestEnvironment>;
+
+beforeEach(() => {
+  env = buildTestEnvironment();
+  mockSystemAdministratorAuth(env.auth);
+});
+
+afterEach(() => {
+  env.peerServer.close();
+});
+
+test('a host describes itself as one', async () => {
+  expect(await env.apiClient.getAppMode()).toEqual('host');
+});
+
+test('scheduling restore mode asks the next boot to start there', async () => {
+  const { apiClient, bootIntentController, logger } = env;
+
+  await apiClient.scheduleRestoreMode();
+
+  expect(bootIntentController.take()).toEqual('restore');
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.AdminRestoreModeScheduled,
+    'system_administrator',
+    expect.objectContaining({ disposition: 'success' })
+  );
+});
+
+test('restore mode cannot be scheduled while an election is configured', async () => {
+  const { apiClient, auth, bootIntentController } = env;
+  await configureMachine(apiClient, auth, readElectionGeneralDefinition());
+
+  await suppressingConsoleOutput(() =>
+    expect(apiClient.scheduleRestoreMode()).rejects.toThrow(
+      'Cannot restore while an election is configured.'
+    )
+  );
+  expect(bootIntentController.take()).toBeUndefined();
+});
+
+test('restore mode cannot be scheduled from a client', async () => {
+  const { apiClient, bootIntentController } = env;
+  await apiClient.setMachineMode({ mode: 'client' });
+
+  await suppressingConsoleOutput(() =>
+    expect(apiClient.scheduleRestoreMode()).rejects.toThrow(
+      'Only a host can be restored.'
+    )
+  );
+  expect(bootIntentController.take()).toBeUndefined();
+});

--- a/apps/admin/backend/src/app.restore_mode.test.ts
+++ b/apps/admin/backend/src/app.restore_mode.test.ts
@@ -3,6 +3,10 @@ import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import { LogEventId } from '@votingworks/logging';
 import { suppressingConsoleOutput } from '@votingworks/test-utils';
 import {
+  BooleanEnvironmentVariableName,
+  getFeatureFlagMock,
+} from '@votingworks/utils';
+import {
   buildTestEnvironment,
   configureMachine,
   mockSystemAdministratorAuth,
@@ -10,15 +14,26 @@ import {
 
 vi.setConfig({ testTimeout: 30_000 });
 
+const featureFlagMock = getFeatureFlagMock();
+vi.mock(import('@votingworks/utils'), async (importActual) => ({
+  ...(await importActual()),
+  isFeatureFlagEnabled: (flag: BooleanEnvironmentVariableName) =>
+    featureFlagMock.isEnabled(flag),
+}));
+
 let env: ReturnType<typeof buildTestEnvironment>;
 
 beforeEach(() => {
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.ENABLE_ADMIN_BACKUP_RESTORE
+  );
   env = buildTestEnvironment();
   mockSystemAdministratorAuth(env.auth);
 });
 
 afterEach(() => {
   env.peerServer.close();
+  featureFlagMock.resetFeatureFlags();
 });
 
 test('a host describes itself as one', async () => {
@@ -57,6 +72,18 @@ test('restore mode cannot be scheduled from a client', async () => {
   await suppressingConsoleOutput(() =>
     expect(apiClient.scheduleRestoreMode()).rejects.toThrow(
       'Only a host can be restored.'
+    )
+  );
+  expect(bootIntentController.take()).toBeUndefined();
+});
+
+test('restore mode cannot be scheduled unless backup and restore are enabled', async () => {
+  const { apiClient, bootIntentController } = env;
+  featureFlagMock.resetFeatureFlags();
+
+  await suppressingConsoleOutput(() =>
+    expect(apiClient.scheduleRestoreMode()).rejects.toThrow(
+      'Backup and restore are not enabled.'
     )
   );
   expect(bootIntentController.take()).toBeUndefined();

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -42,6 +42,8 @@ import { rm } from 'node:fs/promises';
 import { pipeline } from 'node:stream/promises';
 import path, { join } from 'node:path';
 import {
+  BooleanEnvironmentVariableName,
+  isFeatureFlagEnabled,
   ELECTION_PACKAGE_FOLDER,
   generateElectionBasedSubfolderName,
   generateFilenameForElectionPackage,
@@ -323,6 +325,12 @@ function buildApi({
      * As with a change of machine mode, the caller reboots to get there.
      */
     async scheduleRestoreMode(): Promise<void> {
+      assert(
+        isFeatureFlagEnabled(
+          BooleanEnvironmentVariableName.ENABLE_ADMIN_BACKUP_RESTORE
+        ),
+        'Backup and restore are not enabled.'
+      );
       assert(
         store.getCurrentElectionId() === undefined,
         'Cannot restore while an election is configured.'

--- a/apps/admin/backend/src/app.ts
+++ b/apps/admin/backend/src/app.ts
@@ -91,6 +91,7 @@ import {
   CastVoteRecordVoteInfo,
   AdjudicatedCvr,
   AdjudicationError,
+  AppMode,
   MachineMode,
   MachineRecord,
   BallotAdjudicationQueueMetadata,
@@ -101,6 +102,7 @@ import { Workspace } from './util/workspace.js';
 import { getMachineConfig } from './machine_config.js';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
 import { MachineModeController } from './machine_mode.js';
+import { BootIntentController } from './boot_intent.js';
 import { getBallotImages } from './util/adjudication.js';
 import {
   transformWriteInsAndSetManualResults,
@@ -193,6 +195,7 @@ function buildApi({
   auth,
   workspace,
   machineMode,
+  bootIntent,
   logger,
   multiUsbDrive,
   printer,
@@ -200,6 +203,7 @@ function buildApi({
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
   machineMode: MachineModeController;
+  bootIntent: BootIntentController;
   logger: Logger;
   multiUsbDrive: MultiUsbDrive;
   printer: Printer;
@@ -281,6 +285,10 @@ function buildApi({
   return grout.createApi({
     getMachineConfig,
 
+    getAppMode(): AppMode {
+      return 'host';
+    },
+
     getMachineMode(): MachineMode {
       return machineMode.get();
     },
@@ -305,6 +313,26 @@ function buildApi({
         message: `Machine mode changed to ${newMachineMode}.`,
         disposition: 'success',
         newMode: newMachineMode,
+      });
+    },
+
+    /**
+     * Arranges for the machine to start in restore mode on its next boot,
+     * where a backup can be restored into the workspace. Only an unconfigured
+     * host has a workspace a restore may take over, so nothing else may ask.
+     * As with a change of machine mode, the caller reboots to get there.
+     */
+    async scheduleRestoreMode(): Promise<void> {
+      assert(
+        store.getCurrentElectionId() === undefined,
+        'Cannot restore while an election is configured.'
+      );
+      assert(machineMode.get() === 'host', 'Only a host can be restored.');
+
+      bootIntent.request('restore');
+      await logger.logAsCurrentRole(LogEventId.AdminRestoreModeScheduled, {
+        message: 'Machine will start in restore mode on its next boot.',
+        disposition: 'success',
       });
     },
 
@@ -1643,6 +1671,7 @@ export function buildApp({
   auth,
   workspace,
   machineMode,
+  bootIntent,
   logger,
   multiUsbDrive,
   printer,
@@ -1650,6 +1679,7 @@ export function buildApp({
   auth: DippedSmartCardAuthApi;
   workspace: Workspace;
   machineMode: MachineModeController;
+  bootIntent: BootIntentController;
   logger: Logger;
   multiUsbDrive: MultiUsbDrive;
   printer: Printer;
@@ -1659,6 +1689,7 @@ export function buildApp({
     auth,
     workspace,
     machineMode,
+    bootIntent,
     logger,
     multiUsbDrive,
     printer,

--- a/apps/admin/backend/src/backup/cli/main.ts
+++ b/apps/admin/backend/src/backup/cli/main.ts
@@ -11,11 +11,7 @@ import { DisplayProgress, ProgressDisplay } from './progress_display.js';
 import * as views from './views.js';
 import { ProgressEvent } from '../progress.js';
 import { createBackup } from '../create/index.js';
-import {
-  createWorkspace,
-  openWorkspace,
-  Workspace,
-} from '../../util/workspace.js';
+import { openWorkspace, Workspace } from '../../util/workspace.js';
 import { restoreBackup } from '../restore/index.js';
 
 /**
@@ -392,13 +388,9 @@ async function restore(
     Boolean((stderr as NodeJS.WriteStream).isTTY)
   );
 
-  // Not `using`: `restoreBackup` closes the store itself, and the workspace is
-  // not usable afterwards.
-  const workspace = createWorkspace(args.workspace, logger);
-
   const restoreBackupResult = await restoreBackup({
     backup: args.backup,
-    workspace,
+    workspacePath: args.workspace,
     logger,
     signal,
     onProgressEvent: (event) => display.update(displayProgress(event)),

--- a/apps/admin/backend/src/backup/create/prepare_step.ts
+++ b/apps/admin/backend/src/backup/create/prepare_step.ts
@@ -194,7 +194,7 @@ export async function prepare(
     return err(CANCELLED_ERROR);
   }
 
-  const hostModeResult = checkWorkspaceIsHostMode(workspace);
+  const hostModeResult = checkWorkspaceIsHostMode(workspace.path);
   if (hostModeResult.isErr()) {
     return hostModeResult;
   }

--- a/apps/admin/backend/src/backup/host_mode.ts
+++ b/apps/admin/backend/src/backup/host_mode.ts
@@ -1,6 +1,5 @@
 import { err, ok, Result } from '@votingworks/basics';
 import { FileBackedMachineModeController } from '../machine_mode.js';
-import { BaseWorkspace } from '../util/workspace.js';
 
 /**
  * Checks that a workspace belongs to a VxAdmin in host mode, which is the only
@@ -14,11 +13,10 @@ import { BaseWorkspace } from '../util/workspace.js';
  * is the machine that has to read what was restored.
  */
 export function checkWorkspaceIsHostMode(
-  workspace: BaseWorkspace
+  workspacePath: string
 ): Result<void, { type: 'not-host-mode'; message: string }> {
-  const mode = FileBackedMachineModeController.forWorkspace(
-    workspace.path
-  ).get();
+  const mode =
+    FileBackedMachineModeController.forWorkspace(workspacePath).get();
 
   return mode === 'host'
     ? ok()

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -36,15 +36,12 @@ import {
   makeBackup,
   makeConfiguredWorkspace,
   mockDiskSpace,
-  whileWriting,
 } from '../../../test/backup.js';
 import {
   ADMIN_WORKSPACE_DATABASE_NAME,
   createWorkspace,
   openWorkspace,
   getRestoreInProgressMarkerPath,
-  getWorkspaceControlPath,
-  Workspace,
   WORKSPACE_CONTROL_DIRECTORY_NAME,
 } from '../../util/workspace.js';
 import { createBackup } from '../create/index.js';
@@ -113,17 +110,6 @@ async function makeConfiguredWorkspacePath(): Promise<string> {
   using workspace = await makeConfiguredWorkspace();
   addCvrWithBallotImage(workspace, { ballotId: 'existing-ballot' });
   return workspace.path;
-}
-
-/**
- * Opens a workspace for a restore to take over, as a running backend holds one
- * open. `restoreBackup` closes it, so nothing here has to.
- */
-function restorable(workspacePath: string): Workspace {
-  return createWorkspace(
-    workspacePath,
-    mockLogger({ fn: vi.fn, role: 'system_administrator' })
-  );
 }
 
 /**
@@ -252,7 +238,7 @@ test(
     expect(
       await restoreBackup({
         backup: created.path,
-        workspace: restorable(workspacePath),
+        workspacePath,
         logger,
         onProgressEvent: (event) => events.push(event),
       })
@@ -345,7 +331,7 @@ test('restore recreates workspace directories the backup has no files in', async
   expect(
     await restoreBackup({
       backup: created.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger,
     })
   ).toEqual(ok());
@@ -364,7 +350,7 @@ test('restore resolves a relative backup path', async () => {
   expect(
     await restoreBackup({
       backup: relative(process.cwd(), backup.path),
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger,
     })
   ).toEqual(ok());
@@ -384,7 +370,7 @@ test('restore fails if there is no backup manifest', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -414,7 +400,7 @@ test('restore fails if the backup manifest is not readable', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -440,7 +426,7 @@ test('restore fails if the backup manifest version does not match', async () => 
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -475,7 +461,7 @@ test('restore fails if the backup manifest software version does not match', asy
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -506,7 +492,7 @@ test('restore warns but does not fail if the machine ID does not match', async (
   const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger,
   });
 
@@ -545,7 +531,7 @@ test('the recorded machine ID is the signer, not what the manifest claims', asyn
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(makeUnconfiguredWorkspacePath()),
+      workspacePath: makeUnconfiguredWorkspacePath(),
       logger,
     })
   ).toEqual(ok());
@@ -565,7 +551,7 @@ test('restore fails if the backup was signed in another jurisdiction', async () 
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -621,7 +607,7 @@ test.each<{ description: string; tamper: (backup: Backup) => Promise<void> }>([
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -659,7 +645,7 @@ test.runIf(existsSync('/proc/self/mem'))(
     const workspacePath = makeUnconfiguredWorkspacePath();
     const result = await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     });
 
@@ -689,7 +675,7 @@ test('restore fails on missing files from the backup manifest', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -718,7 +704,7 @@ test.runIf(process.platform === 'linux')(
     const workspacePath = makeUnconfiguredWorkspacePath();
     const result = await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     });
 
@@ -745,7 +731,7 @@ test('restore fails if any backup files are an unexpected size', async () => {
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -777,7 +763,7 @@ test('restore fails if any backup files have unexpected content (by hash)', asyn
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -822,7 +808,7 @@ test.each<{ description: string; makePath: (escapeTarget: string) => string }>([
     const workspacePath = makeUnconfiguredWorkspacePath();
     const result = await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     });
 
@@ -857,7 +843,7 @@ test('restore refuses a manifest entry it does not know how to restore', async (
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -892,7 +878,7 @@ test('restore fails if there is no current election in the backup', async () => 
   const workspacePath = makeUnconfiguredWorkspacePath();
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -924,7 +910,7 @@ test('restore clears whatever an unconfigured workspace already holds', async ()
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       onProgressEvent: (event) => events.push(event),
       // Low enough that even these small files report mid-copy progress.
@@ -962,7 +948,7 @@ test('an interrupted restore can be recovered by restoring again', async () => {
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(ok());
@@ -979,7 +965,7 @@ test('an interrupted restore can be recovered by restoring again', async () => {
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger,
     })
   ).toEqual(ok());
@@ -1006,7 +992,7 @@ test('restore refuses a backup the workspace volume cannot hold', async () => {
 
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     minAvailableStorageBytes: 1024,
   });
@@ -1033,7 +1019,7 @@ test('restore fails if the restored files cannot be flushed to disk', async () =
 
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
   });
 
@@ -1054,7 +1040,7 @@ test('restoring into a configured workspace fails', async () => {
   const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
   const result = await restoreBackup({
     backup: backup.path,
-    workspace: restorable(workspacePath),
+    workspacePath,
     logger,
   });
 
@@ -1093,7 +1079,7 @@ test('a restore cancelled before it starts leaves the workspace alone', async ()
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger,
       signal: AbortSignal.abort(),
     })
@@ -1124,7 +1110,7 @@ test('a restore cancelled while vetting the backup leaves the workspace alone', 
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       signal: controller.signal,
     })
@@ -1142,7 +1128,7 @@ test('a restore cancelled between files empties the workspace it had claimed', a
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       signal: controller.signal,
       onProgressEvent(event) {
@@ -1168,7 +1154,7 @@ test('a restore cancelled partway through a file empties the workspace', async (
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace: restorable(workspacePath),
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       signal: controller.signal,
       // Low enough that even these small files report mid-copy progress.
@@ -1192,111 +1178,51 @@ test('a restore cancelled partway through a file empties the workspace', async (
   expect(listWorkspace(workspacePath)).toEqual([]);
 });
 
-test('restore closes the workspace store instead of leaving it on a deleted database', async () => {
+test('restore fills a workspace that has no database yet', async () => {
   const backup = await makeBackup();
-  const workspacePath = makeUnconfiguredWorkspacePath();
-  const workspace = restorable(workspacePath);
+  const workspacePath = makeTemporaryDirectory();
   const logger = mockLogger({ fn: vi.fn, role: 'system_administrator' });
 
+  // Nothing to ask about an election, so nothing is opened, and nothing is
+  // created only to be deleted: a directory is as unconfigured as it gets.
   expect(
-    await restoreBackup({ backup: backup.path, workspace, logger })
+    await restoreBackup({ backup: backup.path, workspacePath, logger })
   ).toEqual(ok());
 
-  // Emptying the workspace unlinks the database this connection was opened on.
-  // Left open it would go on serving the file the restore replaced, and writes
-  // through it would land somewhere nothing will ever read again.
-  expect(() => workspace.store.getCurrentElectionId()).toThrow(
-    /database client .* is closed/
-  );
-
-  // What the restore put on disk is what the next connection finds.
   using restored = openWorkspace(workspacePath, logger);
   expect(restored.store.getCurrentElectionId()).toBeDefined();
 });
 
-test('restore closes the workspace store even when it fails after claiming it', async () => {
+test('restore leaves a workspace it refuses exactly as it found it', async () => {
   const backup = await makeBackup();
-  const workspacePath = makeUnconfiguredWorkspacePath();
-  const workspace = restorable(workspacePath);
-  await rm(join(backup.path, 'workspace', ADMIN_WORKSPACE_DATABASE_NAME));
+  const workspacePath = await makeConfiguredWorkspacePath();
+  const contentsBefore = listWorkspace(workspacePath);
 
+  // Asking whether the workspace holds an election means opening its database,
+  // which must not leave a trace, since the answer here is that it stays.
   expect(
     (
       await restoreBackup({
         backup: backup.path,
-        workspace,
+        workspacePath,
         logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       })
     ).err()
-  ).toMatchObject({ type: 'backup-verification-failed' });
+  ).toMatchObject({ type: 'workspace-already-configured' });
 
-  // A failed restore empties the workspace too, so the connection is just as
-  // dead as after one that succeeded, and the caller is just as finished.
-  expect(() => workspace.store.getCurrentElectionId()).toThrow(
-    /database client .* is closed/
-  );
-  expect(listWorkspace(workspacePath)).toEqual([]);
-});
-
-test('restore refuses while a write transaction is open on the workspace', async () => {
-  const backup = await makeBackup();
-  const workspacePath = makeUnconfiguredWorkspacePath();
-  const workspace = restorable(workspacePath);
-  const contentsBefore = listWorkspace(workspacePath);
-
-  expect(
-    await whileWriting(workspace, () =>
-      restoreBackup({
-        backup: backup.path,
-        workspace,
-        logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-      })
-    )
-  ).toEqual(
-    err({
-      type: 'write-in-progress',
-      message:
-        'Cannot restore while another operation is writing to the database',
-    })
-  );
-
-  // Refused before anything was claimed, so the write can carry on.
   expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
-});
-
-test('restore refuses a write in progress even in a workspace an interrupted restore left', async () => {
-  const backup = await makeBackup();
-  const workspacePath = makeUnconfiguredWorkspacePath();
-  await mkdir(getWorkspaceControlPath(workspacePath), { recursive: true });
-  await writeFile(getRestoreInProgressMarkerPath(workspacePath), '');
-  const workspace = restorable(workspacePath);
-
-  // Recovering an interrupted restore is no reason to cut off a write that is
-  // happening right now.
-  expect(
-    (
-      await whileWriting(workspace, () =>
-        restoreBackup({
-          backup: backup.path,
-          workspace,
-          logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
-        })
-      )
-    ).err()
-  ).toMatchObject({ type: 'write-in-progress' });
 });
 
 test('restore refuses a workspace belonging to a client machine', async () => {
   const backup = await makeBackup();
   const workspacePath = makeUnconfiguredWorkspacePath();
   FileBackedMachineModeController.forWorkspace(workspacePath).set('client');
-  const workspace = restorable(workspacePath);
   const contentsBefore = listWorkspace(workspacePath);
 
   expect(
     await restoreBackup({
       backup: backup.path,
-      workspace,
+      workspacePath,
       logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
     })
   ).toEqual(
@@ -1307,8 +1233,8 @@ test('restore refuses a workspace belonging to a client machine', async () => {
     })
   );
 
-  // Restoring would have emptied the workspace, taking the mode with it and
-  // silently turning a client machine into a host one.
+  // Restoring would have handed a client machine a host's data, which the
+  // client would never serve and the host it was would be gone.
   expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
 });
 
@@ -1331,7 +1257,7 @@ test('restore refuses a manifest naming a file in the control directory', async 
     (
       await restoreBackup({
         backup: backup.path,
-        workspace: restorable(workspacePath),
+        workspacePath,
         logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
       })
     ).err()

--- a/apps/admin/backend/src/backup/restore/index.test.ts
+++ b/apps/admin/backend/src/backup/restore/index.test.ts
@@ -42,8 +42,10 @@ import {
   ADMIN_WORKSPACE_DATABASE_NAME,
   createWorkspace,
   openWorkspace,
-  RESTORE_IN_PROGRESS_MARKER_FILENAME,
+  getRestoreInProgressMarkerPath,
+  getWorkspaceControlPath,
   Workspace,
+  WORKSPACE_CONTROL_DIRECTORY_NAME,
 } from '../../util/workspace.js';
 import { createBackup } from '../create/index.js';
 import { Backup } from '../backup.js';
@@ -125,13 +127,15 @@ function restorable(workspacePath: string): Workspace {
 }
 
 /**
- * Lists everything in a workspace, ignoring the database's sidecar files since
- * those come and go as the database is opened and closed.
+ * Lists a workspace's data, ignoring the database's sidecar files since those
+ * come and go as the database is opened and closed, and the control directory
+ * since it holds settings rather than data.
  */
 function listWorkspace(workspacePath: string): string[] {
   return readdirSync(workspacePath, { recursive: true })
     .map(String)
     .filter((name) => !name.startsWith(`${ADMIN_WORKSPACE_DATABASE_NAME}-`))
+    .filter((name) => !name.startsWith(WORKSPACE_CONTROL_DIRECTORY_NAME))
     .sort();
 }
 
@@ -965,7 +969,7 @@ test('an interrupted restore can be recovered by restoring again', async () => {
 
   // Simulate a crash after the database was copied but before the restore
   // finished: the workspace looks configured, but the marker is still there.
-  const markerPath = join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME);
+  const markerPath = getRestoreInProgressMarkerPath(workspacePath);
   await writeFile(markerPath, '');
 
   // The configured election is half-restored debris, not data to protect, so
@@ -1263,7 +1267,8 @@ test('restore refuses while a write transaction is open on the workspace', async
 test('restore refuses a write in progress even in a workspace an interrupted restore left', async () => {
   const backup = await makeBackup();
   const workspacePath = makeUnconfiguredWorkspacePath();
-  await writeFile(join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME), '');
+  await mkdir(getWorkspaceControlPath(workspacePath), { recursive: true });
+  await writeFile(getRestoreInProgressMarkerPath(workspacePath), '');
   const workspace = restorable(workspacePath);
 
   // Recovering an interrupted restore is no reason to cut off a write that is
@@ -1304,5 +1309,36 @@ test('restore refuses a workspace belonging to a client machine', async () => {
 
   // Restoring would have emptied the workspace, taking the mode with it and
   // silently turning a client machine into a host one.
+  expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
+});
+
+test('restore refuses a manifest naming a file in the control directory', async () => {
+  const backup = await makeBackup();
+  const workspacePath = makeUnconfiguredWorkspacePath();
+  const contentsBefore = listWorkspace(workspacePath);
+
+  // A backup never holds settings, so one claiming to is not one this software
+  // made — and restoring it would switch the machine's mode.
+  await rewriteManifest(backup, (manifest) => ({
+    ...manifest,
+    files: [
+      { ...manifest.files[0]!, path: 'workspace/control/machine_mode' },
+      ...manifest.files.slice(1),
+    ],
+  }));
+
+  expect(
+    (
+      await restoreBackup({
+        backup: backup.path,
+        workspace: restorable(workspacePath),
+        logger: mockLogger({ fn: vi.fn, role: 'system_administrator' }),
+      })
+    ).err()
+  ).toMatchObject({
+    type: 'backup-verification-failed',
+    message: expect.stringContaining('control directory'),
+  });
+
   expect(listWorkspace(workspacePath)).toEqual(contentsBefore);
 });

--- a/apps/admin/backend/src/backup/restore/index.ts
+++ b/apps/admin/backend/src/backup/restore/index.ts
@@ -29,20 +29,19 @@ import {
  * the apparent configuration is half-restored debris, in which case the
  * restore is what recovers the workspace.
  *
- * Emptying the workspace means deleting the database out from under whoever
- * opened it, so the workspace's store is closed first and is not reopened.
- * Once the workspace has been claimed the caller is done with it whatever the
- * outcome, since a failed restore empties it too: a machine has to restart, at
- * which point it reads either the restored database or none at all.
+ * Emptying the workspace means deleting its database, so nothing may have it
+ * open: the caller names the workspace by path, and the restore opens the
+ * database only to look at whether it holds an election, and only if there is
+ * one to open. The machine that reads the result is the one that starts up
+ * afterwards, and it finds either the restored database or none at all.
  */
 export async function restoreBackup(
   rawOptions: RestoreBackupOptions
 ): Promise<Result<void, RestoreError>> {
-  // The workspace resolved its own path when it was opened; only the backup's
-  // needs resolving, as `createBackup` resolves its target.
   const options: RestoreBackupOptions = {
     ...rawOptions,
     backup: resolve(rawOptions.backup),
+    workspacePath: resolve(rawOptions.workspacePath),
   };
   const { logger } = options;
   await logger.logAsCurrentRole(LogEventId.BackupRestoreInit, {
@@ -63,14 +62,14 @@ const CANCELLED_ERROR: RestoreError = {
 async function tryRestoreBackup(
   options: RestoreBackupOptions
 ): Promise<Result<void, RestoreError>> {
-  const { logger, onProgressEvent, signal, workspace } = options;
+  const { logger, onProgressEvent, signal, workspacePath } = options;
   onProgressEvent?.({ type: 'preparing' });
 
   if (signal?.aborted) {
     return err(CANCELLED_ERROR);
   }
 
-  const checkResult = await checkWorkspaceIsRestorable(workspace, logger);
+  const checkResult = await checkWorkspaceIsRestorable(workspacePath, logger);
   if (checkResult.isErr()) {
     return checkResult;
   }
@@ -88,7 +87,7 @@ async function tryRestoreBackup(
   const manifest = vetResult.ok();
 
   const spaceResult = await checkWorkspaceHasSufficientSpace({
-    workspacePath: workspace.path,
+    workspacePath,
     manifest,
     minAvailableStorageBytes: options.minAvailableStorageBytes,
   });
@@ -103,19 +102,13 @@ async function tryRestoreBackup(
     return err(CANCELLED_ERROR);
   }
 
-  // The database file is about to be deleted, so the connection to it goes
-  // first. Held open, it would keep reading and writing the unlinked file: the
-  // restored database would land on disk while this connection went on serving
-  // the one it replaced.
-  workspace.store.close();
-
-  await claimWorkspace(workspace.path);
+  await claimWorkspace(workspacePath);
   let succeeded = false;
   try {
     const copyResult = await copyBackupFiles({
       backup,
       manifest,
-      workspacePath: workspace.path,
+      workspacePath,
       onProgressEvent,
       signal,
       progressEventIntervalBytes: options.progressEventIntervalBytes,
@@ -127,7 +120,7 @@ async function tryRestoreBackup(
     onProgressEvent?.({ type: 'verifying' });
     const verifyResult = verifyRestoredWorkspace({
       manifest,
-      workspacePath: workspace.path,
+      workspacePath,
       logger,
     });
     if (verifyResult.isErr()) {
@@ -138,14 +131,14 @@ async function tryRestoreBackup(
     // restore complete, which must not happen while the restored files live
     // only in the page cache.
     onProgressEvent?.({ type: 'flushing_workspace' });
-    const flushResult = await flushRestoredWorkspace(workspace.path);
+    const flushResult = await flushRestoredWorkspace(workspacePath);
     succeeded = flushResult.isOk();
     return flushResult;
   } finally {
     if (succeeded) {
-      await completeRestore(workspace.path);
+      await completeRestore(workspacePath);
     } else {
-      await abandonFailedRestore(workspace.path);
+      await abandonFailedRestore(workspacePath);
     }
   }
 }

--- a/apps/admin/backend/src/backup/restore/open_step.ts
+++ b/apps/admin/backend/src/backup/restore/open_step.ts
@@ -8,6 +8,7 @@ import {
 import { AuthenticatedBackup } from '../authenticated_backup.js';
 import { Backup } from '../backup.js';
 import { BACKUP_WORKSPACE_DIR, BackupManifest } from '../backup_manifest.js';
+import { WORKSPACE_CONTROL_DIRECTORY_NAME } from '../../util/workspace.js';
 import { RestoreError } from './types.js';
 
 /**
@@ -114,6 +115,7 @@ export async function vetManifest(
   }
 
   const workspacePrefix = `${BACKUP_WORKSPACE_DIR}/`;
+  const controlPrefix = `${workspacePrefix}${WORKSPACE_CONTROL_DIRECTORY_NAME}/`;
   for (const file of manifest.files) {
     // The manifest is the signed statement of what the backup holds, so an
     // entry this software does not know how to restore means the backup cannot
@@ -122,6 +124,15 @@ export async function vetManifest(
       return err({
         type: 'backup-verification-failed',
         message: `Manifest names a file this software does not know how to restore: ${file.path}`,
+      });
+    }
+
+    // A backup holds a machine's data, never its settings: restoring one must
+    // not switch the machine's mode or leave it looking mid-restore.
+    if (file.path.startsWith(controlPrefix)) {
+      return err({
+        type: 'backup-verification-failed',
+        message: `Manifest names a file in the workspace's control directory, which a backup never holds: ${file.path}`,
       });
     }
   }

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -7,7 +7,7 @@ import {
   getRestoreInProgressMarkerPath,
   getWorkspaceControlPath,
   hasInterruptedRestore,
-  Workspace,
+  openWorkspaceStoreIfPresent,
 } from '../../util/workspace.js';
 import { BackupManifest } from '../backup_manifest.js';
 import { checkWorkspaceIsHostMode } from '../host_mode.js';
@@ -17,33 +17,21 @@ const DEFAULT_MIN_AVAILABLE_STORAGE_BYTES = 50_000_000; // 50 MB
 
 /**
  * Checks that the workspace is one a restore may take over: a host machine's,
- * not being written to, and either unconfigured or left behind by an
- * interrupted restore (per the marker), in which case the restore is what
- * recovers it.
+ * and either unconfigured or left behind by an interrupted restore (per the
+ * marker), in which case the restore is what recovers it. A workspace with no
+ * database yet is unconfigured; one with a database is asked, and left as it
+ * was.
  */
 export async function checkWorkspaceIsRestorable(
-  workspace: Workspace,
+  workspacePath: string,
   logger: Logger
 ): Promise<Result<void, RestoreError>> {
-  const hostModeResult = checkWorkspaceIsHostMode(workspace);
+  const hostModeResult = checkWorkspaceIsHostMode(workspacePath);
   if (hostModeResult.isErr()) {
     return hostModeResult;
   }
 
-  // The restore closes this connection and deletes the database under it, so
-  // an operation partway through writing would be cut off mid-transaction with
-  // no way to tell whether its work survived. Checked before the marker, since
-  // a workspace left by an interrupted restore is no reason to cut off a write
-  // that is happening right now.
-  if (workspace.store.isInTransaction()) {
-    return err({
-      type: 'write-in-progress',
-      message:
-        'Cannot restore while another operation is writing to the database',
-    });
-  }
-
-  if (hasInterruptedRestore(workspace.path)) {
+  if (hasInterruptedRestore(workspacePath)) {
     await logger.logAsCurrentRole(LogEventId.BackupRestoreInterrupted, {
       message:
         'Restoring over a workspace an earlier restore left unfinished; ' +
@@ -52,7 +40,8 @@ export async function checkWorkspaceIsRestorable(
     return ok();
   }
 
-  const currentElectionId = workspace.store.getCurrentElectionId();
+  using store = openWorkspaceStoreIfPresent(workspacePath, logger);
+  const currentElectionId = store?.getCurrentElectionId();
   if (currentElectionId) {
     return err({
       type: 'workspace-already-configured',

--- a/apps/admin/backend/src/backup/restore/prepare_step.ts
+++ b/apps/admin/backend/src/backup/restore/prepare_step.ts
@@ -1,10 +1,11 @@
-import { rm, writeFile } from 'node:fs/promises';
-import { emptydir } from 'fs-extra';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { err, iter, ok, Result } from '@votingworks/basics';
 import { getDiskSpaceSummaries } from '@votingworks/backend';
 import { Logger, LogEventId } from '@votingworks/logging';
 import {
+  emptyWorkspaceData,
   getRestoreInProgressMarkerPath,
+  getWorkspaceControlPath,
   hasInterruptedRestore,
   Workspace,
 } from '../../util/workspace.js';
@@ -93,11 +94,12 @@ export async function checkWorkspaceHasSufficientSpace({
 }
 
 /**
- * Takes ownership of the workspace: empties it so the restore starts from a
- * clean slate, and drops the in-progress marker.
+ * Takes ownership of the workspace: empties its data so the restore starts from
+ * a clean slate, and drops the in-progress marker.
  */
 export async function claimWorkspace(workspacePath: string): Promise<void> {
-  await emptydir(workspacePath);
+  await emptyWorkspaceData(workspacePath);
+  await mkdir(getWorkspaceControlPath(workspacePath), { recursive: true });
   await writeFile(getRestoreInProgressMarkerPath(workspacePath), '');
 }
 
@@ -108,7 +110,7 @@ export async function claimWorkspace(workspacePath: string): Promise<void> {
 export async function abandonFailedRestore(
   workspacePath: string
 ): Promise<void> {
-  await emptydir(workspacePath);
+  await emptyWorkspaceData(workspacePath);
 }
 
 /**

--- a/apps/admin/backend/src/backup/restore/types.ts
+++ b/apps/admin/backend/src/backup/restore/types.ts
@@ -1,4 +1,3 @@
-import { Workspace } from '../../util/workspace.js';
 import { ProgressTracking } from '../progress.js';
 
 /**
@@ -7,7 +6,6 @@ import { ProgressTracking } from '../progress.js';
 export type RestoreError =
   | { type: 'cancelled'; message: string }
   | { type: 'workspace-already-configured'; message: string }
-  | { type: 'write-in-progress'; message: string }
   | { type: 'not-host-mode'; message: string }
   | { type: 'backup-read-failed'; message: string }
   | { type: 'backup-authentication-failed'; message: string }
@@ -32,18 +30,16 @@ export interface RestoreBackupOptions extends ProgressTracking {
   backup: string;
 
   /**
-   * The workspace into which the backup should be restored, with an
-   * already-open client for the database. Its contents belong to the restore:
-   * whatever it holds is emptied before copying begins, so it must not contain
-   * anything worth keeping. A workspace whose database is already configured
-   * with an election is refused rather than cleared.
+   * Path of the workspace into which the backup should be restored. Its data
+   * belongs to the restore: whatever it holds is emptied before copying begins,
+   * so it must not contain anything worth keeping. A workspace whose database
+   * is already configured with an election is refused rather than cleared.
    *
-   * The restore closes this workspace's store on its way to emptying the
-   * directory, and does not reopen it. Whatever holds the workspace must be
-   * finished with it: on a machine this means restarting, since the process
-   * kept running would be reading a database file that no longer exists.
+   * Nothing may be serving the workspace: the restore deletes its database,
+   * and a process still reading that file would be reading nothing anyone will
+   * see again. That is why a machine restores by rebooting into restore mode.
    */
-  workspace: Workspace;
+  workspacePath: string;
 
   /**
    * How many bytes must remain available on the workspace's volume after the

--- a/apps/admin/backend/src/backup/staging_area.test.ts
+++ b/apps/admin/backend/src/backup/staging_area.test.ts
@@ -93,6 +93,23 @@ test('a lock that fails for any other reason is not reported as busy', async () 
   ).rejects.toThrow('ENOENT');
 });
 
+test('a staging area that cannot be cleaned up releases its lock', async () => {
+  const workspacePath = makeTemporaryDirectory();
+  const stagingArea = (
+    await BackupStagingArea.inWorkspace(workspacePath)
+  ).unsafeUnwrap();
+  const error: NodeJS.ErrnoException = new Error('input/output error');
+  error.code = 'EIO';
+  vi.mocked(rm).mockRejectedValueOnce(error);
+
+  await expect(stagingArea.cleanup()).rejects.toThrow('input/output error');
+
+  const lock = await tryLockFileExclusive(
+    BackupStagingArea.lockPathIn(workspacePath)
+  );
+  await lock.unsafeUnwrap().release();
+});
+
 test('a staging area that cannot be created releases its lock', async () => {
   const workspacePath = makeTemporaryDirectory();
   const error: NodeJS.ErrnoException = new Error('input/output error');

--- a/apps/admin/backend/src/backup/staging_area.ts
+++ b/apps/admin/backend/src/backup/staging_area.ts
@@ -215,9 +215,15 @@ export class BackupStagingArea {
    * to the staging area will be deleted.
    */
   async cleanup(): Promise<void> {
-    await rm(this.stagingAreaPath, { recursive: true, force: true });
-    this.preparedPaths.clear();
-    this.readyFiles.clear();
-    await this.lock.release();
+    // Released even if the removal fails: the descriptor holds the lock until
+    // the process exits, so skipping this would refuse every later backup
+    // until a restart.
+    try {
+      await rm(this.stagingAreaPath, { recursive: true, force: true });
+      this.preparedPaths.clear();
+      this.readyFiles.clear();
+    } finally {
+      await this.lock.release();
+    }
   }
 }

--- a/apps/admin/backend/src/boot_intent.test.ts
+++ b/apps/admin/backend/src/boot_intent.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from 'vitest';
+import {
+  makeTemporaryDirectory,
+  makeTemporaryFile,
+  makeTemporaryPath,
+} from '@votingworks/fixtures';
+import { FileBackedBootIntentController } from './boot_intent.js';
+import { getWorkspaceControlPath } from './util/workspace.js';
+
+test('nothing is pending when no intent was requested', () => {
+  const controller = new FileBackedBootIntentController(makeTemporaryPath());
+  expect(controller.take()).toBeUndefined();
+});
+
+test('a requested intent is handed over exactly once', () => {
+  const filePath = makeTemporaryPath();
+  const controller = new FileBackedBootIntentController(filePath);
+
+  controller.request('restore');
+  expect(readFileSync(filePath, 'utf-8')).toEqual('restore');
+
+  expect(controller.take()).toEqual('restore');
+  expect(existsSync(filePath)).toEqual(false);
+
+  // Spent by the taking: the boot after the one that acts on it is ordinary.
+  expect(controller.take()).toBeUndefined();
+});
+
+test('surrounding whitespace does not change an intent', () => {
+  const controller = new FileBackedBootIntentController(
+    makeTemporaryFile({ content: '  restore\n' })
+  );
+  expect(controller.take()).toEqual('restore');
+});
+
+test('contents that are not an intent are cleared and mean nothing', () => {
+  const filePath = makeTemporaryFile({ content: 'reboot' });
+  const controller = new FileBackedBootIntentController(filePath);
+
+  expect(controller.take()).toBeUndefined();
+  expect(existsSync(filePath)).toEqual(false);
+});
+
+test('fails if the file is there but cannot be read', () => {
+  const controller = new FileBackedBootIntentController(
+    makeTemporaryDirectory()
+  );
+  expect(() => controller.take()).toThrow();
+});
+
+test('forWorkspace keeps the intent in the control directory', () => {
+  const workspacePath = makeTemporaryDirectory();
+
+  FileBackedBootIntentController.forWorkspace(workspacePath).request('restore');
+
+  expect(
+    existsSync(join(getWorkspaceControlPath(workspacePath), 'next_boot'))
+  ).toEqual(true);
+  expect(
+    FileBackedBootIntentController.forWorkspace(workspacePath).take()
+  ).toEqual('restore');
+});

--- a/apps/admin/backend/src/boot_intent.ts
+++ b/apps/admin/backend/src/boot_intent.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { isNonExistentFileOrDirectoryError } from '@votingworks/basics';
+import { getWorkspaceControlPath } from './util/workspace.js';
+
+/**
+ * What a machine has been asked to do the next time it starts, instead of
+ * running in whatever mode it is in. `restore` starts it in restore mode, where
+ * a backup can be restored into a workspace nothing is serving.
+ */
+export type BootIntent = 'restore';
+
+/**
+ * Records an intent for the next boot and hands it over exactly once. Unlike a
+ * machine mode, an intent is spent by being taken: whatever the boot that takes
+ * it goes on to do, the boot after that is an ordinary one.
+ */
+export interface BootIntentController {
+  request(intent: BootIntent): void;
+
+  /**
+   * Returns the pending intent, if any, and clears it.
+   */
+  take(): BootIntent | undefined;
+}
+
+/**
+ * Keeps the boot intent in a file, present only while an intent is pending.
+ */
+export class FileBackedBootIntentController implements BootIntentController {
+  constructor(private readonly filePath: string) {}
+
+  request(intent: BootIntent): void {
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    writeFileSync(this.filePath, intent, 'utf-8');
+  }
+
+  take(): BootIntent | undefined {
+    let contents: string;
+    try {
+      contents = readFileSync(this.filePath, 'utf-8');
+    } catch (error) {
+      if (isNonExistentFileOrDirectoryError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
+
+    // Cleared before it is acted on, and not with `force`: a file that cannot
+    // be removed would send every boot from here on into restore mode, which
+    // is worth failing loudly over.
+    rmSync(this.filePath);
+
+    return contents.trim() === 'restore' ? 'restore' : undefined;
+  }
+
+  static forWorkspace(workspacePath: string): FileBackedBootIntentController {
+    return new FileBackedBootIntentController(
+      join(getWorkspaceControlPath(workspacePath), 'next_boot')
+    );
+  }
+}

--- a/apps/admin/backend/src/client_app.test.ts
+++ b/apps/admin/backend/src/client_app.test.ts
@@ -517,3 +517,7 @@ test('adjudicateCvr proxies to host peer API', async () => {
     })
   );
 });
+
+test('a client describes itself as one', async () => {
+  expect(await env.apiClient.getAppMode()).toEqual('client');
+});

--- a/apps/admin/backend/src/client_app.ts
+++ b/apps/admin/backend/src/client_app.ts
@@ -40,6 +40,7 @@ import {
   BallotAdjudicationData,
   BallotImages,
   AdjudicationError,
+  AppMode,
   WriteInCandidateRecord,
 } from './types.js';
 import { type HostConnection } from './client_store.js';
@@ -167,6 +168,10 @@ function buildClientApi({
 
   return grout.createApi({
     getMachineConfig,
+
+    getAppMode(): AppMode {
+      return 'client';
+    },
 
     getMachineMode(): MachineMode {
       return machineMode.get();

--- a/apps/admin/backend/src/index.ts
+++ b/apps/admin/backend/src/index.ts
@@ -9,6 +9,14 @@ import * as server from './server.js';
 
 export type { Api } from './app.js';
 export type { ClientApi } from './client_app.js';
+export type {
+  AvailableBackup,
+  ListAvailableBackupsError,
+  RestoreApi,
+  RestoreModeError,
+  RestoreStatus,
+} from './restore_app.js';
+export type { BootIntent } from './boot_intent.js';
 export type { PeerApi } from './peer_app.js';
 export type { TallyReportSpec } from './reports/tally_report.js';
 export type { BallotCountReportSpec } from './reports/ballot_count_report.js';

--- a/apps/admin/backend/src/index.ts
+++ b/apps/admin/backend/src/index.ts
@@ -17,6 +17,7 @@ export type {
   RestoreStatus,
 } from './restore_app.js';
 export type { BootIntent } from './boot_intent.js';
+export type { ProgressEvent } from './backup/progress.js';
 export type { PeerApi } from './peer_app.js';
 export type { TallyReportSpec } from './reports/tally_report.js';
 export type { BallotCountReportSpec } from './reports/ballot_count_report.js';

--- a/apps/admin/backend/src/machine_mode.test.ts
+++ b/apps/admin/backend/src/machine_mode.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 import {
   makeTemporaryDirectory,
@@ -7,6 +8,7 @@ import {
 } from '@votingworks/fixtures';
 import { FileBackedMachineModeController } from './machine_mode.js';
 import { MachineMode } from './types.js';
+import { getWorkspaceControlPath } from './util/workspace.js';
 
 describe('FileBackedMachineModeController::get', () => {
   test('returns host when no mode file exists', () => {
@@ -84,5 +86,26 @@ describe('FileBackedMachineModeController::set', () => {
     const controller = new FileBackedMachineModeController(filePath);
     controller.set('#!/usr/bin/env bash\nreboot' as unknown as MachineMode);
     expect(readFileSync(filePath, 'utf-8')).toEqual('host');
+  });
+});
+
+describe('FileBackedMachineModeController::forWorkspace', () => {
+  test('keeps the mode in the control directory, creating it as needed', () => {
+    const workspacePath = makeTemporaryDirectory();
+    const controller =
+      FileBackedMachineModeController.forWorkspace(workspacePath);
+    expect(controller.get()).toEqual('host');
+
+    controller.set('client');
+
+    expect(
+      readFileSync(
+        join(getWorkspaceControlPath(workspacePath), 'machine_mode'),
+        'utf-8'
+      )
+    ).toEqual('client');
+    expect(
+      FileBackedMachineModeController.forWorkspace(workspacePath).get()
+    ).toEqual('client');
   });
 });

--- a/apps/admin/backend/src/machine_mode.ts
+++ b/apps/admin/backend/src/machine_mode.ts
@@ -1,7 +1,8 @@
-import { readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { isNonExistentFileOrDirectoryError } from '@votingworks/basics';
 import type { MachineMode } from './types.js';
+import { getWorkspaceControlPath } from './util/workspace.js';
 
 /**
  * Provides machine mode switching between `host` and `client` modes.
@@ -34,12 +35,13 @@ export class FileBackedMachineModeController {
   }
 
   set(mode: MachineMode): void {
+    mkdirSync(dirname(this.filePath), { recursive: true });
     writeFileSync(this.filePath, mode === 'client' ? mode : 'host', 'utf-8');
   }
 
   static forWorkspace(workspacePath: string): FileBackedMachineModeController {
     return new FileBackedMachineModeController(
-      join(workspacePath, 'machine_mode')
+      join(getWorkspaceControlPath(workspacePath), 'machine_mode')
     );
   }
 }

--- a/apps/admin/backend/src/restore_app.test.ts
+++ b/apps/admin/backend/src/restore_app.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { Buffer } from 'node:buffer';
+import { existsSync } from 'node:fs';
+import { AddressInfo } from 'node:net';
+import { basename, dirname, join } from 'node:path';
+import { buildMockDippedSmartCardAuth } from '@votingworks/auth';
+import { deferred, err, ok } from '@votingworks/basics';
+import { makeTemporaryDirectory } from '@votingworks/fixtures';
+import * as grout from '@votingworks/grout';
+import { DEV_MACHINE_ID } from '@votingworks/types';
+import {
+  detectMultiUsbDrive,
+  SimulatedUsbPlatform,
+} from '@votingworks/usb-drive';
+import {
+  attachUsbDrive,
+  buildMockLogger,
+  mockSystemAdministratorAuth,
+} from '../test/app.js';
+import { makeBackup, mockDiskSpace } from '../test/backup.js';
+import { restoreBackup } from './backup/restore/index.js';
+import { FileBackedMachineModeController } from './machine_mode.js';
+import {
+  buildRestoreApp,
+  RestoreApi,
+  RESTORE_MODE_STORE,
+} from './restore_app.js';
+import {
+  ADMIN_WORKSPACE_DATABASE_NAME,
+  openWorkspace,
+} from './util/workspace.js';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+vi.mock(
+  import('@votingworks/backend'),
+  async (importActual): Promise<typeof import('@votingworks/backend')> => ({
+    ...(await importActual()),
+    getDiskSpaceSummaries: vi.fn(),
+  })
+);
+
+vi.mock(
+  import('./backup/restore/index.js'),
+  async (importActual): Promise<typeof import('./backup/restore/index.js')> => {
+    const actual = await importActual();
+    return { ...actual, restoreBackup: vi.fn(actual.restoreBackup) };
+  }
+);
+
+function buildRestoreTestEnvironment() {
+  const auth = buildMockDippedSmartCardAuth(vi.fn);
+  const workspacePath = makeTemporaryDirectory();
+  const logger = buildMockLogger(auth, RESTORE_MODE_STORE);
+  const usbPlatform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const multiUsbDrive = detectMultiUsbDrive({ logger, platform: usbPlatform });
+  const app = buildRestoreApp({
+    auth,
+    workspacePath,
+    logger,
+    multiUsbDrive,
+    machineMode: FileBackedMachineModeController.forWorkspace(workspacePath),
+  });
+  const server = app.listen();
+  const { port } = server.address() as AddressInfo;
+  const apiClient = grout.createClient<RestoreApi>({
+    baseUrl: `http://localhost:${port}/api`,
+  });
+
+  mockSystemAdministratorAuth(auth);
+
+  return { auth, workspacePath, logger, apiClient, server, usbPlatform };
+}
+
+let env: ReturnType<typeof buildRestoreTestEnvironment>;
+
+beforeEach(() => {
+  mockDiskSpace();
+  env = buildRestoreTestEnvironment();
+});
+
+afterEach(() => {
+  env.server.close();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Attaches a USB drive holding `backup`, as a backup drive would, and returns
+ * the backup's path on the mounted drive.
+ */
+async function insertBackupDrive(
+  backup: { path: string },
+  apiClient: grout.Client<RestoreApi>,
+  usbPlatform: SimulatedUsbPlatform
+): Promise<string> {
+  // A backup lives at `<root>/vxadmin-backups/<name>`; the drive gets the root.
+  await attachUsbDrive(apiClient, usbPlatform, dirname(dirname(backup.path)));
+  const listed = (await apiClient.listAvailableBackups()).unsafeUnwrap();
+  expect(listed).toEqual([
+    { name: basename(backup.path), path: expect.any(String) },
+  ]);
+  return listed[0]!.path;
+}
+
+test('describes itself as restore mode', async () => {
+  const { apiClient } = env;
+
+  expect(await apiClient.getAppMode()).toEqual('restore');
+  expect(await apiClient.getMachineMode()).toEqual('host');
+  expect(await apiClient.isMultiStationAdjudicationEnabled()).toEqual(false);
+  expect(await apiClient.getMachineConfig()).toEqual({
+    machineId: DEV_MACHINE_ID,
+    codeVersion: 'dev',
+  });
+  expect(await apiClient.getRestoreStatus()).toEqual({ state: 'idle' });
+});
+
+test('auth runs against an unconfigured machine', async () => {
+  const { apiClient, auth } = env;
+
+  expect((await apiClient.getAuthStatus()).status).toEqual('logged_in');
+
+  await apiClient.checkPin({ pin: '123456' });
+  await apiClient.logOut();
+  const sessionExpiresAt = new Date();
+  await apiClient.updateSessionExpiry({ sessionExpiresAt });
+
+  const unconfigured = expect.objectContaining({ isConfigured: false });
+  expect(auth.checkPin).toHaveBeenCalledWith(unconfigured, { pin: '123456' });
+  expect(auth.logOut).toHaveBeenCalledWith(unconfigured);
+  expect(auth.updateSessionExpiry).toHaveBeenCalledWith(unconfigured, {
+    sessionExpiresAt,
+  });
+});
+
+test('has no backups to offer without a USB drive', async () => {
+  const { apiClient } = env;
+
+  expect(await apiClient.getUsbDriveStatus()).toEqual({ status: 'no_drive' });
+  expect((await apiClient.listAvailableBackups()).err()).toEqual({
+    type: 'no-usb-drive',
+    message: 'No USB drive is inserted',
+  });
+  expect(
+    (await apiClient.restoreBackup({ backupPath: '/nowhere' })).err()
+  ).toMatchObject({
+    type: 'backup-read-failed',
+    message: 'No USB drive is inserted',
+  });
+});
+
+test('restores a backup from the inserted USB drive', async () => {
+  const { apiClient, workspacePath, usbPlatform, logger } = env;
+  const backup = await makeBackup();
+  const backupPath = await insertBackupDrive(backup, apiClient, usbPlatform);
+
+  // Restore mode has opened nothing in the workspace.
+  expect(
+    existsSync(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).toEqual(false);
+
+  expect(await apiClient.restoreBackup({ backupPath })).toEqual(ok());
+  expect(await apiClient.getRestoreStatus()).toEqual({
+    state: 'restored',
+    backupPath,
+  });
+
+  // The workspace holds the backup; the machine that reads it is the one that
+  // starts after a reboot.
+  using restored = openWorkspace(workspacePath, logger);
+  expect(restored.store.getCurrentElectionId()).toBeDefined();
+
+  await apiClient.ejectUsbDrive();
+  expect((await apiClient.getUsbDriveStatus()).status).toEqual('ejected');
+});
+
+test('restores only a backup that is on the inserted USB drive', async () => {
+  const { apiClient, usbPlatform } = env;
+  const backup = await makeBackup();
+  await insertBackupDrive(backup, apiClient, usbPlatform);
+
+  // The same backup, but where it was made rather than on the drive.
+  expect(
+    (await apiClient.restoreBackup({ backupPath: backup.path })).err()
+  ).toMatchObject({
+    type: 'backup-read-failed',
+    message: expect.stringContaining('not a backup on the inserted USB drive'),
+  });
+  expect(await apiClient.getRestoreStatus()).toEqual({ state: 'idle' });
+});
+
+test('reports progress, refuses a second restore, and can be cancelled', async () => {
+  const { apiClient, usbPlatform } = env;
+  const backup = await makeBackup();
+  const backupPath = await insertBackupDrive(backup, apiClient, usbPlatform);
+
+  // Holds the restore at a point of our choosing, so that what the API does
+  // while one is running can be observed.
+  const restoreHeld = deferred<void>();
+  const restoreFinished = deferred<void>();
+  vi.mocked(restoreBackup).mockImplementationOnce(async (options) => {
+    options.onProgressEvent?.({ type: 'preparing' });
+    restoreHeld.resolve();
+    await restoreFinished.promise;
+    return options.signal?.aborted
+      ? err({ type: 'cancelled', message: 'Restore cancelled' })
+      : ok();
+  });
+
+  const restorePromise = apiClient.restoreBackup({ backupPath });
+  await restoreHeld.promise;
+
+  expect(await apiClient.getRestoreStatus()).toEqual({
+    state: 'restoring',
+    backupPath,
+    progress: { type: 'preparing' },
+  });
+  expect((await apiClient.restoreBackup({ backupPath })).err()).toEqual({
+    type: 'restore-in-progress',
+    message: 'Another restore is already replacing the workspace',
+  });
+
+  await apiClient.cancelRestore();
+  restoreFinished.resolve();
+
+  expect((await restorePromise).err()).toEqual({
+    type: 'cancelled',
+    message: 'Restore cancelled',
+  });
+  expect(await apiClient.getRestoreStatus()).toEqual({
+    state: 'failed',
+    backupPath,
+    error: { type: 'cancelled', message: 'Restore cancelled' },
+  });
+
+  // Cancelling with nothing running is a no-op.
+  await apiClient.cancelRestore();
+});
+
+test('passes on a drive whose backups directory is something else', async () => {
+  const { apiClient, usbPlatform } = env;
+  await attachUsbDrive(apiClient, usbPlatform, {
+    'vxadmin-backups': Buffer.from('not a directory'),
+  });
+
+  expect((await apiClient.listAvailableBackups()).err()).toMatchObject({
+    type: 'not-directory',
+  });
+  expect(
+    (await apiClient.restoreBackup({ backupPath: '/nowhere' })).err()
+  ).toMatchObject({
+    type: 'backup-read-failed',
+    message: expect.stringContaining('is not a directory'),
+  });
+});

--- a/apps/admin/backend/src/restore_app.ts
+++ b/apps/admin/backend/src/restore_app.ts
@@ -1,0 +1,269 @@
+import express, { Application } from 'express';
+import { basename, resolve } from 'node:path';
+import * as grout from '@votingworks/grout';
+import { DippedSmartCardAuthApi } from '@votingworks/auth';
+import { err, ok, Result } from '@votingworks/basics';
+import { createSystemCallApi } from '@votingworks/backend';
+import { Logger } from '@votingworks/logging';
+import {
+  createUsbDriveAdapter,
+  MultiUsbDrive,
+  UsbDriveStatus,
+} from '@votingworks/usb-drive';
+import { getMachineConfig } from './machine_config.js';
+import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
+import { MachineModeController } from './machine_mode.js';
+import { AppMode, BaseStore, MachineMode } from './types.js';
+import { constructAuthMachineState } from './util/auth.js';
+import { BackupRoot, ListBackupsError } from './backup/backup_root.js';
+import { ProgressEvent } from './backup/progress.js';
+import { restoreBackup } from './backup/restore/index.js';
+import { RestoreError } from './backup/restore/types.js';
+
+/**
+ * What restore mode presents to auth in place of a store: no election, so the
+ * machine is unconfigured as far as who may log in. Nothing in restore mode
+ * opens the workspace's database except the restore itself.
+ */
+export const RESTORE_MODE_STORE: BaseStore = {
+  getCurrentElectionId: () => undefined,
+  // @coverage-exclude: asked about only when there is an election, and here
+  // there never is
+  getElectionKey: () => undefined,
+  // @coverage-exclude: as above
+  getSystemSettings: () => undefined,
+};
+
+/**
+ * A backup on the inserted USB drive that may be restored.
+ */
+export interface AvailableBackup {
+  name: string;
+  path: string;
+}
+
+/**
+ * Why the backups on the inserted USB drive could not be listed.
+ */
+export type ListAvailableBackupsError =
+  | ListBackupsError
+  | { type: 'no-usb-drive'; message: string };
+
+/**
+ * Where the restore stands. Progress arrives through this rather than through
+ * the `restoreBackup` call, which returns only when the restore is over.
+ */
+export type RestoreStatus =
+  | { state: 'idle' }
+  | { state: 'restoring'; backupPath: string; progress?: ProgressEvent }
+  | { state: 'restored'; backupPath: string }
+  | { state: 'failed'; backupPath: string; error: RestoreError };
+
+/**
+ * Why the restore API refused or failed a restore: whatever the restore itself
+ * reports, or that one is already running.
+ */
+export type RestoreModeError =
+  | RestoreError
+  | { type: 'restore-in-progress'; message: string };
+
+function buildRestoreApi({
+  auth,
+  workspacePath,
+  machineMode,
+  logger,
+  multiUsbDrive,
+}: {
+  auth: DippedSmartCardAuthApi;
+  workspacePath: string;
+  machineMode: MachineModeController;
+  logger: Logger;
+  multiUsbDrive: MultiUsbDrive;
+}) {
+  const usbDriveAdapter = createUsbDriveAdapter(
+    multiUsbDrive,
+    // return the first FAT32 drive
+    (drives) => drives.find((d) => d.partition?.fstype === 'fat32')?.diskPath
+  );
+
+  let status: RestoreStatus = { state: 'idle' };
+  let abortController: AbortController | undefined;
+
+  async function listAvailableBackups(): Promise<
+    Result<AvailableBackup[], ListAvailableBackupsError>
+  > {
+    const usbDriveStatus = await usbDriveAdapter.status();
+    if (usbDriveStatus.status !== 'mounted') {
+      return err({
+        type: 'no-usb-drive',
+        message: 'No USB drive is inserted',
+      });
+    }
+
+    const listResult = await new BackupRoot(
+      usbDriveStatus.mountpoint
+    ).listBackups();
+    if (listResult.isErr()) {
+      return listResult;
+    }
+
+    return ok(
+      listResult
+        .ok()
+        .map((backup) => ({ name: basename(backup.path), path: backup.path }))
+    );
+  }
+
+  return grout.createApi({
+    getMachineConfig,
+
+    getAppMode(): AppMode {
+      return 'restore';
+    },
+
+    getMachineMode(): MachineMode {
+      return machineMode.get();
+    },
+
+    isMultiStationAdjudicationEnabled(): boolean {
+      return isMultiStationAdjudicationEnabled();
+    },
+
+    getAuthStatus() {
+      return auth.getAuthStatus(constructAuthMachineState(RESTORE_MODE_STORE));
+    },
+
+    checkPin(input: { pin: string }) {
+      return auth.checkPin(
+        constructAuthMachineState(RESTORE_MODE_STORE),
+        input
+      );
+    },
+
+    logOut() {
+      return auth.logOut(constructAuthMachineState(RESTORE_MODE_STORE));
+    },
+
+    updateSessionExpiry(input: { sessionExpiresAt: Date }) {
+      return auth.updateSessionExpiry(
+        constructAuthMachineState(RESTORE_MODE_STORE),
+        input
+      );
+    },
+
+    getUsbDriveStatus(): Promise<UsbDriveStatus> {
+      return usbDriveAdapter.status();
+    },
+
+    async ejectUsbDrive(): Promise<void> {
+      return await usbDriveAdapter.eject();
+    },
+
+    listAvailableBackups,
+
+    getRestoreStatus(): RestoreStatus {
+      return status;
+    },
+
+    /**
+     * Restores one of the backups on the inserted USB drive into the
+     * workspace. Resolves when the restore is over; poll `getRestoreStatus`
+     * for progress in the meantime, and call `cancelRestore` to stop it. Once
+     * a backup has been restored, rebooting is what puts it to use.
+     */
+    async restoreBackup(input: {
+      backupPath: string;
+    }): Promise<Result<void, RestoreModeError>> {
+      if (status.state === 'restoring') {
+        return err({
+          type: 'restore-in-progress',
+          message: 'Another restore is already replacing the workspace',
+        });
+      }
+
+      const availableResult = await listAvailableBackups();
+      if (availableResult.isErr()) {
+        return err({
+          type: 'backup-read-failed',
+          message: availableResult.err().message,
+        });
+      }
+      const backupPath = resolve(input.backupPath);
+      if (!availableResult.ok().some((backup) => backup.path === backupPath)) {
+        return err({
+          type: 'backup-read-failed',
+          message: `${input.backupPath} is not a backup on the inserted USB drive`,
+        });
+      }
+
+      abortController = new AbortController();
+      status = { state: 'restoring', backupPath };
+
+      const result = await restoreBackup({
+        backup: backupPath,
+        workspacePath,
+        logger,
+        signal: abortController.signal,
+        onProgressEvent: (progress) => {
+          status = { state: 'restoring', backupPath, progress };
+        },
+      });
+
+      abortController = undefined;
+      status = result.isOk()
+        ? { state: 'restored', backupPath }
+        : { state: 'failed', backupPath, error: result.err() };
+      return result;
+    },
+
+    cancelRestore(): void {
+      abortController?.abort();
+    },
+
+    ...createSystemCallApi({
+      usbDrive: usbDriveAdapter,
+      logger,
+      machineId: getMachineConfig().machineId,
+      codeVersion: getMachineConfig().codeVersion,
+      workspacePath,
+      // @coverage-exclude
+      getAuthStatus: () =>
+        auth.getAuthStatus(constructAuthMachineState(RESTORE_MODE_STORE)),
+    }),
+  });
+}
+
+/**
+ * The API a VxAdmin serves in restore mode, for the frontend to build a Grout
+ * client from.
+ */
+export type RestoreApi = ReturnType<typeof buildRestoreApi>;
+
+/**
+ * Builds the express application for restore mode: a machine booted, on
+ * request, to restore a backup into a workspace it is not otherwise serving.
+ */
+export function buildRestoreApp({
+  auth,
+  workspacePath,
+  machineMode,
+  logger,
+  multiUsbDrive,
+}: {
+  auth: DippedSmartCardAuthApi;
+  workspacePath: string;
+  machineMode: MachineModeController;
+  logger: Logger;
+  multiUsbDrive: MultiUsbDrive;
+}): Application {
+  const app: Application = express();
+  const api = buildRestoreApi({
+    auth,
+    workspacePath,
+    machineMode,
+    logger,
+    multiUsbDrive,
+  });
+  app.use('/api', grout.buildRouter(api, express));
+  return app;
+}

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -23,9 +23,13 @@ import {
   SimulatedUsbPlatform,
 } from '@votingworks/usb-drive';
 import { createMockPrinterHandler } from '@votingworks/printing';
+import * as grout from '@votingworks/grout';
 import { start } from './server.js';
 import { FileBackedMachineModeController } from './machine_mode.js';
+import { FileBackedBootIntentController } from './boot_intent.js';
+import type { RestoreApi } from './restore_app.js';
 import {
+  ADMIN_WORKSPACE_DATABASE_NAME,
   createWorkspace,
   getRestoreInProgressMarkerPath,
   getWorkspaceControlPath,
@@ -388,4 +392,37 @@ test('starts client networking in client mode', async () => {
   );
 
   featureFlagMock.resetFeatureFlags();
+});
+
+test('starts in restore mode when the last boot asked for it, and only then', async () => {
+  const logger = mockLogger({ fn: vi.fn });
+  const workspacePath = makeTemporaryDirectory();
+  const usbPlatform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const multiUsbDrive = detectMultiUsbDrive({ logger, platform: usbPlatform });
+  FileBackedBootIntentController.forWorkspace(workspacePath).request('restore');
+
+  server = await suppressingConsoleOutput(() =>
+    start({ logger, workspacePath, multiUsbDrive, port: 0 })
+  );
+  const { port } = server.address() as AddressInfo;
+  const apiClient = grout.createClient<RestoreApi>({
+    baseUrl: `http://localhost:${port}/api`,
+  });
+
+  expect(await apiClient.getAppMode()).toEqual('restore');
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.AdminRestoreModeEntered,
+    'system',
+    { message: expect.stringContaining(workspacePath) }
+  );
+
+  // Spent by the taking: the next boot is an ordinary one.
+  expect(
+    FileBackedBootIntentController.forWorkspace(workspacePath).take()
+  ).toBeUndefined();
+
+  // Restore mode serves no workspace: it opened no database.
+  expect(
+    existsSync(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).toEqual(false);
 });

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -397,6 +397,9 @@ test('starts client networking in client mode', async () => {
 test('starts in restore mode when the last boot asked for it, and only then', async () => {
   const logger = mockLogger({ fn: vi.fn });
   const workspacePath = makeTemporaryDirectory();
+  featureFlagMock.enableFeatureFlag(
+    BooleanEnvironmentVariableName.ENABLE_ADMIN_BACKUP_RESTORE
+  );
   const usbPlatform = new SimulatedUsbPlatform(makeTemporaryDirectory());
   const multiUsbDrive = detectMultiUsbDrive({ logger, platform: usbPlatform });
   FileBackedBootIntentController.forWorkspace(workspacePath).request('restore');
@@ -425,4 +428,40 @@ test('starts in restore mode when the last boot asked for it, and only then', as
   expect(
     existsSync(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
   ).toEqual(false);
+  featureFlagMock.resetFeatureFlags();
+});
+
+test('ignores a request for restore mode when backup and restore are not enabled', async () => {
+  const logger = mockLogger({ fn: vi.fn });
+  const workspacePath = makeTemporaryDirectory();
+  const usbPlatform = new SimulatedUsbPlatform(makeTemporaryDirectory());
+  const multiUsbDrive = detectMultiUsbDrive({ logger, platform: usbPlatform });
+  const { printer } = createMockPrinterHandler();
+  FileBackedBootIntentController.forWorkspace(workspacePath).request('restore');
+
+  server = await suppressingConsoleOutput(() =>
+    start({ logger, workspacePath, multiUsbDrive, printer, port: 0 })
+  );
+
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.WorkspaceConfigurationMessage,
+    'system',
+    {
+      message: expect.stringContaining('not enabled'),
+      disposition: 'failure',
+    }
+  );
+  expect(logger.log).not.toHaveBeenCalledWith(
+    LogEventId.AdminRestoreModeEntered,
+    'system',
+    expect.anything()
+  );
+
+  // Started as a host, and the request is spent all the same.
+  expect(
+    existsSync(join(workspacePath, ADMIN_WORKSPACE_DATABASE_NAME))
+  ).toEqual(true);
+  expect(
+    FileBackedBootIntentController.forWorkspace(workspacePath).take()
+  ).toBeUndefined();
 });

--- a/apps/admin/backend/src/server.test.ts
+++ b/apps/admin/backend/src/server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { assert } from '@votingworks/basics';
-import { readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, writeFileSync } from 'node:fs';
 import { AddressInfo } from 'node:net';
 import { join } from 'node:path';
 import { LogEventId, mockLogger } from '@votingworks/logging';
@@ -24,9 +24,12 @@ import {
 } from '@votingworks/usb-drive';
 import { createMockPrinterHandler } from '@votingworks/printing';
 import { start } from './server.js';
+import { FileBackedMachineModeController } from './machine_mode.js';
 import {
   createWorkspace,
-  RESTORE_IN_PROGRESS_MARKER_FILENAME,
+  getRestoreInProgressMarkerPath,
+  getWorkspaceControlPath,
+  hasInterruptedRestore,
 } from './util/workspace.js';
 import { importCastVoteRecords } from './cast_vote_records.js';
 import { startHostNetworking, startClientNetworking } from './networking.js';
@@ -146,7 +149,10 @@ test('errors on start with no workspace', async () => {
 test('discards a workspace an interrupted restore left behind', async () => {
   const logger = mockLogger({ fn: vi.fn });
   const workspacePath = makeTemporaryDirectory();
-  writeFileSync(join(workspacePath, RESTORE_IN_PROGRESS_MARKER_FILENAME), '');
+  // Writing the mode creates the control directory, whose files are settings
+  // rather than half-restored data and so must survive the discard.
+  FileBackedMachineModeController.forWorkspace(workspacePath).set('host');
+  writeFileSync(getRestoreInProgressMarkerPath(workspacePath), '');
   writeFileSync(join(workspacePath, 'half-copied-file'), 'partial');
 
   const startedServer = await start({ logger, workspacePath });
@@ -157,9 +163,10 @@ test('discards a workspace an interrupted restore left behind', async () => {
     { message: expect.stringContaining(workspacePath) }
   );
   expect(readdirSync(workspacePath)).not.toContain('half-copied-file');
-  expect(readdirSync(workspacePath)).not.toContain(
-    RESTORE_IN_PROGRESS_MARKER_FILENAME
-  );
+  expect(hasInterruptedRestore(workspacePath)).toEqual(false);
+  expect(
+    existsSync(join(getWorkspaceControlPath(workspacePath), 'machine_mode'))
+  ).toEqual(true);
 
   startedServer.close();
 });

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -29,6 +29,7 @@ import {
 import { detectDevices, startCpuMetricsLogging } from '@votingworks/backend';
 import { useDevDockRouter } from '@votingworks/dev-dock-backend';
 import { assert, assertDefined, throwIllegalValue } from '@votingworks/basics';
+import { UserRole } from '@votingworks/types';
 import { PEER_PORT, PORT } from './globals.js';
 import {
   createWorkspace,
@@ -40,21 +41,53 @@ import {
 import { buildApp } from './app.js';
 import { buildClientApp } from './client_app.js';
 import { buildPeerApp } from './peer_app.js';
+import { buildRestoreApp, RESTORE_MODE_STORE } from './restore_app.js';
 import { getMachineConfig } from './machine_config.js';
 import { isMultiStationAdjudicationEnabled } from './multi_station_config.js';
 import { startHostNetworking, startClientNetworking } from './networking.js';
 import { rootDebug } from './util/debug.js';
 import { getUserRole } from './util/auth.js';
-import type { MachineMode } from './types.js';
+import type { AppMode } from './types.js';
 import {
   FileBackedMachineModeController,
   MachineModeController,
 } from './machine_mode.js';
+import {
+  BootIntentController,
+  FileBackedBootIntentController,
+} from './boot_intent.js';
 
 const debug = rootDebug.extend('server');
 
+function allowedUserRoles(appMode: AppMode): UserRole[] {
+  switch (appMode) {
+    case 'host': {
+      return ['vendor', 'system_administrator', 'election_manager'];
+    }
+
+    case 'client': {
+      return [
+        'vendor',
+        'system_administrator',
+        'election_manager',
+        'poll_worker',
+      ];
+    }
+
+    // Restore mode has no election to manage; what it has is a workspace to
+    // replace, which is a system administrator's business.
+    case 'restore': {
+      return ['vendor', 'system_administrator'];
+    }
+
+    default: {
+      throwIllegalValue(appMode);
+    }
+  }
+}
+
 function createAuth(
-  machineMode: MachineMode,
+  appMode: AppMode,
   baseLogger: BaseLogger
 ): DippedSmartCardAuth {
   return new DippedSmartCardAuth({
@@ -66,15 +99,7 @@ function createAuth(
         : new JavaCard(),
     config: {
       allowElectionManagersToAccessUnconfiguredMachines: false,
-      allowedUserRoles:
-        machineMode === 'client'
-          ? [
-              'vendor',
-              'system_administrator',
-              'election_manager',
-              'poll_worker',
-            ]
-          : ['vendor', 'system_administrator', 'election_manager'],
+      allowedUserRoles: allowedUserRoles(appMode),
     },
     logger: baseLogger,
   });
@@ -92,6 +117,7 @@ export interface StartOptions {
   multiUsbDrive?: MultiUsbDrive;
   printer?: Printer;
   machineMode?: MachineModeController;
+  bootIntent?: BootIntentController;
 }
 
 /**
@@ -110,6 +136,18 @@ export async function start(options: StartOptions = {}): Promise<Server> {
 
   const workspacePath =
     options.workspacePath ?? resolveWorkspacePath(baseLogger);
+
+  // Taken first, and spent by the taking: whatever this boot goes on to do,
+  // the next one is an ordinary boot.
+  const bootIntent =
+    options.bootIntent ??
+    FileBackedBootIntentController.forWorkspace(workspacePath);
+  const machineMode =
+    options.machineMode ??
+    FileBackedMachineModeController.forWorkspace(workspacePath);
+  const appMode: AppMode =
+    bootIntent.take() === 'restore' ? 'restore' : machineMode.get();
+
   if (hasInterruptedRestore(workspacePath)) {
     await emptyWorkspaceData(workspacePath);
     baseLogger.log(LogEventId.BackupRestoreInterrupted, 'system', {
@@ -119,14 +157,9 @@ export async function start(options: StartOptions = {}): Promise<Server> {
     });
   }
 
-  const machineMode =
-    options.machineMode ??
-    FileBackedMachineModeController.forWorkspace(workspacePath);
-
   let app;
 
-  const machineModeValue = machineMode.get();
-  switch (machineModeValue) {
+  switch (appMode) {
     case 'host': {
       // TODO(CARO) add some kind of validation that the workspace is properly configured for host mode
       const workspace = createWorkspace(workspacePath, baseLogger);
@@ -181,6 +214,7 @@ export async function start(options: StartOptions = {}): Promise<Server> {
         printer,
         workspace,
         machineMode,
+        bootIntent,
       });
 
       // Log election results data check at startup
@@ -252,8 +286,34 @@ export async function start(options: StartOptions = {}): Promise<Server> {
       break;
     }
 
+    case 'restore': {
+      const auth = createAuth('restore', baseLogger);
+      const logger = Logger.from(
+        baseLogger,
+        // @coverage-exclude
+        () => getUserRole(auth, RESTORE_MODE_STORE)
+      );
+      const multiUsbDrive =
+        options.multiUsbDrive ?? detectMultiUsbDriveFromEnv({ logger });
+
+      app = buildRestoreApp({
+        auth,
+        logger,
+        multiUsbDrive,
+        workspacePath,
+        machineMode,
+      });
+
+      baseLogger.log(LogEventId.AdminRestoreModeEntered, 'system', {
+        message:
+          `Starting in restore mode, as asked on the last boot. ` +
+          `${workspacePath} is not being served; a backup may be restored into it.`,
+      });
+      break;
+    }
+
     default:
-      throwIllegalValue(machineModeValue);
+      throwIllegalValue(appMode);
   }
 
   useDevDockRouter(app, express, {

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import { emptydir } from 'fs-extra';
 import {
   LogEventId,
   BaseLogger,
@@ -34,6 +33,7 @@ import { PEER_PORT, PORT } from './globals.js';
 import {
   createWorkspace,
   createClientWorkspace,
+  emptyWorkspaceData,
   hasInterruptedRestore,
   resolveWorkspacePath,
 } from './util/workspace.js';
@@ -111,7 +111,7 @@ export async function start(options: StartOptions = {}): Promise<Server> {
   const workspacePath =
     options.workspacePath ?? resolveWorkspacePath(baseLogger);
   if (hasInterruptedRestore(workspacePath)) {
-    await emptydir(workspacePath);
+    await emptyWorkspaceData(workspacePath);
     baseLogger.log(LogEventId.BackupRestoreInterrupted, 'system', {
       message:
         `A restore of ${workspacePath} was interrupted before it finished; ` +

--- a/apps/admin/backend/src/server.ts
+++ b/apps/admin/backend/src/server.ts
@@ -145,8 +145,20 @@ export async function start(options: StartOptions = {}): Promise<Server> {
   const machineMode =
     options.machineMode ??
     FileBackedMachineModeController.forWorkspace(workspacePath);
+  const intent = bootIntent.take();
+  const isRestoreEnabled = isFeatureFlagEnabled(
+    BooleanEnvironmentVariableName.ENABLE_ADMIN_BACKUP_RESTORE
+  );
+  if (intent === 'restore' && !isRestoreEnabled) {
+    baseLogger.log(LogEventId.WorkspaceConfigurationMessage, 'system', {
+      message:
+        'Restore mode was asked for on the last boot, but backup and restore ' +
+        'are not enabled; starting normally.',
+      disposition: 'failure',
+    });
+  }
   const appMode: AppMode =
-    bootIntent.take() === 'restore' ? 'restore' : machineMode.get();
+    intent === 'restore' && isRestoreEnabled ? 'restore' : machineMode.get();
 
   if (hasInterruptedRestore(workspacePath)) {
     await emptyWorkspaceData(workspacePath);

--- a/apps/admin/backend/src/types.ts
+++ b/apps/admin/backend/src/types.ts
@@ -34,6 +34,13 @@ export type { ExportDataResult, ExportDataError } from '@votingworks/backend';
 export type MachineMode = 'host' | 'client';
 
 /**
+ * What this VxAdmin process is running as: its machine mode, or restore mode
+ * for the one boot that asked for it. Restore mode serves no election data;
+ * it exists to restore a backup into a workspace nothing is using.
+ */
+export type AppMode = MachineMode | 'restore';
+
+/**
  * The role a machine plays on the network: a VxAdmin host or client, or a
  * networked central scanner.
  */

--- a/apps/admin/backend/src/util/workspace.test.ts
+++ b/apps/admin/backend/src/util/workspace.test.ts
@@ -10,6 +10,7 @@ import {
   getRestoreInProgressMarkerPath,
   getWorkspaceControlPath,
   hasInterruptedRestore,
+  openWorkspaceStoreIfPresent,
   WORKSPACE_CONTROL_DIRECTORY_NAME,
 } from './workspace.js';
 import { Store } from '../store.js';
@@ -81,4 +82,20 @@ test('emptying a workspace that has no control directory leaves it empty', async
   await emptyWorkspaceData(dir);
 
   expect(readdirSync(dir)).toEqual([]);
+});
+
+test('opening a store only if present creates nothing where there is none', () => {
+  const dir = makeTemporaryDirectory();
+  const logger = mockBaseLogger({ fn: vi.fn });
+
+  expect(openWorkspaceStoreIfPresent(dir, logger)).toBeUndefined();
+  expect(readdirSync(dir)).toEqual([]);
+
+  {
+    using workspace = createWorkspace(dir, logger);
+    expect(workspace.store.getCurrentElectionId()).toBeUndefined();
+  }
+
+  using store = openWorkspaceStoreIfPresent(dir, logger);
+  expect(store).toBeInstanceOf(Store);
 });

--- a/apps/admin/backend/src/util/workspace.test.ts
+++ b/apps/admin/backend/src/util/workspace.test.ts
@@ -1,7 +1,17 @@
 import { beforeEach, expect, test, vi } from 'vitest';
+import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { makeTemporaryDirectory } from '@votingworks/fixtures';
 import { mockBaseLogger } from '@votingworks/logging';
-import { createWorkspace, createClientWorkspace } from './workspace.js';
+import {
+  createWorkspace,
+  createClientWorkspace,
+  emptyWorkspaceData,
+  getRestoreInProgressMarkerPath,
+  getWorkspaceControlPath,
+  hasInterruptedRestore,
+  WORKSPACE_CONTROL_DIRECTORY_NAME,
+} from './workspace.js';
 import { Store } from '../store.js';
 import { ClientStore } from '../client_store.js';
 
@@ -44,4 +54,31 @@ test('createClientWorkspace', async () => {
   await expect(workspace.getDiskSpaceSummary()).resolves.toEqual(
     expect.objectContaining({ available: expect.any(Number) })
   );
+});
+
+test('emptying a workspace removes its data and marker but keeps its control files', async () => {
+  const dir = makeTemporaryDirectory();
+  {
+    using workspace = createWorkspace(dir, mockBaseLogger({ fn: vi.fn }));
+    writeFileSync(join(dir, 'ballot-images', 'ballot.jpg'), 'image');
+    expect(workspace).toBeDefined();
+  }
+  mkdirSync(getWorkspaceControlPath(dir));
+  writeFileSync(join(getWorkspaceControlPath(dir), 'machine_mode'), 'client');
+  writeFileSync(getRestoreInProgressMarkerPath(dir), '');
+
+  await emptyWorkspaceData(dir);
+
+  expect(readdirSync(dir)).toEqual([WORKSPACE_CONTROL_DIRECTORY_NAME]);
+  expect(readdirSync(getWorkspaceControlPath(dir))).toEqual(['machine_mode']);
+  expect(hasInterruptedRestore(dir)).toEqual(false);
+});
+
+test('emptying a workspace that has no control directory leaves it empty', async () => {
+  const dir = makeTemporaryDirectory();
+  writeFileSync(join(dir, 'data.db'), 'stale');
+
+  await emptyWorkspaceData(dir);
+
+  expect(readdirSync(dir)).toEqual([]);
 });

--- a/apps/admin/backend/src/util/workspace.ts
+++ b/apps/admin/backend/src/util/workspace.ts
@@ -1,4 +1,5 @@
 import { existsSync, statSync } from 'node:fs';
+import { readdir, rm } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { ensureDirSync } from 'fs-extra';
 import { getDiskSpaceSummaries, getNodeEnv } from '@votingworks/backend';
@@ -13,9 +14,26 @@ import { ClientStore } from '../client_store.js';
 export const ADMIN_WORKSPACE_DATABASE_NAME = 'data.db';
 
 /**
- * Dropped into a workspace while a restore is running and removed only once it
- * succeeds. Its presence afterwards means a restore was interrupted partway
- * through, so the workspace holds nothing worth keeping.
+ * Subdirectory of a workspace for the files that describe the machine rather
+ * than hold its data: which mode it is in, whether a restore is underway. Kept
+ * apart from the data so that emptying the data, which a restore does and
+ * which recovering from an interrupted one does, leaves them alone. See
+ * {@link emptyWorkspaceData}.
+ */
+export const WORKSPACE_CONTROL_DIRECTORY_NAME = 'control';
+
+/**
+ * Path of the directory described by {@link WORKSPACE_CONTROL_DIRECTORY_NAME}.
+ */
+export function getWorkspaceControlPath(workspacePath: string): string {
+  return join(resolve(workspacePath), WORKSPACE_CONTROL_DIRECTORY_NAME);
+}
+
+/**
+ * Dropped into a workspace's control directory while a restore is running and
+ * removed only once it succeeds. Its presence afterwards means a restore was
+ * interrupted partway through, so the workspace's data is nothing worth
+ * keeping.
  */
 export const RESTORE_IN_PROGRESS_MARKER_FILENAME = 'restore-in-progress';
 
@@ -23,7 +41,10 @@ export const RESTORE_IN_PROGRESS_MARKER_FILENAME = 'restore-in-progress';
  * Path of the marker described by {@link RESTORE_IN_PROGRESS_MARKER_FILENAME}.
  */
 export function getRestoreInProgressMarkerPath(workspacePath: string): string {
-  return join(resolve(workspacePath), RESTORE_IN_PROGRESS_MARKER_FILENAME);
+  return join(
+    getWorkspaceControlPath(workspacePath),
+    RESTORE_IN_PROGRESS_MARKER_FILENAME
+  );
 }
 
 /**
@@ -31,6 +52,28 @@ export function getRestoreInProgressMarkerPath(workspacePath: string): string {
  */
 export function hasInterruptedRestore(workspacePath: string): boolean {
   return existsSync(getRestoreInProgressMarkerPath(workspacePath));
+}
+
+/**
+ * Empties a workspace of its data, i.e. everything but the control directory,
+ * and takes the restore-in-progress marker off, since empty data is not
+ * half-restored data. What remains is an unconfigured workspace that has kept
+ * its settings. Used to clear a workspace before a restore fills it and to
+ * discard what a failed or interrupted restore left behind.
+ */
+export async function emptyWorkspaceData(workspacePath: string): Promise<void> {
+  const resolvedPath = resolve(workspacePath);
+  const entries = await readdir(resolvedPath);
+  await Promise.all(
+    entries
+      .filter((entry) => entry !== WORKSPACE_CONTROL_DIRECTORY_NAME)
+      .map((entry) =>
+        rm(join(resolvedPath, entry), { recursive: true, force: true })
+      )
+  );
+
+  // Last, so the marker never comes off while anything it describes remains.
+  await rm(getRestoreInProgressMarkerPath(workspacePath), { force: true });
 }
 
 /**

--- a/apps/admin/backend/src/util/workspace.ts
+++ b/apps/admin/backend/src/util/workspace.ts
@@ -178,6 +178,28 @@ export function openWorkspace(root: string, logger: BaseLogger): Workspace {
 }
 
 /**
+ * Opens a workspace's store if the workspace has a database, and creates nothing
+ * where there is none: for looking at what a workspace holds while leaving it
+ * as it is.
+ */
+export function openWorkspaceStoreIfPresent(
+  root: string,
+  logger: BaseLogger
+): Store | undefined {
+  const paths = workspacePaths(root);
+  if (!existsSync(paths.db)) {
+    return undefined;
+  }
+
+  return Store.fileStore(
+    paths.db,
+    paths.ballotImages,
+    paths.electionPackages,
+    logger
+  );
+}
+
+/**
  * Returns a client Workspace with in-memory connection state.
  */
 export function createClientWorkspace(root: string): ClientWorkspace {

--- a/apps/admin/backend/test/app.ts
+++ b/apps/admin/backend/test/app.ts
@@ -47,6 +47,7 @@ import { Api, MachineMode, PeerApi } from '../src/index.js';
 import { BaseStore } from '../src/types.js';
 import { createWorkspace } from '../src/util/workspace.js';
 import { buildApp } from '../src/app.js';
+import { BootIntent, BootIntentController } from '../src/boot_intent.js';
 import { buildPeerApp } from '../src/peer_app.js';
 import { getMachineConfig } from '../src/machine_config.js';
 import { deleteTmpFileAfterTestSuiteCompletes } from './cleanup.js';
@@ -202,12 +203,24 @@ export function buildTestEnvironment(workspaceRoot?: string) {
   const multiUsbDrive = detectMultiUsbDrive({ logger, platform: usbPlatform });
   const mockPrinterHandler = createMockPrinterHandler();
   let machineMode: MachineMode = 'host';
+  let bootIntent: BootIntent | undefined;
+  const bootIntentController: BootIntentController = {
+    request: (intent) => {
+      bootIntent = intent;
+    },
+    take: () => {
+      const taken = bootIntent;
+      bootIntent = undefined;
+      return taken;
+    },
+  };
   const app = buildApp({
     auth,
     workspace,
     logger,
     multiUsbDrive,
     printer: mockPrinterHandler.printer,
+    bootIntent: bootIntentController,
     machineMode: {
       get: () => machineMode,
       set: (newMachineMode) => {
@@ -249,5 +262,6 @@ export function buildTestEnvironment(workspaceRoot?: string) {
     usbPlatform,
     multiUsbDrive,
     mockPrinterHandler,
+    bootIntentController,
   };
 }

--- a/apps/admin/frontend/src/index.tsx
+++ b/apps/admin/frontend/src/index.tsx
@@ -13,30 +13,46 @@ import {
   AppErrorBoundary,
   SystemCallContextProvider,
 } from '@votingworks/ui';
-import { assert } from '@votingworks/basics';
+import { assert, throwIllegalValue } from '@votingworks/basics';
 import { LogSource, BaseLogger } from '@votingworks/logging';
 import { App as ServerApp } from './app.js';
 import { ClientApp } from './client/client_app.js';
+import { RestoreApp } from './restore/restore_app.js';
 import { createApiClient } from './api.js';
 import {
   SharedApiClientContext,
   createSharedQueryClient,
-  getMachineMode,
+  getAppMode,
   isMultiStationAdjudicationEnabled,
   systemCallApi,
 } from './shared_api.js';
 
 function PrimaryApp(): JSX.Element | null {
-  const machineModeQuery = getMachineMode.useQuery();
+  const appModeQuery = getAppMode.useQuery();
   const isMultiStationEnabledQuery =
     isMultiStationAdjudicationEnabled.useQuery();
-  if (!machineModeQuery.isSuccess || !isMultiStationEnabledQuery.isSuccess) {
+  if (!appModeQuery.isSuccess || !isMultiStationEnabledQuery.isSuccess) {
     return null;
   }
-  if (machineModeQuery.data === 'client' && isMultiStationEnabledQuery.data) {
-    return <ClientApp />;
+
+  const appMode = appModeQuery.data;
+  switch (appMode) {
+    case 'restore': {
+      return <RestoreApp />;
+    }
+
+    case 'client': {
+      return isMultiStationEnabledQuery.data ? <ClientApp /> : <ServerApp />;
+    }
+
+    case 'host': {
+      return <ServerApp />;
+    }
+
+    default: {
+      throwIllegalValue(appMode);
+    }
   }
-  return <ServerApp />;
 }
 
 const apiClient = createApiClient();

--- a/apps/admin/frontend/src/restore/api.ts
+++ b/apps/admin/frontend/src/restore/api.ts
@@ -1,0 +1,166 @@
+import React from 'react';
+import { deepEqual } from '@votingworks/basics';
+import type { RestoreApi } from '@votingworks/admin-backend';
+import * as grout from '@votingworks/grout';
+import {
+  AUTH_STATUS_POLLING_INTERVAL_MS,
+  QUERY_CLIENT_DEFAULT_OPTIONS,
+  USB_DRIVE_STATUS_POLLING_INTERVAL_MS,
+  usePollingQuery,
+} from '@votingworks/ui';
+import {
+  QueryClient,
+  QueryKey,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+/**
+ * How often to ask where a restore stands. A restore reports progress as it
+ * copies, so this is what makes the progress bar move.
+ */
+export const RESTORE_STATUS_POLLING_INTERVAL_MS = 500;
+
+export type ApiClient = grout.Client<RestoreApi>;
+
+// @coverage-exclude: used by RestoreApp outside tests
+export function createApiClient(): ApiClient {
+  return grout.createClient<RestoreApi>({ baseUrl: '/api' });
+}
+
+export const ApiClientContext = React.createContext<ApiClient | undefined>(
+  undefined
+);
+
+export function useApiClient(): ApiClient {
+  const apiClient = React.useContext(ApiClientContext);
+  // @coverage-exclude
+  if (!apiClient) {
+    throw new Error('ApiClientContext.Provider not found');
+  }
+  return apiClient;
+}
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: QUERY_CLIENT_DEFAULT_OPTIONS });
+}
+
+export const getMachineConfig = {
+  queryKey(): QueryKey {
+    return ['getMachineConfig'];
+  },
+  useQuery() {
+    const apiClient = useApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getMachineConfig());
+  },
+} as const;
+
+export const getAuthStatus = {
+  queryKey(): QueryKey {
+    return ['getAuthStatus'];
+  },
+  usePollingQuery() {
+    const apiClient = useApiClient();
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getAuthStatus(),
+      AUTH_STATUS_POLLING_INTERVAL_MS,
+      {
+        structuralSharing(oldData, newData) {
+          if (!oldData) {
+            return newData;
+          }
+          return deepEqual(oldData, newData) ? oldData : newData;
+        },
+      }
+    );
+  },
+} as const;
+
+export const checkPin = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.checkPin, {
+      // @coverage-exclude: query invalidation
+      async onSuccess() {
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
+export const logOut = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.logOut, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getAuthStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
+export const getUsbDriveStatus = {
+  queryKey(): QueryKey {
+    return ['getUsbDriveStatus'];
+  },
+  usePollingQuery() {
+    const apiClient = useApiClient();
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getUsbDriveStatus(),
+      USB_DRIVE_STATUS_POLLING_INTERVAL_MS
+    );
+  },
+} as const;
+
+export const listAvailableBackups = {
+  queryKey(): QueryKey {
+    return ['listAvailableBackups'];
+  },
+  usePollingQuery() {
+    const apiClient = useApiClient();
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.listAvailableBackups(),
+      USB_DRIVE_STATUS_POLLING_INTERVAL_MS
+    );
+  },
+} as const;
+
+export const getRestoreStatus = {
+  queryKey(): QueryKey {
+    return ['getRestoreStatus'];
+  },
+  usePollingQuery() {
+    const apiClient = useApiClient();
+    return usePollingQuery(
+      this.queryKey(),
+      () => apiClient.getRestoreStatus(),
+      RESTORE_STATUS_POLLING_INTERVAL_MS
+    );
+  },
+} as const;
+
+export const restoreBackup = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.restoreBackup, {
+      // Whatever the outcome, the status is what says so.
+      async onSettled() {
+        await queryClient.invalidateQueries(getRestoreStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
+export const cancelRestore = {
+  useMutation() {
+    const apiClient = useApiClient();
+    return useMutation(apiClient.cancelRestore);
+  },
+} as const;

--- a/apps/admin/frontend/src/restore/restore_app.test.tsx
+++ b/apps/admin/frontend/src/restore/restore_app.test.tsx
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { err, ok } from '@votingworks/basics';
+import { createMockClient, MockClient } from '@votingworks/grout-test-utils';
+import type {
+  AvailableBackup,
+  RestoreApi,
+  RestoreStatus,
+} from '@votingworks/admin-backend';
+import {
+  mockSessionExpiresAt,
+  mockSystemAdministratorUser,
+} from '@votingworks/test-utils';
+import { DEV_MACHINE_ID, DippedSmartCardAuth } from '@votingworks/types';
+import { mockUsbDriveStatus, SystemCallContextProvider } from '@votingworks/ui';
+import { render, screen, waitFor } from '../../test/react_testing_library.js';
+import { SharedApiClientContext, systemCallApi } from '../shared_api.js';
+import { ApiClient, createQueryClient } from './api.js';
+import { RestoreApp } from './restore_app.js';
+
+type RestoreProgress = Extract<
+  RestoreStatus,
+  { state: 'restoring' }
+>['progress'];
+
+let apiMock: MockClient<RestoreApi>;
+let queryClient: QueryClient;
+
+const BACKUP: AvailableBackup = {
+  name: 'sample-backup',
+  path: '/media/usb/vxadmin-backups/sample-backup',
+};
+
+const SYSTEM_ADMINISTRATOR_AUTH: DippedSmartCardAuth.AuthStatus = {
+  status: 'logged_in',
+  user: mockSystemAdministratorUser(),
+  sessionExpiresAt: mockSessionExpiresAt(),
+  programmableCard: { status: 'no_card' },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  apiMock = createMockClient<RestoreApi>();
+  queryClient = createQueryClient();
+  apiMock.getMachineConfig
+    .expectCallWith()
+    .resolves({ machineId: DEV_MACHINE_ID, codeVersion: 'dev' });
+});
+
+afterEach(() => {
+  queryClient.clear();
+  apiMock.assertComplete();
+});
+
+function renderRestoreApp() {
+  const apiClient = apiMock as unknown as ApiClient;
+  return render(
+    <SharedApiClientContext.Provider value={apiClient}>
+      <SystemCallContextProvider api={systemCallApi}>
+        <RestoreApp apiClient={apiClient} queryClient={queryClient} />
+      </SystemCallContextProvider>
+    </SharedApiClientContext.Provider>
+  );
+}
+
+function setUnlocked({
+  usbDriveInserted = true,
+  restoreStatus = { state: 'idle' },
+}: {
+  usbDriveInserted?: boolean;
+  restoreStatus?: RestoreStatus;
+} = {}) {
+  apiMock.getAuthStatus
+    .expectRepeatedCallsWith()
+    .resolves(SYSTEM_ADMINISTRATOR_AUTH);
+  apiMock.getRestoreStatus.expectRepeatedCallsWith().resolves(restoreStatus);
+
+  // The backups are offered only while there is no restore to show instead.
+  if (
+    restoreStatus.state === 'restoring' ||
+    restoreStatus.state === 'restored'
+  ) {
+    return;
+  }
+  apiMock.getUsbDriveStatus
+    .expectRepeatedCallsWith()
+    .resolves(mockUsbDriveStatus(usbDriveInserted ? 'mounted' : 'no_drive'));
+  apiMock.listAvailableBackups
+    .expectRepeatedCallsWith()
+    .resolves(
+      usbDriveInserted
+        ? ok([BACKUP])
+        : err({ type: 'no-usb-drive', message: 'No USB drive is inserted' })
+    );
+}
+
+test('asks for a system administrator card while locked', async () => {
+  apiMock.getAuthStatus
+    .expectRepeatedCallsWith()
+    .resolves({ status: 'logged_out', reason: 'machine_locked' });
+  renderRestoreApp();
+
+  await screen.findByText('VxAdmin Locked');
+  screen.getByText(/restore mode/);
+  screen.getByText(DEV_MACHINE_ID);
+});
+
+test('turns away a card that is not a system administrator card', async () => {
+  apiMock.getAuthStatus
+    .expectRepeatedCallsWith()
+    .resolves({ status: 'logged_out', reason: 'user_role_not_allowed' });
+  renderRestoreApp();
+
+  await screen.findByText('Use a system administrator card.');
+});
+
+test('asks for a USB drive when none is inserted', async () => {
+  setUnlocked({ usbDriveInserted: false });
+  renderRestoreApp();
+
+  await screen.findByRole('heading', { name: 'Restore Backup' });
+  await screen.findByText('Insert a USB drive containing a VxAdmin backup.');
+  expect(screen.getButton('Restart')).toBeEnabled();
+});
+
+test('lists the backups on the USB drive and restores the chosen one', async () => {
+  setUnlocked();
+  apiMock.restoreBackup
+    .expectCallWith({ backupPath: BACKUP.path })
+    .resolves(ok());
+  renderRestoreApp();
+
+  await screen.findByText('Backups on USB Drive');
+  screen.getButton(`Restore ${BACKUP.name}`).click();
+
+  await waitFor(() => apiMock.restoreBackup.assertComplete());
+});
+
+test('shows definite progress while files are copied', async () => {
+  setUnlocked({
+    restoreStatus: {
+      state: 'restoring',
+      backupPath: BACKUP.path,
+      progress: {
+        type: 'copy_files',
+        copiedCount: 1,
+        totalCount: 4,
+        copiedBytes: 250,
+        totalBytes: 1000,
+      },
+    },
+  });
+  apiMock.cancelRestore.expectCallWith().resolves();
+  renderRestoreApp();
+
+  await screen.findByText('Copying files (1 of 4)');
+  const progressBar = screen.getByRole('progressbar');
+  expect(progressBar.firstElementChild).toHaveStyle({ width: '25%' });
+  expect(screen.getButton('Restart')).toBeDisabled();
+  expect(screen.queryByText('Backups on USB Drive')).toBeNull();
+
+  screen.getButton('Cancel Restore').click();
+  await waitFor(() => apiMock.cancelRestore.assertComplete());
+});
+
+test('shows indeterminate progress while the extent of the work is unknown', async () => {
+  setUnlocked({
+    restoreStatus: {
+      state: 'restoring',
+      backupPath: BACKUP.path,
+      progress: { type: 'verifying' },
+    },
+  });
+  renderRestoreApp();
+
+  await screen.findByText('Verifying restored files');
+  screen.getByRole('progressbar', { name: 'In progress' });
+});
+
+test('offers a restart once the backup is restored', async () => {
+  setUnlocked({
+    restoreStatus: { state: 'restored', backupPath: BACKUP.path },
+  });
+  apiMock.reboot.expectCallWith().resolves();
+  renderRestoreApp();
+
+  await screen.findByText('Backup restored. Restart VxAdmin to use it.');
+  expect(screen.queryByText('Backups on USB Drive')).toBeNull();
+
+  screen.getButton('Restart').click();
+  await waitFor(() => apiMock.reboot.assertComplete());
+});
+
+test('reports a failed restore and offers the backups again', async () => {
+  setUnlocked({
+    restoreStatus: {
+      state: 'failed',
+      backupPath: BACKUP.path,
+      error: { type: 'backup-read-failed', message: 'Missing backup file' },
+    },
+  });
+  renderRestoreApp();
+
+  await screen.findByText('Restore failed: Missing backup file');
+  await screen.findByText('Backups on USB Drive');
+});
+
+test('walks through the card reader, PIN, and remove-card states', async () => {
+  apiMock.getAuthStatus
+    .expectCallWith()
+    .resolves({ status: 'logged_out', reason: 'no_card_reader' });
+  apiMock.getAuthStatus.expectCallWith().resolves({
+    status: 'checking_pin',
+    user: mockSystemAdministratorUser(),
+  });
+  apiMock.getAuthStatus
+    .expectRepeatedCallsWith()
+    .resolves({ status: 'remove_card', user: mockSystemAdministratorUser() });
+  renderRestoreApp();
+
+  await screen.findByText('Card Reader Not Detected');
+  await screen.findByText('Enter Card PIN');
+  await screen.findByText('Remove card to unlock VxAdmin');
+});
+
+test.each<{ progress: RestoreProgress; label: string }>([
+  { progress: undefined, label: 'Preparing to restore' },
+  { progress: { type: 'preparing' }, label: 'Preparing to restore' },
+  {
+    progress: {
+      type: 'copy_files',
+      copiedCount: 0,
+      totalCount: 0,
+      copiedBytes: 0,
+      totalBytes: 0,
+    },
+    label: 'Copying files (0 of 0)',
+  },
+  {
+    progress: { type: 'flushing_workspace' },
+    label: 'Writing restored files to disk',
+  },
+  // A backup's event, which a restore never sends, still shows movement.
+  { progress: { type: 'db_snapshot', progress: 0.5 }, label: 'Restoring' },
+])('shows indeterminate progress for $label', async ({ progress, label }) => {
+  setUnlocked({
+    restoreStatus: { state: 'restoring', backupPath: BACKUP.path, progress },
+  });
+  renderRestoreApp();
+
+  await screen.findByText(label);
+  screen.getByRole('progressbar', { name: 'In progress' });
+});
+
+test('reports a cancelled restore', async () => {
+  setUnlocked({
+    restoreStatus: {
+      state: 'failed',
+      backupPath: BACKUP.path,
+      error: { type: 'cancelled', message: 'Restore cancelled' },
+    },
+  });
+  renderRestoreApp();
+
+  await screen.findByText('Restore cancelled.');
+});
+
+test('explains a USB drive whose backups cannot be read', async () => {
+  apiMock.getAuthStatus
+    .expectRepeatedCallsWith()
+    .resolves(SYSTEM_ADMINISTRATOR_AUTH);
+  apiMock.getRestoreStatus
+    .expectRepeatedCallsWith()
+    .resolves({ state: 'idle' });
+  apiMock.getUsbDriveStatus
+    .expectRepeatedCallsWith()
+    .resolves(mockUsbDriveStatus('mounted'));
+  apiMock.listAvailableBackups
+    .expectRepeatedCallsWith()
+    .resolves(
+      err({ type: 'not-directory', message: 'vxadmin-backups is a file' })
+    );
+  renderRestoreApp();
+
+  await screen.findByText(/Could not read backups from the USB drive/);
+  screen.getByText(/vxadmin-backups is a file/);
+});
+
+test('says so when the USB drive holds no backups', async () => {
+  apiMock.getAuthStatus
+    .expectRepeatedCallsWith()
+    .resolves(SYSTEM_ADMINISTRATOR_AUTH);
+  apiMock.getRestoreStatus
+    .expectRepeatedCallsWith()
+    .resolves({ state: 'idle' });
+  apiMock.getUsbDriveStatus
+    .expectRepeatedCallsWith()
+    .resolves(mockUsbDriveStatus('mounted'));
+  apiMock.listAvailableBackups.expectRepeatedCallsWith().resolves(ok([]));
+  renderRestoreApp();
+
+  await screen.findByText('No backups were found on the USB drive.');
+});
+
+test('locks the machine on request', async () => {
+  setUnlocked();
+  apiMock.logOut.expectCallWith().resolves();
+  renderRestoreApp();
+
+  (await screen.findButton('Lock Machine')).click();
+  await waitFor(() => apiMock.logOut.assertComplete());
+});

--- a/apps/admin/frontend/src/restore/restore_app.tsx
+++ b/apps/admin/frontend/src/restore/restore_app.tsx
@@ -1,0 +1,36 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RestoreAppRoot } from './restore_app_root.js';
+import {
+  ApiClient,
+  ApiClientContext,
+  createApiClient,
+  createQueryClient,
+} from './api.js';
+import { SharedApiClientContext } from '../shared_api.js';
+
+export interface RestoreAppProps {
+  apiClient?: ApiClient;
+  queryClient?: QueryClient;
+}
+
+/**
+ * The app a VxAdmin serves when it has been booted into restore mode: nothing
+ * but what it takes to restore a backup and restart.
+ */
+export function RestoreApp({
+  apiClient,
+  // @coverage-defer
+  queryClient = createQueryClient(),
+}: RestoreAppProps): JSX.Element {
+  // @coverage-defer
+  const resolvedApiClient = apiClient ?? createApiClient();
+  return (
+    <ApiClientContext.Provider value={resolvedApiClient}>
+      <SharedApiClientContext.Provider value={resolvedApiClient}>
+        <QueryClientProvider client={queryClient}>
+          <RestoreAppRoot />
+        </QueryClientProvider>
+      </SharedApiClientContext.Provider>
+    </ApiClientContext.Provider>
+  );
+}

--- a/apps/admin/frontend/src/restore/restore_app_root.tsx
+++ b/apps/admin/frontend/src/restore/restore_app_root.tsx
@@ -1,0 +1,101 @@
+import {
+  H1,
+  H3,
+  InfoBar,
+  InvalidCardScreen,
+  Main,
+  RemoveCardScreen,
+  Screen,
+  SetupCardReaderPage,
+  SystemInfo,
+  UnlockMachineScreen,
+} from '@votingworks/ui';
+import type { MachineConfig } from '@votingworks/admin-backend';
+import { checkPin, getAuthStatus, getMachineConfig } from './api.js';
+import { RestoreScreen } from './screens/restore_screen.js';
+
+function RestoreModeLockedScreen({
+  machineConfig,
+}: {
+  machineConfig: MachineConfig;
+}): JSX.Element {
+  return (
+    <Screen>
+      <Main centerChild>
+        <div>
+          <H1 align="center">VxAdmin Locked</H1>
+          <H3 align="center" style={{ fontWeight: 'normal' }}>
+            VxAdmin is in restore mode. Insert a system administrator card to
+            unlock.
+          </H3>
+        </div>
+      </Main>
+      <InfoBar>
+        <SystemInfo
+          mode="admin"
+          codeVersion={machineConfig.codeVersion}
+          machineId={machineConfig.machineId}
+        />
+      </InfoBar>
+    </Screen>
+  );
+}
+
+export function RestoreAppRoot(): JSX.Element | null {
+  const authStatusQuery = getAuthStatus.usePollingQuery();
+  const machineConfigQuery = getMachineConfig.useQuery();
+  const checkPinMutation = checkPin.useMutation();
+
+  if (!authStatusQuery.isSuccess || !machineConfigQuery.isSuccess) {
+    return null;
+  }
+
+  const auth = authStatusQuery.data;
+  const machineConfig = machineConfigQuery.data;
+
+  if (auth.status === 'logged_out' && auth.reason === 'no_card_reader') {
+    return <SetupCardReaderPage />;
+  }
+
+  if (auth.status === 'checking_pin') {
+    return (
+      <UnlockMachineScreen
+        auth={auth}
+        checkPin={
+          // @coverage-exclude: tested via host app
+          async (pin) => {
+            try {
+              await checkPinMutation.mutateAsync({ pin });
+            } catch {
+              // Handled by default query client error handling
+            }
+          }
+        }
+      />
+    );
+  }
+
+  if (auth.status === 'remove_card') {
+    return (
+      <RemoveCardScreen productName="VxAdmin" cardInsertionDirection="right" />
+    );
+  }
+
+  if (auth.status === 'logged_out') {
+    if (
+      auth.reason === 'machine_locked' ||
+      auth.reason === 'machine_locked_by_session_expiry'
+    ) {
+      return <RestoreModeLockedScreen machineConfig={machineConfig} />;
+    }
+    return (
+      <InvalidCardScreen
+        reasonAndContext={auth}
+        recommendedAction="Use a system administrator card."
+        cardInsertionDirection="right"
+      />
+    );
+  }
+
+  return <RestoreScreen machineConfig={machineConfig} />;
+}

--- a/apps/admin/frontend/src/restore/screens/restore_screen.tsx
+++ b/apps/admin/frontend/src/restore/screens/restore_screen.tsx
@@ -1,0 +1,285 @@
+import styled, { keyframes } from 'styled-components';
+import type {
+  MachineConfig,
+  ProgressEvent,
+  RestoreStatus,
+} from '@votingworks/admin-backend';
+import {
+  Button,
+  Callout,
+  H1,
+  H2,
+  InfoBar,
+  Main,
+  P,
+  ProgressBar,
+  Screen,
+  SystemInfo,
+  useSystemCallApi,
+} from '@votingworks/ui';
+import {
+  cancelRestore,
+  getRestoreStatus,
+  getUsbDriveStatus,
+  listAvailableBackups,
+  logOut,
+  restoreBackup,
+} from '../api.js';
+
+const slide = keyframes`
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(300%);
+  }
+`;
+
+const IndeterminateTrack = styled.div`
+  background-color: ${(p) => p.theme.colors.containerLow};
+  border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid
+    ${(p) => p.theme.colors.outline};
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  height: 0.75rem;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const IndeterminateFill = styled.div`
+  background-color: ${(p) => p.theme.colors.primary};
+  height: 100%;
+  width: 33%;
+  animation: ${slide} 1.2s linear infinite;
+`;
+
+/**
+ * A progress bar for work whose extent is not known: it moves, so the operator
+ * can tell the machine is not stuck, without claiming how far along it is.
+ */
+function IndeterminateProgressBar(): JSX.Element {
+  return (
+    <IndeterminateTrack role="progressbar" aria-label="In progress">
+      <IndeterminateFill />
+    </IndeterminateTrack>
+  );
+}
+
+const Section = styled.div`
+  max-width: 40rem;
+  margin-bottom: 1.5rem;
+`;
+
+const ButtonRow = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+`;
+
+/**
+ * What to show for the restore's latest progress event: a phase name, and how
+ * far along it is when the phase can say.
+ */
+function describeProgress(progress?: ProgressEvent): {
+  label: string;
+  fraction?: number;
+} {
+  switch (progress?.type) {
+    case undefined:
+    case 'preparing': {
+      return { label: 'Preparing to restore' };
+    }
+
+    case 'copy_files': {
+      return {
+        label: `Copying files (${progress.copiedCount} of ${progress.totalCount})`,
+        fraction:
+          progress.totalBytes > 0
+            ? Math.min(1, progress.copiedBytes / progress.totalBytes)
+            : undefined,
+      };
+    }
+
+    case 'verifying': {
+      return { label: 'Verifying restored files' };
+    }
+
+    case 'flushing_workspace': {
+      return { label: 'Writing restored files to disk' };
+    }
+
+    // The remaining events belong to creating a backup, which a restore never
+    // reports.
+    default: {
+      return { label: 'Restoring' };
+    }
+  }
+}
+
+function RestoreProgress({
+  status,
+}: {
+  status: Extract<RestoreStatus, { state: 'restoring' }>;
+}): JSX.Element {
+  const cancelRestoreMutation = cancelRestore.useMutation();
+  const { label, fraction } = describeProgress(status.progress);
+  return (
+    <Section>
+      <H2>Restoring…</H2>
+      <P>{label}</P>
+      {fraction === undefined ? (
+        <IndeterminateProgressBar />
+      ) : (
+        <ProgressBar progress={fraction} />
+      )}
+      <P>
+        <Button
+          onPress={() => cancelRestoreMutation.mutate()}
+          disabled={cancelRestoreMutation.isLoading}
+        >
+          Cancel Restore
+        </Button>
+      </P>
+    </Section>
+  );
+}
+
+function RestoreOutcome({
+  status,
+}: {
+  status: Extract<RestoreStatus, { state: 'restored' | 'failed' }>;
+}): JSX.Element {
+  if (status.state === 'restored') {
+    return (
+      <Section>
+        <Callout icon="Done" color="primary">
+          Backup restored. Restart VxAdmin to use it.
+        </Callout>
+      </Section>
+    );
+  }
+
+  return (
+    <Section>
+      <Callout icon="Danger" color="danger">
+        {status.error.type === 'cancelled'
+          ? 'Restore cancelled.'
+          : `Restore failed: ${status.error.message}`}
+      </Callout>
+    </Section>
+  );
+}
+
+function AvailableBackups(): JSX.Element | null {
+  const usbDriveStatusQuery = getUsbDriveStatus.usePollingQuery();
+  const backupsQuery = listAvailableBackups.usePollingQuery();
+  const restoreBackupMutation = restoreBackup.useMutation();
+
+  if (!usbDriveStatusQuery.isSuccess || !backupsQuery.isSuccess) {
+    return null;
+  }
+
+  if (usbDriveStatusQuery.data.status !== 'mounted') {
+    return (
+      <Section>
+        <P>Insert a USB drive containing a VxAdmin backup.</P>
+      </Section>
+    );
+  }
+
+  const backupsResult = backupsQuery.data;
+  if (backupsResult.isErr()) {
+    return (
+      <Section>
+        <Callout icon="Warning" color="warning">
+          Could not read backups from the USB drive:{' '}
+          {backupsResult.err().message}
+        </Callout>
+      </Section>
+    );
+  }
+
+  const backups = backupsResult.ok();
+  if (backups.length === 0) {
+    return (
+      <Section>
+        <P>No backups were found on the USB drive.</P>
+      </Section>
+    );
+  }
+
+  return (
+    <Section>
+      <H2>Backups on USB Drive</H2>
+      <P>Restoring replaces everything on this machine with the backup.</P>
+      <ButtonRow>
+        {backups.map((backup) => (
+          <Button
+            key={backup.path}
+            variant="primary"
+            icon="Import"
+            onPress={() =>
+              restoreBackupMutation.mutate({ backupPath: backup.path })
+            }
+            disabled={restoreBackupMutation.isLoading}
+          >
+            Restore {backup.name}
+          </Button>
+        ))}
+      </ButtonRow>
+    </Section>
+  );
+}
+
+export function RestoreScreen({
+  machineConfig,
+}: {
+  machineConfig: MachineConfig;
+}): JSX.Element | null {
+  const restoreStatusQuery = getRestoreStatus.usePollingQuery();
+  const rebootMutation = useSystemCallApi().reboot.useMutation();
+  const logOutMutation = logOut.useMutation();
+
+  if (!restoreStatusQuery.isSuccess) {
+    return null;
+  }
+  const status = restoreStatusQuery.data;
+
+  return (
+    <Screen>
+      <Main padded>
+        <H1>Restore Backup</H1>
+        <Section>
+          <P>
+            VxAdmin is in restore mode. It is not serving election data until it
+            restarts, with or without a restore.
+          </P>
+        </Section>
+        {status.state === 'restoring' && <RestoreProgress status={status} />}
+        {(status.state === 'restored' || status.state === 'failed') && (
+          <RestoreOutcome status={status} />
+        )}
+        {status.state !== 'restoring' && status.state !== 'restored' && (
+          <AvailableBackups />
+        )}
+        <ButtonRow>
+          <Button
+            variant={status.state === 'restored' ? 'primary' : undefined}
+            onPress={() => rebootMutation.mutate()}
+            disabled={status.state === 'restoring' || rebootMutation.isLoading}
+          >
+            Restart
+          </Button>
+          <Button onPress={() => logOutMutation.mutate()}>Lock Machine</Button>
+        </ButtonRow>
+      </Main>
+      <InfoBar>
+        <SystemInfo
+          mode="admin"
+          codeVersion={machineConfig.codeVersion}
+          machineId={machineConfig.machineId}
+        />
+      </InfoBar>
+    </Screen>
+  );
+}

--- a/apps/admin/frontend/src/shared_api.ts
+++ b/apps/admin/frontend/src/shared_api.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Api, ClientApi } from '@votingworks/admin-backend';
+import type { Api, ClientApi, RestoreApi } from '@votingworks/admin-backend';
 import {
   QueryClient,
   QueryKey,
@@ -15,9 +15,11 @@ import {
 import { getAuthStatus, getUsbDriveStatus } from './api.js';
 
 /**
- * Methods shared between host (Api) and client (ClientApi) backends.
+ * Methods shared between the host (Api), client (ClientApi), and restore mode
+ * (RestoreApi) backends.
  */
 type SharedMethods =
+  | 'getAppMode'
   | 'logOut'
   | 'getAuthStatus'
   | 'checkPin'
@@ -28,7 +30,8 @@ type SharedMethods =
   | 'isMultiStationAdjudicationEnabled';
 
 export type SharedApiClient = Pick<grout.Client<Api>, SharedMethods> &
-  Pick<grout.Client<ClientApi>, SharedMethods>;
+  Pick<grout.Client<ClientApi>, SharedMethods> &
+  Pick<grout.Client<RestoreApi>, SharedMethods>;
 
 export const SharedApiClientContext = React.createContext<
   SharedApiClient | undefined
@@ -53,6 +56,17 @@ export function createSharedQueryClient(): QueryClient {
 export const systemCallApi = createSystemCallApi(
   useSharedApiClient as () => grout.Client<Api>
 );
+
+// @coverage-exclude: used in index.tsx which is excluded from coverage
+export const getAppMode = {
+  queryKey(): QueryKey {
+    return ['getAppMode'];
+  },
+  useQuery() {
+    const apiClient = useSharedApiClient();
+    return useQuery(this.queryKey(), () => apiClient.getAppMode());
+  },
+} as const;
 
 // @coverage-exclude: used in index.tsx which is excluded from coverage
 export const getMachineMode = {

--- a/libs/eslint-plugin-vx/src/configs/recommended.ts
+++ b/libs/eslint-plugin-vx/src/configs/recommended.ts
@@ -192,6 +192,9 @@ export default function buildRecommended(
             // typescript-eslint v8 changed the default from 'none' to 'all';
             // keep the pre-v8 behavior of ignoring unused catch bindings.
             caughtErrors: 'none',
+            // A `using` binding is there to be disposed at the end of its
+            // scope, so having a name nothing reads is the normal case.
+            ignoreUsingDeclarations: true,
           },
         ],
         '@typescript-eslint/prefer-readonly': 'error',

--- a/libs/logging/VotingWorksLoggingDocumentation.md
+++ b/libs/logging/VotingWorksLoggingDocumentation.md
@@ -746,3 +746,11 @@ IDs are logged with each log to identify the log being written.
 **Type:** [application-action](#application-action)
 **Description:** A user viewed the live reporting QR Code.
 **Machines:** vx-admin, vx-scan
+### admin-restore-mode-scheduled
+**Type:** [user-action](#user-action)
+**Description:** A user arranged for VxAdmin to start in restore mode on its next boot, where a backup can be restored.
+**Machines:** vx-admin
+### admin-restore-mode-entered
+**Type:** [system-status](#system-status)
+**Description:** VxAdmin started in restore mode, as arranged on the previous boot. It serves no election data until it is rebooted.
+**Machines:** vx-admin

--- a/libs/logging/log_event_details.toml
+++ b/libs/logging/log_event_details.toml
@@ -1182,3 +1182,15 @@ eventId = "live-report-viewed"
 eventType = "application-action"
 documentationMessage = "A user viewed the live reporting QR Code."
 restrictInDocumentationToApps = ["vx-admin", "vx-scan"]
+
+[Events.AdminRestoreModeScheduled]
+eventId = "admin-restore-mode-scheduled"
+eventType = "user-action"
+documentationMessage = "A user arranged for VxAdmin to start in restore mode on its next boot, where a backup can be restored."
+restrictInDocumentationToApps = ["vx-admin"]
+
+[Events.AdminRestoreModeEntered]
+eventId = "admin-restore-mode-entered"
+eventType = "system-status"
+documentationMessage = "VxAdmin started in restore mode, as arranged on the previous boot. It serves no election data until it is rebooted."
+restrictInDocumentationToApps = ["vx-admin"]

--- a/libs/logging/src/log_event_enums.ts
+++ b/libs/logging/src/log_event_enums.ts
@@ -249,6 +249,8 @@ export enum LogEventId {
   AdminContestAdjudicated = 'admin-contest-adjudicated',
   LowDiskSpace = 'low-disk-space',
   LiveReportingUrlViewer = 'live-report-viewed',
+  AdminRestoreModeScheduled = 'admin-restore-mode-scheduled',
+  AdminRestoreModeEntered = 'admin-restore-mode-entered',
 }
 
 const ElectionConfigured: LogDetails = {
@@ -1611,6 +1613,22 @@ const LiveReportingUrlViewer: LogDetails = {
   restrictInDocumentationToApps: [AppName.VxAdmin, AppName.VxScan],
 };
 
+const AdminRestoreModeScheduled: LogDetails = {
+  eventId: LogEventId.AdminRestoreModeScheduled,
+  eventType: LogEventType.UserAction,
+  documentationMessage:
+    'A user arranged for VxAdmin to start in restore mode on its next boot, where a backup can be restored.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
+const AdminRestoreModeEntered: LogDetails = {
+  eventId: LogEventId.AdminRestoreModeEntered,
+  eventType: LogEventType.SystemStatus,
+  documentationMessage:
+    'VxAdmin started in restore mode, as arranged on the previous boot. It serves no election data until it is rebooted.',
+  restrictInDocumentationToApps: [AppName.VxAdmin],
+};
+
 export function getDetailsForEventId(eventId: LogEventId): LogDetails {
   switch (eventId) {
     case LogEventId.ElectionConfigured:
@@ -1979,6 +1997,10 @@ export function getDetailsForEventId(eventId: LogEventId): LogDetails {
       return LowDiskSpace;
     case LogEventId.LiveReportingUrlViewer:
       return LiveReportingUrlViewer;
+    case LogEventId.AdminRestoreModeScheduled:
+      return AdminRestoreModeScheduled;
+    case LogEventId.AdminRestoreModeEntered:
+      return AdminRestoreModeEntered;
     default:
       throwIllegalValue(eventId);
   }

--- a/libs/logging/types-rust/src/log_event_enums.rs
+++ b/libs/logging/types-rust/src/log_event_enums.rs
@@ -481,5 +481,9 @@ pub enum EventId {
     LowDiskSpace,
     #[serde(rename = "live-report-viewed")]
     LiveReportingUrlViewer,
+    #[serde(rename = "admin-restore-mode-scheduled")]
+    AdminRestoreModeScheduled,
+    #[serde(rename = "admin-restore-mode-entered")]
+    AdminRestoreModeEntered,
 }
 derive_display!(EventId);


### PR DESCRIPTION
## Overview

Refs #7897

Fourth fix from the pre-ship security review of backup & restore.

A restore replaces a workspace file by file, so it cannot run in the process serving that workspace: the machine would go on reading a database that no longer exists, and its logger would be asking a closed store for the current role. Yet the machine's own API is the only way an operator has of asking for a restore. So a machine now restores itself by rebooting into a restore mode that serves the workspace to no one.

- A workspace's control files — `machine_mode`, the restore-in-progress marker, and the new one-shot `next_boot` intent — live in `control/`, which emptying the workspace's data leaves alone. A backup manifest naming a control file is refused.
- `scheduleRestoreMode` on an unconfigured host writes the intent; the next boot takes it, clears it before acting on it, and starts in restore mode. Restore mode opens no store. Its API lists the backups on the inserted USB drive, restores one with progress, cancels, and reboots, which is also how it is left. All of this is gated on `ENABLE_ADMIN_BACKUP_RESTORE`.
- `restoreBackup` now names the workspace by path and opens the database only to ask whether it holds an election, and only if there is a database to open.
- A placeholder restore UI: a lock screen asking for a system administrator card, then one screen listing the backups on the drive, with the restore's phase shown as a definite progress bar while copying and an indeterminate one otherwise.

Also releases `BackupStagingArea`'s lock even when its cleanup fails, and lets `using` bindings go unused in lint.

Dev workflow heads-up: the CLI is a separate process, so stop the backend before `backups restore`.

## Testing Plan

- Automated tests for the control directory, the intent lifecycle, booting into restore mode and ignoring the intent when the flag is off, the restore API end to end against a simulated USB drive, and each state of the UI.
- Exercised for real: a backend booted into restore mode with a signed 6,002-file backup on the mock USB drive and a mock system administrator card, driven headlessly through unlock, restore with live progress, completion, and a plain restart that came up as a host serving the restored election.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ua9RqSe7qRi4s9HR65CN7
