### PR TITLE
chore(backend): remove dependency on `libs/fs`

### DIFF
--- a/libs/backend/package.json
+++ b/libs/backend/package.json
@@ -58,7 +58,6 @@
     "@types/yauzl": "2.10.3",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/fixtures": "workspace:*",
-    "@votingworks/fs": "workspace:*",
     "@votingworks/test-utils": "workspace:*",
     "eslint-plugin-vx": "workspace:*",
     "fast-check": "2.23.2",

--- a/libs/backend/test/utils.ts
+++ b/libs/backend/test/utils.ts
@@ -1,4 +1,6 @@
 /* eslint-disable max-classes-per-file */
+import { readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
 import {
   CAST_VOTE_RECORD_HASHES_TABLE_SCHEMA,
   clearCastVoteRecordHashes,
@@ -15,7 +17,6 @@ import {
   PollsState,
   SystemSettings,
 } from '@votingworks/types';
-import { FileSystemEntryType, listDirectoryRecursive } from '@votingworks/fs';
 import {
   CentralScannerStore,
   ElectionRecord,
@@ -221,11 +222,14 @@ export async function summarizeDirectoryContents(
   directoryPath: string
 ): Promise<string[]> {
   const filePathsRelativeToDirectoryPath: string[] = [];
-  for await (const entryResult of listDirectoryRecursive(directoryPath)) {
-    const entry = entryResult.unsafeUnwrap();
-    if (entry.type === FileSystemEntryType.File) {
+
+  for (const entry of await readdir(directoryPath, {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    if (entry.isFile()) {
       filePathsRelativeToDirectoryPath.push(
-        entry.path.replace(`${directoryPath}/`, '')
+        relative(directoryPath, join(entry.parentPath, entry.name))
       );
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3226,9 +3226,6 @@ importers:
       '@votingworks/fixtures':
         specifier: workspace:*
         version: link:../fixtures
-      '@votingworks/fs':
-        specifier: workspace:*
-        version: link:../fs
       '@votingworks/test-utils':
         specifier: workspace:*
         version: link:../test-utils


### PR DESCRIPTION
## Overview
_(Inspired by #9285 and trying to use `HashingPassthrough` in `copyFile`)_

It was only used as a `devDependency` and in a way that's better served by the node stdlib.

## Testing Plan
Existing tests.