### PR TITLE
chore(deps): upgrade `@vitejs/plugin-react`

### DIFF
--- a/apps/admin/frontend/package.json
+++ b/apps/admin/frontend/package.json
@@ -92,7 +92,7 @@
     "@types/readable-stream": "2.3.9",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/admin-backend": "workspace:*",
     "@votingworks/backend": "workspace:*",

--- a/apps/central-scan/frontend/package.json
+++ b/apps/central-scan/frontend/package.json
@@ -75,7 +75,7 @@
     "@types/setimmediate": "^1.0.2",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/backend": "workspace:*",
     "@votingworks/central-scan-backend": "workspace:*",

--- a/apps/design/frontend/package.json
+++ b/apps/design/frontend/package.json
@@ -97,7 +97,7 @@
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
     "@types/tmp": "0.2.4",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/fixtures": "workspace:*",
     "@votingworks/grout-test-utils": "workspace:*",

--- a/apps/mark-scan/frontend/package.json
+++ b/apps/mark-scan/frontend/package.json
@@ -86,7 +86,7 @@
     "@types/setimmediate": "^1.0.2",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/backend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/mark/frontend/package.json
+++ b/apps/mark/frontend/package.json
@@ -85,7 +85,7 @@
     "@types/setimmediate": "^1.0.2",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/backend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/pollbook/frontend/package.json
+++ b/apps/pollbook/frontend/package.json
@@ -86,7 +86,7 @@
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
     "@types/tmp": "0.2.4",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/backend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/print/frontend/package.json
+++ b/apps/print/frontend/package.json
@@ -75,7 +75,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/backend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/apps/scan/frontend/package.json
+++ b/apps/scan/frontend/package.json
@@ -81,7 +81,7 @@
     "@types/setimmediate": "^1.0.2",
     "@types/styled-components": "^5.1.26",
     "@types/testing-library__jest-dom": "^5.14.9",
-    "@vitejs/plugin-react": "^1.3.2",
+    "@vitejs/plugin-react": "^6.1.1",
     "@vitest/coverage-istanbul": "^4.1.6",
     "@votingworks/backend": "workspace:*",
     "@votingworks/fixtures": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,8 +390,8 @@ importers:
         specifier: ^5.14.9
         version: 5.14.9
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -741,8 +741,8 @@ importers:
         specifier: ^5.14.9
         version: 5.14.9
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -1167,8 +1167,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -1490,8 +1490,8 @@ importers:
         specifier: ^5.14.9
         version: 5.14.9
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -1850,8 +1850,8 @@ importers:
         specifier: ^5.14.9
         version: 5.14.9
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -2240,8 +2240,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -2527,8 +2527,8 @@ importers:
         specifier: ^5.14.9
         version: 5.14.9
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -2887,8 +2887,8 @@ importers:
         specifier: ^5.14.9
         version: 5.14.9
       '@vitejs/plugin-react':
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^6.1.1
+        version: 6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@vitest/coverage-istanbul':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
@@ -5208,7 +5208,7 @@ importers:
         version: 10.5.10(@types/react@18.3.3)(react@18.3.1)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))
       '@storybook/react-vite':
         specifier: 10.5.10
-        version: 10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(@typescript/typescript6@6.0.2)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
+        version: 10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))(typescript@7.0.2)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@tanstack/react-query':
         specifier: 4.32.1
         version: 4.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5307,7 +5307,7 @@ importers:
         version: 2.2.2(esbuild@0.28.1)
       eslint-plugin-storybook:
         specifier: 10.5.10
-        version: 10.5.10(@typescript/typescript6@6.0.2)(eslint@9.39.5)
+        version: 10.5.10(eslint@9.39.5)(typescript@7.0.2)
       eslint-plugin-vx:
         specifier: workspace:*
         version: link:../eslint-plugin-vx
@@ -5882,30 +5882,6 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.29.7':
     resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-development@7.18.6':
-    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-self@7.18.6':
-    resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.19.6':
-    resolution: {integrity: sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx@7.20.13':
-    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -7820,10 +7796,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rollup/pluginutils@4.2.1':
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-
   '@rollup/pluginutils@5.0.3':
     resolution: {integrity: sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==}
     engines: {node: '>=14.0.0'}
@@ -9044,9 +9016,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitejs/plugin-react@1.3.2':
-    resolution: {integrity: sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==}
-    engines: {node: '>=12.0.0'}
+  '@vitejs/plugin-react@6.1.1':
+    resolution: {integrity: sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      oxc-transform-react: ^0.145.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      oxc-transform-react:
+        optional: true
 
   '@vitest/coverage-istanbul@4.1.6':
     resolution: {integrity: sha512-lOt/VDh+sihAx3OUxCE5CC0qZfAhIzE3Dxw75NJ3P0C6ruUgT9b/jZKECE1ctpbxSVic9OkLdXz5UEX39ks4Sw==}
@@ -12835,10 +12819,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-refresh@0.13.0:
-    resolution: {integrity: sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==}
-    engines: {node: '>=0.10.0'}
-
   react-router-dom@5.3.4:
     resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
     peerDependencies:
@@ -14723,7 +14703,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.29.7': {}
+  '@babel/helper-plugin-utils@7.29.7':
+    optional: true
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
@@ -14790,6 +14771,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
@@ -14844,34 +14826,6 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
     optional: true
-
-  '@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.29.7)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-source@7.19.6(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.29.7(supports-color@5.5.0)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
-      '@babel/types': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/runtime@7.29.7': {}
 
@@ -15660,13 +15614,13 @@ snapshots:
       '@types/yargs': 17.0.22
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(@typescript/typescript6@6.0.2)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@7.0.2)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))':
     dependencies:
       glob: 13.0.6
