### PR TITLE
[libs/backend] Add HashingPassthrough stream util

### DIFF
--- a/libs/backend/src/hash.test.ts
+++ b/libs/backend/src/hash.test.ts
@@ -1,0 +1,71 @@
+import { Buffer } from 'node:buffer';
+import { createHash, Hash } from 'node:crypto';
+import { expect, test, vi } from 'vitest';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { makeTemporaryFile } from '@votingworks/fixtures';
+import { createWriteStream, readFileSync, WriteStream } from 'node:fs';
+import { buffer } from 'node:stream/consumers';
+import { HashingPassthrough } from './hash';
+
+test('HashingPassthrough - matches regular hasher output', async () => {
+  const phrase = Buffer.of(0xca, 0xfe);
+  const nPhrases = 100 * 1024; // Need this to be large enough to need draining.
+  const chunks = Array.from({ length: nPhrases }, () => phrase);
+
+  const referenceHash = createHash('sha256');
+  for (const chunk of chunks) referenceHash.update(chunk);
+
+  const hashingStream = new HashingPassthrough(createHash('sha256'));
+  const { outputPath, outputStream } = tempFile();
+
+  await pipeline(Readable.from(chunks), hashingStream, outputStream);
+  expect(hashingStream.digest('hex')).toEqual(referenceHash.digest('hex'));
+
+  const output = readFileSync(outputPath);
+  expect(output).toEqual(Buffer.alloc(nPhrases * phrase.length, phrase));
+});
+
+test('HashingPassthrough - handles string chunks', async () => {
+  const stringChunk = 'hello';
+
+  const referenceHash = createHash('sha256');
+  referenceHash.update(stringChunk);
+
+  const hashingStream = new HashingPassthrough(createHash('sha256'));
+  const { outputPath, outputStream } = tempFile();
+
+  await pipeline(Readable.from([stringChunk]), hashingStream, outputStream);
+  expect(hashingStream.digest('hex')).toEqual(referenceHash.digest('hex'));
+
+  const output = readFileSync(outputPath, 'utf8');
+  expect(output).toEqual('hello');
+});
+
+test('HashingPassthrough.digest() asserts stream is fully hashed', () => {
+  const hashingStream = new HashingPassthrough(createHash('sha256'));
+  hashingStream.write(Buffer.of(0xca, 0xfe));
+  expect(() => hashingStream.digest('hex')).toThrow(/incomplete hash/);
+});
+
+test('HashingPassthrough - propagates errors', async () => {
+  const error = new Error('something went wrong');
+
+  const mockHash = {
+    digest: vi.fn(),
+    update: vi.fn(() => {
+      throw error;
+    }),
+  } as const as unknown as Hash;
+
+  const hashingStream = new HashingPassthrough(mockHash);
+  hashingStream.write(Buffer.of(0xca, 0xfe));
+  hashingStream.end();
+
+  await expect(async () => await buffer(hashingStream)).rejects.toThrow(error);
+});
+
+function tempFile(): { outputPath: string; outputStream: WriteStream } {
+  const outputPath = makeTemporaryFile();
+  return { outputPath, outputStream: createWriteStream(outputPath) };
+}

--- a/libs/backend/src/hash.ts
+++ b/libs/backend/src/hash.ts
@@ -1,0 +1,59 @@
+import * as util from 'node:util';
+import { BinaryToTextEncoding, Hash } from 'node:crypto';
+import { Transform, TransformCallback } from 'node:stream';
+
+import { assert } from '@votingworks/basics';
+
+/**
+ * Pipes an input stream to an output stream, unchanged, hashing each chunk
+ * along the way.
+ *
+ * NOTE: Not a sink - must be piped to an output stream to avoid hangs when the
+ * buffer is full. Use `node:crypto/createHash` directly if no passthrough is
+ * needed.
+ *
+ * ### Example
+ * ```ts
+ * async function writeAndHash(hugeStream: Readable, outputPath: string) {
+ *   const hashingStream = new HashingPassthrough(createHash('sha256'));
+ *   await pipeline(hugeStream, hashingStream, createWriteStream(outputPath));
+ *
+ *   return hashingStream.digest('hex');
+ * }
+ * ```
+ */
+export class HashingPassthrough extends Transform {
+  private hashComplete = false;
+
+  constructor(private readonly hash: Hash) {
+    super();
+  }
+
+  /**
+   * @see {@link Hash.digest}
+   * @throws if called before input stream ends or if called more than once.
+   */
+  digest(encoding: BinaryToTextEncoding): string {
+    assert(this.hashComplete, 'digest requested on incomplete hash');
+    return this.hash.digest(encoding);
+  }
+
+  _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: TransformCallback
+  ): void {
+    try {
+      this.hash.update(chunk);
+    } catch (e) {
+      return callback(e instanceof Error ? e : new Error(util.inspect(e)));
+    }
+
+    callback(null, chunk);
+  }
+
+  _flush(callback: TransformCallback): void {
+    this.hashComplete = true;
+    callback();
+  }
+}

--- a/libs/backend/src/index.ts
+++ b/libs/backend/src/index.ts
@@ -11,6 +11,7 @@ export * from './election_package';
 export * from './exceptions';
 export * from './exec';
 export * from './exporter';
+export * from './hash';
 export * from './initialize_system_audio';
 export * from './is_device_attached';
 export * from './pdf_to_text';


### PR DESCRIPTION
## Overview

Supporting https://github.com/votingworks/vxsuite/issues/9217

Adding a hashing passthrough stream helper - first use case will be for hashing large election JSON files and election ZIP files while writing to file, since they're too large to generate in-memory.

The existing `sha256File()`  used when reading election packages didn't quite fit the need, since that requires reading the file twice - once to hash and another to transfer it to S3. There might be cases of the existing util that can be replaced with this one later on (cases where we're creating duplicate file streams).

## Demo Video or Screenshot
N/A

## Testing Plan
- Simple sanity check test to compare streaming hash against the synchronous one.

## Checklist
N/A