-      react-docgen-typescript: 2.2.2(@typescript/typescript6@6.0.2)
+      react-docgen-typescript: 2.2.2(typescript@7.0.2)
       vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -16610,11 +16564,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/pluginutils@4.2.1':
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-
   '@rollup/pluginutils@5.0.3(rollup@3.29.5)':
     dependencies:
       '@types/estree': 1.0.9
@@ -17136,12 +17085,12 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
-  '@storybook/react-vite@10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(@typescript/typescript6@6.0.2)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))':
+  '@storybook/react-vite@10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.5)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))(typescript@7.0.2)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(@typescript/typescript6@6.0.2)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@7.0.2)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
       '@rollup/pluginutils': 5.0.3(rollup@3.29.5)
       '@storybook/builder-vite': 10.5.10(esbuild@0.28.1)(rollup@3.29.5)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))
-      '@storybook/react': 10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(@typescript/typescript6@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))
+      '@storybook/react': 10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))(typescript@7.0.2)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 18.3.1
@@ -17152,7 +17101,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2)
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -17161,19 +17110,19 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(@typescript/typescript6@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))':
+  '@storybook/react@10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))(typescript@7.0.2)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.5.10(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.3
-      react-docgen-typescript: 2.2.2(@typescript/typescript6@6.0.2)
+      react-docgen-typescript: 2.2.2(typescript@7.0.2)
       react-dom: 18.3.1(react@18.3.1)
       storybook: 10.5.10(@types/react@18.3.3)(prettier@3.9.6)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17771,12 +17720,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@7.0.2)
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      eslint: 9.39.5
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.67.0(@typescript/typescript6@6.0.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.67.0(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.67.0
       debug: 4.4.3
       typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.67.0(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@7.0.2)
+      '@typescript-eslint/types': 8.67.0
+      debug: 4.4.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17802,6 +17772,10 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.67.0(@typescript/typescript6@6.0.2)':
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
+
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@7.0.2)':
+    dependencies:
+      typescript: 7.0.2
 
   '@typescript-eslint/type-utils@8.67.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)':
     dependencies:
@@ -17848,6 +17822,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@7.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.67.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@7.0.2)
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/visitor-keys': 8.67.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@7.0.2)
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.67.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
@@ -17857,6 +17846,18 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.67.0(@typescript/typescript6@6.0.2)
       eslint: 9.39.5
       typescript: '@typescript/typescript6@6.0.2'
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.67.0(eslint@9.39.5)(typescript@7.0.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
+      '@typescript-eslint/parser': 8.67.0(eslint@9.39.5)(typescript@7.0.2)
+      '@typescript-eslint/scope-manager': 8.67.0
+      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@7.0.2)
+      eslint: 9.39.5
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -18004,18 +18005,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitejs/plugin-react@1.3.2':
+  '@vitejs/plugin-react@6.1.1(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2))':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.29.7)
-      '@rollup/pluginutils': 4.2.1
-      react-refresh: 0.13.0
-      resolve: 1.22.12
-    transitivePeerDependencies:
-      - supports-color
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.8.2)
 
   '@vitest/coverage-istanbul@4.1.6(vitest@4.1.6)':
     dependencies:
@@ -19579,10 +19572,10 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@10.5.10(@typescript/typescript6@6.0.2)(eslint@9.39.5):
+  eslint-plugin-storybook@10.5.10(eslint@9.39.5)(typescript@7.0.2):
     dependencies:
       '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/utils': 8.67.0(@typescript/typescript6@6.0.2)(eslint@9.39.5)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.5)(typescript@7.0.2)
       eslint: 9.39.5
     transitivePeerDependencies:
       - supports-color
@@ -22429,9 +22422,9 @@ snapshots:
       chart.js: 4.4.7
       react: 18.3.1
 
-  react-docgen-typescript@2.2.2(@typescript/typescript6@6.0.2):
+  react-docgen-typescript@2.2.2(typescript@7.0.2):
     dependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 7.0.2
 
   react-docgen@8.0.3:
     dependencies:
@@ -22508,8 +22501,6 @@ snapshots:
       warning: 4.0.3
     optionalDependencies:
       '@types/react': 18.3.3
-
-  react-refresh@0.13.0: {}
 
   react-router-dom@5.3.4(react@18.3.1):
     dependencies:
@@ -23465,6 +23456,10 @@ snapshots:
   ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
       typescript: '@typescript/typescript6@6.0.2'
+
+  ts-api-utils@2.5.0(typescript@7.0.2):
+    dependencies:
+      typescript: 7.0.2
 
   ts-declaration-location@1.0.7(@typescript/typescript6@6.0.2):
     dependencies:


### PR DESCRIPTION
## Overview
We were on a truly ancient version (2022). Needed to unblock both the React 19 JSX runtime and React Compiler ([CHANGELOG.md](https://github.com/vitejs/vite-plugin-react/blob/c9eba3e76ab2bfa9adcb8b69f9b165e5b4261cd0/packages/plugin-react/CHANGELOG.md)).

## Testing Plan
Verified that hot reloading works as before by editing a file in VxAdmin's frontend.