### PR TITLE
[VxCentralScan / VxAdmin] Networking: Flesh out error cases, don't retry indefinitely

### DIFF
--- a/apps/admin/backend/src/network_cvr_transfer.ts
+++ b/apps/admin/backend/src/network_cvr_transfer.ts
@@ -133,6 +133,32 @@ export class NetworkCvrImportQueue {
   }
 }
 
+/**
+ * Whether the host can accept cast vote records in the given mode right now:
+ * not once results are official, and only in the mode its existing CVRs lock
+ * it to. Checked at registration and again at each transfer step, since the
+ * host's state can change between a scanner's heartbeats.
+ */
+export function checkCvrImportAllowed(
+  store: Store,
+  electionId: string,
+  isTestMode: boolean
+): Result<
+  void,
+  | { type: 'results-official' }
+  | { type: 'invalid-mode'; currentMode: 'test' | 'official' }
+> {
+  if (assertDefined(store.getElection(electionId)).isOfficialResults) {
+    return err({ type: 'results-official' });
+  }
+  const transferMode: CvrFileMode = isTestMode ? 'test' : 'official';
+  const currentMode = store.getCurrentCvrFileModeForElection(electionId);
+  if (currentMode !== 'unlocked' && transferMode !== currentMode) {
+    return err({ type: 'invalid-mode', currentMode });
+  }
+  return ok();
+}
+
 function checkScannerCompatibility(
   store: Store,
   input: { codeVersion: string; ballotHash: string }
@@ -185,14 +211,17 @@ export async function startCvrTransfer(
   }
   const { electionId } = compatibility.ok();
 
-  const transferMode: CvrFileMode = input.isTestMode ? 'test' : 'official';
-  const currentMode = store.getCurrentCvrFileModeForElection(electionId);
-  if (currentMode !== 'unlocked' && transferMode !== currentMode) {
-    return reject({ type: 'invalid-mode', currentMode });
-  }
-
   if (store.getNetworkCvrImportId(electionId, input.machineId, input.batchId)) {
     return ok({ alreadyComplete: true });
+  }
+
+  const importAllowed = checkCvrImportAllowed(
+    store,
+    electionId,
+    input.isTestMode
+  );
+  if (importAllowed.isErr()) {
+    return reject(importAllowed.err());
   }
 
   const transferDirectoryPath = getTransferDirectoryPath(
@@ -497,7 +526,18 @@ async function moveStagedTransfer({
   // back. All rows are inserted before any image file moves so a rollback
   // can't leave moved images behind.
   const moveResult = store.withTransaction(
-    (): Result<void, { subType: string }> => {
+    (): Result<void, FinishCvrTransferError> => {
+      // Re-checked inside the transaction so that a USB import or marking
+      // results official that landed since the transfer started is honored.
+      const importAllowed = checkCvrImportAllowed(
+        store,
+        electionId,
+        manifest.isTestMode
+      );
+      if (importAllowed.isErr()) {
+        return err(importAllowed.err());
+      }
+
       store.addScannerBatch({
         batchId: manifest.batchId,
         electionId,
@@ -540,7 +580,7 @@ async function moveStagedTransfer({
           adjudicationFlags: data.adjudicationFlags,
         });
         if (addResult.isErr()) {
-          return err({ subType: addResult.err().type });
+          return err({ type: 'import-failed', subType: addResult.err().type });
         }
         const { cvrId, isNew } = addResult.ok();
         inserted.push({ cvrId, isNew, ballotId, data });
@@ -586,15 +626,16 @@ async function moveStagedTransfer({
   );
 
   if (moveResult.isErr()) {
-    const { subType } = moveResult.err();
+    const error = moveResult.err();
+    const detail = error.type === 'import-failed' ? error.subType : error.type;
     logger.log(LogEventId.ImportCastVoteRecordsComplete, 'system', {
-      message: `Failed to import CVR transfer of batch ${manifest.batchId} from scanner ${manifest.machineId}: ${subType}.`,
+      message: `Failed to import CVR transfer of batch ${manifest.batchId} from scanner ${manifest.machineId}: ${detail}.`,
       disposition: 'failure',
       scannerMachineId: manifest.machineId,
       batchId: manifest.batchId,
-      error: subType,
+      error: detail,
     });
-    return err({ type: 'import-failed', subType });
+    return err(error);
   }
 
   await fs.rm(transferDirectoryPath, { recursive: true, force: true });

--- a/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
+++ b/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
@@ -415,6 +415,76 @@ test('startCvrTransfer enforces the test/official mode lock', async () => {
   ).toEqual(err({ type: 'invalid-mode', currentMode: 'test' }));
 });
 
+test('transfers are refused once results are marked official', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+
+  (await peerApiClient.startCvrTransfer(startInput(batch))).unsafeUnwrap();
+  for (const cvr of batch.cvrs) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+
+  // Results are marked official while the transfer is in flight
+  mockElectionManagerAuth(auth, electionDefinition.election);
+  await apiClient.markResultsOfficial();
+
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(err({ type: 'results-official' }));
+  expect(workspace.store.getCvrFiles(electionId)).toHaveLength(0);
+  expect(
+    await peerApiClient.startCvrTransfer(
+      startInput(batch, { batchId: 'another-batch' })
+    )
+  ).toEqual(err({ type: 'results-official' }));
+});
+
+test('finishCvrTransfer honors a mode lock that landed mid-transfer', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+
+  (await peerApiClient.startCvrTransfer(startInput(batch))).unsafeUnwrap();
+  for (const cvr of batch.cvrs) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+
+  // An official-mode import lands before the test-mode transfer finishes
+  workspace.store.addCastVoteRecordFileRecord({
+    id: 'official-import',
+    electionId,
+    isTestMode: false,
+    filename: 'official-export',
+    exportedTimestamp: new Date().toISOString(),
+    scannerIds: new Set(['CS-02']),
+    pollingPlaceIds: new Set(),
+    batchIds: [],
+    source: { type: 'usb', sha256Hash: 'test-hash' },
+  });
+
+  expect(
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).toEqual(err({ type: 'invalid-mode', currentMode: 'official' }));
+  // Nothing from the refused transfer was imported
+  expect(workspace.store.getCvrFiles(electionId)).toHaveLength(1);
+  expect(
+    workspace.store.getNetworkCvrImportId(electionId, SCANNER_ID, batch.batchId)
+  ).toBeUndefined();
+});
+
 test('upload endpoint rejects invalid requests', async () => {
   const { apiClient, auth, peerApiClient, peerServer } = buildTestEnvironment();
   await configureMachine(apiClient, auth, electionDefinition);

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -13,7 +13,11 @@ import {
 import { assertDefined, err, ok, range } from '@votingworks/basics';
 import { LogEventId } from '@votingworks/logging';
 import type { Result } from '@votingworks/basics';
-import { buildTestEnvironment, configureMachine } from '../test/app.js';
+import {
+  buildTestEnvironment,
+  configureMachine,
+  mockElectionManagerAuth,
+} from '../test/app.js';
 import { getCurrentTime } from './get_current_time.js';
 import {
   addMockCvrFileToStore,
@@ -244,6 +248,7 @@ test('registerScanner records the scanner and returns the host machine config', 
   expect(
     await peerApiClient.registerScanner({
       machineId: 'SCANNER-01',
+      isTestMode: true,
       codeVersion: 'dev',
       ballotHash: electionDefinition.ballotHash,
     })
@@ -262,6 +267,120 @@ test('registerScanner records the scanner and returns the host machine config', 
   ]);
 });
 
+test('registerScanner refuses a scanner once results are marked official', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition = readElectionGeneralDefinition();
+  await configureMachine(apiClient, auth, electionDefinition);
+  mockElectionManagerAuth(auth, electionDefinition.election);
+  await apiClient.markResultsOfficial();
+
+  expect(
+    await peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'dev',
+      ballotHash: electionDefinition.ballotHash,
+      isTestMode: true,
+    })
+  ).toEqual(err({ type: 'results-official' }));
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      registrationError: 'results-official',
+    }),
+  ]);
+});
+
+test('registerScanner refuses an official-mode scanner once test CVRs lock the mode', async () => {
+  const { peerApiClient, apiClient, auth, workspace, peerLogger } =
+    buildTestEnvironment();
+  const electionDefinition = readElectionGeneralDefinition();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  workspace.store.addCastVoteRecordFileRecord({
+    id: 'test-import',
+    electionId,
+    isTestMode: true,
+    filename: 'test-export',
+    exportedTimestamp: new Date().toISOString(),
+    scannerIds: new Set(['SCANNER-02']),
+    pollingPlaceIds: new Set(),
+    batchIds: [],
+    source: { type: 'usb', sha256Hash: 'test-hash' },
+  });
+
+  expect(
+    await peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'dev',
+      ballotHash: electionDefinition.ballotHash,
+      isTestMode: false,
+    })
+  ).toEqual(err({ type: 'invalid-mode', currentMode: 'test' }));
+  expect(peerLogger.log).toHaveBeenCalledWith(
+    LogEventId.AdminNetworkStatus,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      message: expect.stringContaining(
+        'tabulating test ballots and the scanner is in official ballot mode'
+      ),
+    })
+  );
+});
+
+test('registerScanner refuses a scanner in the other ballot mode once CVRs lock the mode', async () => {
+  const { peerApiClient, apiClient, auth, workspace } = buildTestEnvironment();
+  const electionDefinition = readElectionGeneralDefinition();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+
+  function register(isTestMode: boolean) {
+    return peerApiClient.registerScanner({
+      machineId: 'SCANNER-01',
+      codeVersion: 'dev',
+      ballotHash: electionDefinition.ballotHash,
+      isTestMode,
+    });
+  }
+
+  const registered = ok({
+    machineId: DEV_MACHINE_ID,
+    codeVersion: 'dev',
+  });
+  // With no CVRs loaded yet, a scanner in either mode registers
+  expect(await register(false)).toEqual(registered);
+  expect(await register(true)).toEqual(registered);
+
+  // An official import locks the mode
+  workspace.store.addCastVoteRecordFileRecord({
+    id: 'official-import',
+    electionId,
+    isTestMode: false,
+    filename: 'official-export',
+    exportedTimestamp: new Date().toISOString(),
+    scannerIds: new Set(['SCANNER-02']),
+    pollingPlaceIds: new Set(),
+    batchIds: [],
+    source: { type: 'usb', sha256Hash: 'test-hash' },
+  });
+  expect(await register(true)).toEqual(
+    err({ type: 'invalid-mode', currentMode: 'official' })
+  );
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      registrationError: 'invalid-mode',
+    }),
+  ]);
+  expect(await register(false)).toEqual(registered);
+  expect(workspace.store.getMachines()).toEqual([
+    expect.objectContaining({
+      machineId: 'SCANNER-01',
+      registrationError: null,
+    }),
+  ]);
+});
+
 test('registerScanner records a scanner configured for a different election with an error', async () => {
   const { peerApiClient, apiClient, auth, peerLogger, workspace } =
     buildTestEnvironment();
@@ -269,6 +388,7 @@ test('registerScanner records a scanner configured for a different election with
   expect(
     await peerApiClient.registerScanner({
       machineId: 'SCANNER-01',
+      isTestMode: true,
       codeVersion: 'dev',
       ballotHash: 'some-other-ballot-hash',
     })
@@ -296,6 +416,7 @@ test('registerScanner records an unconfigured scanner with an error', async () =
   expect(
     await peerApiClient.registerScanner({
       machineId: 'SCANNER-01',
+      isTestMode: true,
       codeVersion: 'dev',
     })
   ).toEqual(err({ type: 'scanner-unconfigured' }));
@@ -312,6 +433,7 @@ test('registerScanner records a scanner with an error when the host is unconfigu
   expect(
     await peerApiClient.registerScanner({
       machineId: 'SCANNER-01',
+      isTestMode: true,
       codeVersion: 'dev',
       ballotHash: readElectionGeneralDefinition().ballotHash,
     })
@@ -329,6 +451,7 @@ test('registerScanner records a scanner running an incompatible code version wit
   expect(
     await peerApiClient.registerScanner({
       machineId: 'SCANNER-01',
+      isTestMode: true,
       codeVersion: 'some-other-version',
     })
   ).toEqual(err({ type: 'code-version-mismatch' }));

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -44,6 +44,7 @@ import {
   getBallotImageMetadata,
 } from './util/adjudication.js';
 import {
+  checkCvrImportAllowed,
   finishCvrTransfer,
   NetworkCvrImportQueue,
   receiveCvrTransferUpload,
@@ -82,6 +83,7 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       codeVersion: string;
       ballotHash?: string;
       pollingPlaceId?: string;
+      isTestMode: boolean;
     }): Result<MachineConfig, RegisterScannerError> {
       const machineConfig = getMachineConfig();
 
@@ -136,16 +138,14 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
         );
       }
       const currentElectionId = store.getCurrentElectionId();
-      const hostBallotHash = currentElectionId
-        ? assertDefined(store.getElection(currentElectionId)).electionDefinition
-            .ballotHash
-        : undefined;
-      if (hostBallotHash === undefined) {
+      if (!currentElectionId) {
         return reject(
           { type: 'host-unconfigured' },
           'this host is not configured with an election.'
         );
       }
+      const hostBallotHash = assertDefined(store.getElection(currentElectionId))
+        .electionDefinition.ballotHash;
       if (input.ballotHash !== hostBallotHash) {
         return reject(
           { type: 'ballot-hash-mismatch' },
@@ -154,6 +154,27 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
             scannerBallotHash: input.ballotHash,
             hostBallotHash,
           }
+        );
+      }
+      // Refuse to register a scanner whose cast vote records this host could
+      // not accept, so the scanner shows the reason instead of sending
+      // batches into a refusal.
+      const importAllowed = checkCvrImportAllowed(
+        store,
+        currentElectionId,
+        input.isTestMode
+      );
+      if (importAllowed.isErr()) {
+        const error = importAllowed.err();
+        return reject(
+          error,
+          error.type === 'results-official'
+            ? 'results on this host have been marked official.'
+            : `this host is tabulating ${
+                error.currentMode
+              } ballots and the scanner is in ${
+                input.isTestMode ? 'test' : 'official'
+              } ballot mode.`
         );
       }
       debug('Scanner %s registered with host', input.machineId);

--- a/apps/admin/frontend/src/screens/tally/scanners_tab.test.tsx
+++ b/apps/admin/frontend/src/screens/tally/scanners_tab.test.tsx
@@ -92,9 +92,17 @@ test('renders scanners in error states with the rejection reason', async () => {
         machineId: 'CS-04',
         registrationError: 'host-unconfigured',
       }),
-      // Offline wins over a stale registration error
       mockScanner({
         machineId: 'CS-05',
+        registrationError: 'results-official',
+      }),
+      mockScanner({
+        machineId: 'CS-06',
+        registrationError: 'invalid-mode',
+      }),
+      // Offline wins over a stale registration error
+      mockScanner({
+        machineId: 'CS-07',
         registrationError: 'code-version-mismatch',
         status: Admin.ClientMachineStatus.Offline,
       }),
@@ -112,6 +120,8 @@ test('renders scanners in error states with the rejection reason', async () => {
     'CS-02— Different Election00Now',
     'CS-03— Scanner Not Configured00Now',
     'CS-04— VxAdmin Not Configured00Now',
-    'CS-05— Offline00Now',
+    'CS-05— Connected00Now',
+    'CS-06— Ballot Mode Mismatch00Now',
+    'CS-07— Offline00Now',
   ]);
 });

--- a/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
+++ b/apps/admin/frontend/src/screens/tally/scanners_tab.tsx
@@ -78,6 +78,16 @@ function ScannerStatus({ scanner }: { scanner: MachineRecord }): JSX.Element {
             <Icons.Warning color="warning" /> VxAdmin Not Configured
           </InlineStatus>
         );
+      // Results being official refuses the scanner's batches, not the
+      // scanner itself, so it still reads as connected here.
+      case 'results-official':
+        break;
+      case 'invalid-mode':
+        return (
+          <InlineStatus>
+            <Icons.Warning color="warning" /> Ballot Mode Mismatch
+          </InlineStatus>
+        );
       default:
         throwIllegalValue(registrationError);
     }

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -23,7 +23,11 @@ create table batches (
   error text,
   -- When this batch's cast vote records were successfully sent to a VxAdmin
   -- host over the network. Null until sent.
-  sent_to_admin_at text
+  sent_to_admin_at text,
+  -- Set when sending this batch to a VxAdmin host failed in a way that needs
+  -- operator attention. The batch is skipped (other batches keep sending)
+  -- until the operator retries it.
+  send_to_admin_error text
 ) strict;
 
 create index idx_batches_unsent_to_admin on batches (started_at)

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -218,6 +218,32 @@ test('unconfigure w/ ignoreBackupRequirement', async () => {
   });
 });
 
+test('retrySendBatchToAdmin clears a batch send failure', async () => {
+  const electionDefinition =
+    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
+
+  await withApp(async ({ apiClient, importer, store }) => {
+    importer.configure(
+      electionDefinition,
+      jurisdiction,
+      'test-election-package-hash'
+    );
+    store.setPollingPlaceId(anyPollingPlace(electionDefinition.election).id);
+
+    const batchId = store.addBatch();
+    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.finishBatch({ batchId });
+    store.setBatchSendToAdminError(batchId, 'sending failed');
+    expect(store.getBatch(batchId).sendToAdminError).toEqual('sending failed');
+    // A failed batch is skipped by the send queue
+    expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
+
+    await apiClient.retrySendBatchToAdmin({ batchId });
+    expect(store.getBatch(batchId).sendToAdminError).toBeUndefined();
+    expect(store.getNextBatchToSendToAdmin()?.id).toEqual(batchId);
+  });
+});
+
 test('clearing scanning data', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
@@ -352,12 +378,14 @@ test('getNetworkStatus reports the connection info from the store when networkin
     store.setNetworkConnectionInfo({
       status: 'online-host-detected',
       hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
     });
     expect(await apiClient.getNetworkStatus()).toEqual({
       isEnabled: true,
       connection: {
         status: 'online-host-detected',
         hostMachineId: '0002',
+        hostAddress: 'http://169.254.10.20:3002',
       },
     });
   });

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -129,6 +129,14 @@ function buildApi({
       );
     },
 
+    async retrySendBatchToAdmin({ batchId }: { batchId: string }) {
+      workspace.store.setBatchSendToAdminError(batchId, null);
+      await logger.logAsCurrentRole(LogEventId.CentralScanNetworkStatus, {
+        message: `User retried sending batch ${batchId} to VxAdmin.`,
+        batchId,
+      });
+    },
+
     async deleteBatch({ batchId }: { batchId: string }) {
       const numberOfBallotsInBatch = workspace.store
         .getBatches()

--- a/apps/central-scan/backend/src/cvr_sync.test.ts
+++ b/apps/central-scan/backend/src/cvr_sync.test.ts
@@ -349,12 +349,17 @@ test('a refusal at start is retried rather than failing the batch', async () => 
   expect(store.getBatch(batchId).isSendingToAdmin).toEqual(true);
 });
 
-test('repeated transient failures back off, then mark the batch failed', async () => {
+test('repeated transient failures back off, then mark the batch failed and move on', async () => {
   const store = buildStore();
   const batchId = addFinishedBatch(store);
+  const nextBatchId = addFinishedBatch(store);
   setRegistered(store);
   const mockClient = createMockHostApiClient();
-  mockClient.startCvrTransfer.mockRejectedValue(new Error('ECONNREFUSED'));
+  mockClient.startCvrTransfer.mockImplementation((input) =>
+    input.batchId === batchId
+      ? Promise.reject(new Error('ECONNREFUSED'))
+      : Promise.resolve(ok({ alreadyComplete: true }))
+  );
   mockUploadResponses();
 
   startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
@@ -364,15 +369,18 @@ test('repeated transient failures back off, then mark the batch failed', async (
     await advancePollingInterval();
   }
 
-  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(5);
+  expect(
+    mockClient.startCvrTransfer.mock.calls.map((call) => call[0].batchId)
+  ).toEqual([batchId, batchId, batchId, batchId, batchId, nextBatchId]);
   expect(store.getBatch(batchId).sendToAdminError).toContain(
     'sending failed 5 times in a row'
   );
-  // The failed batch is no longer in the send queue
+  // Once the batch failed out, the next batch sent without waiting
+  expect(store.getBatch(nextBatchId).sentToAdminAt).toBeDefined();
   expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
 });
 
-test('a batch waiting to retry stays sending and is passed over until due', async () => {
+test('a batch waiting to retry stays sending until it succeeds', async () => {
   const store = buildStore();
   const batchId = addFinishedBatch(store);
   setRegistered(store);
@@ -384,8 +392,6 @@ test('a batch waiting to retry stays sending and is passed over until due', asyn
   await advancePollingInterval();
   expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(1);
   expect(store.getBatch(batchId).isSendingToAdmin).toEqual(true);
-  // Not due again yet
-  expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
 
   mockClient.startCvrTransfer.mockResolvedValue(ok({ alreadyComplete: true }));
   for (let i = 0; i < 5; i += 1) {
@@ -417,7 +423,7 @@ test('does not attempt sends while disconnected and forgets pending retries', as
   expect(store.getBatch(batchId).sendToAdminError).toBeUndefined();
 });
 
-test('a batch waiting to retry does not delay the batches behind it', async () => {
+test('a batch waiting to retry holds the batches behind it until it sends', async () => {
   const store = buildStore();
   const flakyBatchId = addFinishedBatch(store);
   const nextBatchId = addFinishedBatch(store);
@@ -440,20 +446,22 @@ test('a batch waiting to retry does not delay the batches behind it', async () =
   ).toEqual([flakyBatchId, flakyBatchId]);
   expect(store.getBatch(flakyBatchId).isSendingToAdmin).toEqual(true);
 
-  // While the flaky batch waits out its backoff, the next batch sends
+  // While the flaky batch waits out its backoff, nothing is sent
   await advancePollingInterval();
   expect(
     mockClient.startCvrTransfer.mock.calls.map((call) => call[0].batchId)
-  ).toEqual([flakyBatchId, flakyBatchId, nextBatchId]);
-  expect(store.getBatch(nextBatchId).sentToAdminAt).toBeDefined();
+  ).toEqual([flakyBatchId, flakyBatchId]);
+  expect(store.getBatch(nextBatchId).sentToAdminAt).toBeUndefined();
   expect(store.getBatch(flakyBatchId).isSendingToAdmin).toEqual(true);
 
-  // Once its backoff passes, the first batch is tried again
+  // Once its backoff passes, the flaky batch is tried again and succeeds, and
+  // the next batch follows on the next pass
   mockClient.startCvrTransfer.mockResolvedValue(ok({ alreadyComplete: true }));
-  for (let i = 0; i < 3; i += 1) {
-    await advancePollingInterval();
-  }
+  await advancePollingInterval();
   expect(store.getBatch(flakyBatchId).sentToAdminAt).toBeDefined();
+  expect(store.getBatch(nextBatchId).sentToAdminAt).toBeUndefined();
+  await advancePollingInterval();
+  expect(store.getBatch(nextBatchId).sentToAdminAt).toBeDefined();
 });
 
 test('an unexpected error while sending is retried like a transient failure', async () => {

--- a/apps/central-scan/backend/src/cvr_sync.test.ts
+++ b/apps/central-scan/backend/src/cvr_sync.test.ts
@@ -10,7 +10,10 @@ import {
 import { randomUUID as uuid } from 'node:crypto';
 import { err, ok } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
-import { NETWORK_POLLING_INTERVAL_MS } from '@votingworks/networking';
+import {
+  FinishCvrTransferError,
+  NETWORK_POLLING_INTERVAL_MS,
+} from '@votingworks/networking';
 import { getEntries, openZip } from '@votingworks/utils';
 import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
@@ -205,6 +208,14 @@ async function waitForFailure(
   );
 }
 
+/** The sole batch is neither sent nor failed and is still being sent (awaiting a retry). */
+function expectAwaitingRetry(store: Store): void {
+  const [batch] = store.getBatches();
+  expect(batch.sentToAdminAt).toBeUndefined();
+  expect(batch.sendToAdminError).toBeUndefined();
+  expect(batch.isSendingToAdmin).toEqual(true);
+}
+
 async function advancePollingInterval(): Promise<void> {
   await vi.advanceTimersByTimeAsync(0);
   await vi.advanceTimersByTimeAsync(NETWORK_POLLING_INTERVAL_MS);
@@ -318,13 +329,14 @@ test('marks a batch sent without uploading when the host already has it', async 
   expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
 });
 
-test('retries on the next pass when the host refuses the transfer', async () => {
+test('a refusal at start is retried rather than failing the batch', async () => {
   const store = buildStore();
-  addFinishedBatch(store);
+  const batchId = addFinishedBatch(store);
   setRegistered(store);
   const mockClient = createMockHostApiClient();
+  // The heartbeat detects the same conditions and pauses sending itself
   mockClient.startCvrTransfer.mockResolvedValue(
-    err({ type: 'ballot-hash-mismatch' })
+    err({ type: 'invalid-mode', currentMode: 'official' })
   );
   mockUploadResponses();
 
@@ -332,10 +344,154 @@ test('retries on the next pass when the host refuses the transfer', async () => 
   startCvrSync({ logger, store });
   await advancePollingInterval();
   await waitForFailure(logger, 'start');
-  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
 
+  expectAwaitingRetry(store);
+  expect(store.getBatch(batchId).isSendingToAdmin).toEqual(true);
+});
+
+test('repeated transient failures back off, then mark the batch failed', async () => {
+  const store = buildStore();
+  const batchId = addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockRejectedValue(new Error('ECONNREFUSED'));
+  mockUploadResponses();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  // Attempts are spaced by an exponential backoff; advance well past the
+  // point where the failure threshold is reached.
+  for (let i = 0; i < 40; i += 1) {
+    await advancePollingInterval();
+  }
+
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(5);
+  expect(store.getBatch(batchId).sendToAdminError).toContain(
+    'sending failed 5 times in a row'
+  );
+  // The failed batch is no longer in the send queue
+  expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
+});
+
+test('a batch waiting to retry stays sending and is passed over until due', async () => {
+  const store = buildStore();
+  const batchId = addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockRejectedValue(new Error('ECONNREFUSED'));
+  mockUploadResponses();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
   await advancePollingInterval();
-  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(2);
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(1);
+  expect(store.getBatch(batchId).isSendingToAdmin).toEqual(true);
+  // Not due again yet
+  expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
+
+  mockClient.startCvrTransfer.mockResolvedValue(ok({ alreadyComplete: true }));
+  for (let i = 0; i < 5; i += 1) {
+    await advancePollingInterval();
+  }
+  expect(store.getBatch(batchId).sentToAdminAt).toBeDefined();
+  expect(store.getBatch(batchId).isSendingToAdmin).toBeUndefined();
+});
+
+test('does not attempt sends while disconnected and forgets pending retries', async () => {
+  const store = buildStore();
+  const batchId = addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockRejectedValue(new Error('ECONNREFUSED'));
+  mockUploadResponses();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getBatch(batchId).isSendingToAdmin).toEqual(true);
+
+  store.setNetworkConnectionInfo({ status: 'offline' });
+  for (let i = 0; i < 3; i += 1) {
+    await advancePollingInterval();
+  }
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(1);
+  // Attempts are forgotten while disconnected; sending starts over on reconnect
+  expect(store.getBatch(batchId).isSendingToAdmin).toBeUndefined();
+  expect(store.getBatch(batchId).sendToAdminError).toBeUndefined();
+});
+
+test('a batch waiting to retry does not delay the batches behind it', async () => {
+  const store = buildStore();
+  const flakyBatchId = addFinishedBatch(store);
+  const nextBatchId = addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockImplementation(({ batchId }) =>
+    batchId === flakyBatchId
+      ? Promise.reject(new Error('ECONNRESET'))
+      : Promise.resolve(ok({ alreadyComplete: true }))
+  );
+  mockUploadResponses();
+
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  // The first backoff (2s) is one polling interval, so the flaky batch gets a
+  // second attempt before its backoff grows past the interval
+  await advancePollingInterval();
+  await advancePollingInterval();
+  expect(
+    mockClient.startCvrTransfer.mock.calls.map((call) => call[0].batchId)
+  ).toEqual([flakyBatchId, flakyBatchId]);
+  expect(store.getBatch(flakyBatchId).isSendingToAdmin).toEqual(true);
+
+  // While the flaky batch waits out its backoff, the next batch sends
+  await advancePollingInterval();
+  expect(
+    mockClient.startCvrTransfer.mock.calls.map((call) => call[0].batchId)
+  ).toEqual([flakyBatchId, flakyBatchId, nextBatchId]);
+  expect(store.getBatch(nextBatchId).sentToAdminAt).toBeDefined();
+  expect(store.getBatch(flakyBatchId).isSendingToAdmin).toEqual(true);
+
+  // Once its backoff passes, the first batch is tried again
+  mockClient.startCvrTransfer.mockResolvedValue(ok({ alreadyComplete: true }));
+  for (let i = 0; i < 3; i += 1) {
+    await advancePollingInterval();
+  }
+  expect(store.getBatch(flakyBatchId).sentToAdminAt).toBeDefined();
+});
+
+test('an unexpected error while sending is retried like a transient failure', async () => {
+  const store = buildStore();
+  const batchId = addFinishedBatch(store);
+  setRegistered(store);
+  const mockClient = createMockHostApiClient();
+  mockClient.startCvrTransfer.mockResolvedValue(ok({ alreadyComplete: true }));
+  mockUploadResponses();
+  // Blow up inside sendBatchToAdmin, outside of anything it classifies itself
+  vi.spyOn(store, 'getTestMode').mockImplementationOnce(() => {
+    throw new Error('disk on fire');
+  });
+
+  const logger = mockBaseLogger({ fn: vi.fn });
+  startCvrSync({ logger, store });
+  await advancePollingInterval();
+
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.CentralScanNetworkStatus,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      batchId,
+      message: expect.stringContaining(
+        'failed unexpectedly: Error: disk on fire'
+      ),
+      stack: expect.stringContaining('disk on fire'),
+    })
+  );
+  // Counted as one transient failure: still sending, not failed
+  expectAwaitingRetry(store);
+
+  // The next attempt (after the backoff) succeeds
+  for (let i = 0; i < 3; i += 1) {
+    await advancePollingInterval();
+  }
+  expect(store.getBatch(batchId).sentToAdminAt).toBeDefined();
 });
 
 test('retries on the next pass when an upload fails', async () => {
@@ -351,7 +507,7 @@ test('retries on the next pass when an upload fails', async () => {
   await waitForFailure(logger, 'upload');
 
   expect(mockClient.finishCvrTransfer).not.toHaveBeenCalled();
-  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+  expectAwaitingRetry(store);
 });
 
 test('retries on the next pass when the host is unreachable', async () => {
@@ -366,29 +522,81 @@ test('retries on the next pass when the host is unreachable', async () => {
   startCvrSync({ logger, store });
   await advancePollingInterval();
   await waitForFailure(logger, 'start');
-  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+  expectAwaitingRetry(store);
 });
 
-test('does not mark a batch sent when finish fails', async () => {
+test.each<FinishCvrTransferError>([
+  // Re-sending on the next pass recovers from these
+  { type: 'transfer-not-found' },
+  { type: 'sheet-count-mismatch', expected: 1, received: 0 },
+  // The heartbeat detects these host state changes and pauses sending itself
+  { type: 'results-official' },
+  { type: 'invalid-mode', currentMode: 'official' },
+])(
+  'does not mark a batch sent or failed when finish fails with $type',
+  async (error) => {
+    const store = buildStore();
+    addFinishedBatch(store);
+    setRegistered(store);
+    const mockClient = createMockHostApiClient();
+    mockClient.finishCvrTransfer.mockResolvedValue(err(error));
+    mockUploadResponses();
+
+    const logger = mockBaseLogger({ fn: vi.fn });
+    startCvrSync({ logger, store });
+    await advancePollingInterval();
+    await waitForFailure(logger, 'finish');
+
+    expectAwaitingRetry(store);
+  }
+);
+
+test('a failed import marks the batch failed and skips it, sending the next batch', async () => {
   const store = buildStore();
-  addFinishedBatch(store);
+  const failingBatchId = addFinishedBatch(store);
+  const nextBatchId = addFinishedBatch(store);
   setRegistered(store);
   const mockClient = createMockHostApiClient();
   mockClient.finishCvrTransfer.mockResolvedValue(
-    err({
-      type: 'sheet-count-mismatch',
-      expected: 1,
-      received: 0,
-    })
+    err({ type: 'import-failed', subType: 'invalid-cast-vote-record' })
   );
   mockUploadResponses();
 
-  const logger = mockBaseLogger({ fn: vi.fn });
-  startCvrSync({ logger, store });
+  startCvrSync({ logger: mockBaseLogger({ fn: vi.fn }), store });
   await advancePollingInterval();
-  await waitForFailure(logger, 'finish');
+  await vi.waitFor(
+    () =>
+      expect(store.getBatch(failingBatchId).sendToAdminError).toContain(
+        'could not import'
+      ),
+    { timeout: 30_000 }
+  );
+  expect(mockClient.startCvrTransfer.mock.calls[0][0].batchId).toEqual(
+    failingBatchId
+  );
 
-  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+  // The failed batch is skipped and the next batch sends
+  mockClient.startCvrTransfer.mockResolvedValue(ok({ alreadyComplete: true }));
+  await advancePollingInterval();
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(2);
+  expect(mockClient.startCvrTransfer.mock.calls[1][0].batchId).toEqual(
+    nextBatchId
+  );
+  expect(store.getBatch(nextBatchId).sentToAdminAt).toBeDefined();
+  expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
+
+  // Nothing more is attempted for the failed batch until an operator retries
+  await advancePollingInterval();
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(2);
+
+  // Manual retry puts it back in the queue
+  store.setBatchSendToAdminError(failingBatchId, null);
+  await advancePollingInterval();
+  expect(mockClient.startCvrTransfer).toHaveBeenCalledTimes(3);
+  expect(mockClient.startCvrTransfer.mock.calls[2][0].batchId).toEqual(
+    failingBatchId
+  );
+  expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
 });
 
 test('does not mark a batch sent when finish is unreachable', async () => {
@@ -404,7 +612,7 @@ test('does not mark a batch sent when finish is unreachable', async () => {
   await advancePollingInterval();
   await waitForFailure(logger, 'finish');
 
-  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+  expectAwaitingRetry(store);
 });
 
 test('retries on the next pass when an upload cannot reach the host', async () => {
@@ -420,12 +628,12 @@ test('retries on the next pass when an upload cannot reach the host', async () =
   await waitForFailure(logger, 'upload');
 
   expect(mockClient.finishCvrTransfer).not.toHaveBeenCalled();
-  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+  expectAwaitingRetry(store);
 });
 
-test('retries on the next pass when a cast vote record cannot be built', async () => {
+test('marks the batch failed when a cast vote record cannot be built', async () => {
   const store = buildStore();
-  addFinishedBatch(store);
+  const batchId = addFinishedBatch(store);
   setRegistered(store);
   const mockClient = createMockHostApiClient();
   const fetchMock = mockUploadResponses();
@@ -438,7 +646,9 @@ test('retries on the next pass when a cast vote record cannot be built', async (
 
   expect(fetchMock).not.toHaveBeenCalled();
   expect(mockClient.finishCvrTransfer).not.toHaveBeenCalled();
-  expect(store.getNextBatchToSendToAdmin()).toBeDefined();
+  // Bad local data won't fix itself on retry, so the batch is set aside
+  expect(store.getBatch(batchId).sendToAdminError).toContain('could not build');
+  expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
 });
 
 test('does nothing when registered with no batches to send', async () => {

--- a/apps/central-scan/backend/src/cvr_sync.ts
+++ b/apps/central-scan/backend/src/cvr_sync.ts
@@ -128,23 +128,13 @@ async function sendBatchToAdmin({
   if (startResult.isErr()) {
     const errorType = startResult.err().type;
     logFailure('start', `host refused transfer (${errorType}).`);
-    switch (errorType) {
-      // These won't resolve without operator action.
-      case 'ballot-hash-mismatch':
-      case 'code-version-mismatch':
-      case 'invalid-mode':
-        return {
-          type: 'fatal-failure',
-          detail: `VxAdmin refused the transfer: ${errorType}`,
-        };
-      // The host may simply not be configured yet.
-      case 'host-unconfigured':
-      case 'scanner-unconfigured':
-        return { type: 'transient-failure', detail: errorType };
-      // istanbul ignore next -- compile-time check
-      default:
-        return throwIllegalValue(errorType);
-    }
+    // The heartbeat registers with the same checks, so any refusal here can
+    // only be racing a connection status change that will pause sending and
+    // surface the condition itself.
+    return {
+      type: 'transient-failure',
+      detail: `VxAdmin refused the transfer (${errorType})`,
+    };
   }
   if (startResult.ok().alreadyComplete) {
     store.setBatchSentToAdmin(batch.id);
@@ -225,9 +215,12 @@ async function sendBatchToAdmin({
           type: 'fatal-failure',
           detail: 'VxAdmin could not import the batch',
         };
-      // Recoverable by re-sending on the next pass.
+      // Recoverable by re-sending on the next pass, or (for a host-state
+      // refusal) racing a connection status change, as at start.
       case 'transfer-not-found':
       case 'sheet-count-mismatch':
+      case 'results-official':
+      case 'invalid-mode':
         return { type: 'transient-failure', detail: errorType };
       default:
         return throwIllegalValue(errorType);
@@ -278,10 +271,7 @@ export function startCvrSync({
       isSending = true;
       try {
         const connection = store.getNetworkConnectionInfo();
-        if (
-          connection.status !== 'online-host-detected' ||
-          !connection.hostAddress
-        ) {
+        if (connection.status !== 'online-host-detected') {
           store.clearSendToAdminAttempts();
           return;
         }

--- a/apps/central-scan/backend/src/cvr_sync.ts
+++ b/apps/central-scan/backend/src/cvr_sync.ts
@@ -1,6 +1,11 @@
 import { Buffer } from 'node:buffer';
 import * as grout from '@votingworks/grout';
-import { assertDefined, iter, throwIllegalValue } from '@votingworks/basics';
+import {
+  assertDefined,
+  iter,
+  Optional,
+  throwIllegalValue,
+} from '@votingworks/basics';
 import type { ReadableFile } from '@votingworks/auth';
 import {
   AcceptedSheet,
@@ -30,7 +35,8 @@ export const CVR_TRANSFER_REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * After this many consecutive transient failures sending the same batch, the
- * batch is marked failed and skipped until an operator retries it.
+ * batch is marked failed and sending moves on to the next batch. The failed
+ * batch is not tried again until an operator retries it.
  */
 export const MAX_CONSECUTIVE_SEND_FAILURES = 5;
 
@@ -264,6 +270,23 @@ export function startCvrSync({
     });
   }
 
+  /**
+   * The batch being retried after transient failures, with its consecutive
+   * failure count and the earliest time to try again. Batches send in order,
+   * so there is at most one. In memory only: after a restart, sending simply
+   * starts over.
+   */
+  let retry: Optional<{
+    batchId: string;
+    failures: number;
+    nextAttemptAt: number;
+  }>;
+
+  function stopSending(): void {
+    retry = undefined;
+    store.setSendingToAdminBatchId(undefined);
+  }
+
   process.nextTick(() => {
     setInterval(async () => {
       // @coverage-exclude: re-entrancy guard
@@ -272,14 +295,23 @@ export function startCvrSync({
       try {
         const connection = store.getNetworkConnectionInfo();
         if (connection.status !== 'online-host-detected') {
-          store.clearSendToAdminAttempts();
+          stopSending();
           return;
         }
-        // Failed batches and batches still waiting out a retry backoff are
-        // excluded by the store, so neither holds up the batches behind it.
+        // Batches send in order; one that has failed out is passed over until
+        // an operator retries it.
         const batch = store.getNextBatchToSendToAdmin();
-        if (!batch) return;
-        store.startSendingBatchToAdmin(batch.id);
+        if (!batch) {
+          stopSending();
+          return;
+        }
+        if (retry?.batchId !== batch.id) {
+          // A different batch is up (the last one sent, failed out or was
+          // deleted), so it starts with a clean slate.
+          retry = undefined;
+        }
+        if (retry && Date.now() < retry.nextAttemptAt) return;
+        store.setSendingToAdminBatchId(batch.id);
         let outcome: SendBatchOutcome;
         try {
           outcome = await sendBatchToAdmin({
@@ -305,25 +337,31 @@ export function startCvrSync({
         }
         switch (outcome.type) {
           case 'sent':
+            stopSending();
             break;
           case 'fatal-failure':
             markBatchFailed(batch.id, outcome.detail);
+            stopSending();
             break;
           case 'transient-failure': {
-            const failures = store.recordBatchSendToAdminFailure(batch.id);
+            const failures = (retry?.failures ?? 0) + 1;
             if (failures >= MAX_CONSECUTIVE_SEND_FAILURES) {
               markBatchFailed(
                 batch.id,
                 `sending failed ${failures} times in a row (${outcome.detail})`
               );
+              stopSending();
             } else {
               // Exponential backoff: 2s after the first failure, then 4s, 8s,
-              // 16s, …, capped at MAX_SEND_RETRY_DELAY_MS.
-              store.deferBatchSendToAdmin(
-                batch.id,
-                Date.now() +
-                  Math.min(2 ** failures * 1000, MAX_SEND_RETRY_DELAY_MS)
-              );
+              // 16s, …, capped at MAX_SEND_RETRY_DELAY_MS. The batch stays
+              // "sending" in the meantime.
+              retry = {
+                batchId: batch.id,
+                failures,
+                nextAttemptAt:
+                  Date.now() +
+                  Math.min(2 ** failures * 1000, MAX_SEND_RETRY_DELAY_MS),
+              };
             }
             break;
           }

--- a/apps/central-scan/backend/src/cvr_sync.ts
+++ b/apps/central-scan/backend/src/cvr_sync.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import * as grout from '@votingworks/grout';
-import { assertDefined, iter } from '@votingworks/basics';
+import { assertDefined, iter, throwIllegalValue } from '@votingworks/basics';
 import type { ReadableFile } from '@votingworks/auth';
 import {
   AcceptedSheet,
@@ -28,6 +28,23 @@ const debug = makeDebug('scan:cvr-sync');
  */
 export const CVR_TRANSFER_REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
 
+/**
+ * After this many consecutive transient failures sending the same batch, the
+ * batch is marked failed and skipped until an operator retries it.
+ */
+export const MAX_CONSECUTIVE_SEND_FAILURES = 5;
+
+/** Longest delay between transient-failure retries. */
+export const MAX_SEND_RETRY_DELAY_MS = 60 * 1000;
+
+/** The result of one attempt to send a batch. */
+export type SendBatchOutcome =
+  | { type: 'sent' }
+  /** Likely to resolve on its own (e.g. host unreachable); retried with backoff. */
+  | { type: 'transient-failure'; detail: string }
+  /** Needs operator attention; the batch is skipped until manually retried. */
+  | { type: 'fatal-failure'; detail: string };
+
 async function readableFileToBuffer(file: ReadableFile): Promise<Buffer> {
   const chunks: Buffer[] = [];
   for await (const chunk of file.open()) {
@@ -52,12 +69,10 @@ async function sendBatchToAdmin({
   logger: BaseLogger;
   hostAddress: string;
   batch: BatchInfo;
-}): Promise<void> {
+}): Promise<SendBatchOutcome> {
   const { machineId, codeVersion } = getMachineConfig();
-  const electionRecord = store.getElectionRecord();
-  // @coverage-exclude: batches can't exist while unconfigured
-  if (!electionRecord) return;
-  const { electionDefinition } = electionRecord;
+  // Batches can't exist while unconfigured
+  const { electionDefinition } = assertDefined(store.getElectionRecord());
 
   const systemSettings = assertDefined(store.getSystemSettings());
   const scannerState: ScannerStateUnchangedByExport = {
@@ -108,11 +123,28 @@ async function sendBatchToAdmin({
     });
   } catch (error) {
     logFailure('start', `host unreachable (${error}).`);
-    return;
+    return { type: 'transient-failure', detail: 'host unreachable' };
   }
   if (startResult.isErr()) {
-    logFailure('start', `host refused transfer (${startResult.err().type}).`);
-    return;
+    const errorType = startResult.err().type;
+    logFailure('start', `host refused transfer (${errorType}).`);
+    switch (errorType) {
+      // These won't resolve without operator action.
+      case 'ballot-hash-mismatch':
+      case 'code-version-mismatch':
+      case 'invalid-mode':
+        return {
+          type: 'fatal-failure',
+          detail: `VxAdmin refused the transfer: ${errorType}`,
+        };
+      // The host may simply not be configured yet.
+      case 'host-unconfigured':
+      case 'scanner-unconfigured':
+        return { type: 'transient-failure', detail: errorType };
+      // istanbul ignore next -- compile-time check
+      default:
+        return throwIllegalValue(errorType);
+    }
   }
   if (startResult.ok().alreadyComplete) {
     store.setBatchSentToAdmin(batch.id);
@@ -120,7 +152,7 @@ async function sendBatchToAdmin({
       message: `Batch ${batch.id} was already fully imported by VxAdmin.`,
       batchId: batch.id,
     });
-    return;
+    return { type: 'sent' };
   }
 
   for (const sheet of sheets) {
@@ -132,7 +164,10 @@ async function sendBatchToAdmin({
           buildResult.err().type
         }).`
       );
-      return;
+      return {
+        type: 'fatal-failure',
+        detail: `could not build a cast vote record for sheet ${sheet.id}`,
+      };
     }
     const { castVoteRecordId, files } = buildResult.ok();
 
@@ -156,14 +191,17 @@ async function sendBatchToAdmin({
       );
     } catch (error) {
       logFailure('upload', `host unreachable (${error}).`);
-      return;
+      return { type: 'transient-failure', detail: 'host unreachable' };
     }
     if (response.status !== 200) {
       logFailure(
         'upload',
         `host rejected cast vote record ${castVoteRecordId} (status ${response.status}).`
       );
-      return;
+      return {
+        type: 'transient-failure',
+        detail: `VxAdmin rejected a cast vote record (status ${response.status})`,
+      };
     }
   }
 
@@ -175,14 +213,25 @@ async function sendBatchToAdmin({
     });
   } catch (error) {
     logFailure('finish', `host unreachable (${error}).`);
-    return;
+    return { type: 'transient-failure', detail: 'host unreachable' };
   }
   if (finishResult.isErr()) {
-    logFailure(
-      'finish',
-      `host could not complete the import (${finishResult.err().type}).`
-    );
-    return;
+    const errorType = finishResult.err().type;
+    logFailure('finish', `host could not complete the import (${errorType}).`);
+    switch (errorType) {
+      // Bad data won't fix itself on retry.
+      case 'import-failed':
+        return {
+          type: 'fatal-failure',
+          detail: 'VxAdmin could not import the batch',
+        };
+      // Recoverable by re-sending on the next pass.
+      case 'transfer-not-found':
+      case 'sheet-count-mismatch':
+        return { type: 'transient-failure', detail: errorType };
+      default:
+        return throwIllegalValue(errorType);
+    }
   }
 
   store.setBatchSentToAdmin(batch.id);
@@ -194,12 +243,14 @@ async function sendBatchToAdmin({
     batchId: batch.id,
     cvrCount: finishResult.ok().cvrCount,
   });
+  return { type: 'sent' };
 }
 
 /**
  * Starts the CVR sync loop: while the scanner is registered with a VxAdmin
  * host, sends completed batches' cast vote records to it, oldest first, one
- * batch at a time.
+ * batch in flight at a time. A batch waiting to retry after a transient
+ * failure, or marked failed, doesn't hold up the batches behind it.
  */
 export function startCvrSync({
   store,
@@ -210,6 +261,15 @@ export function startCvrSync({
 }): void {
   debug('Starting CVR sync loop');
   let isSending = false;
+
+  function markBatchFailed(batchId: string, detail: string): void {
+    store.setBatchSendToAdminError(batchId, detail);
+    logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
+      message: `Sending batch ${batchId} to VxAdmin failed and needs attention: ${detail}. It will not be sent again until retried; other batches continue to send.`,
+      disposition: 'failure',
+      batchId,
+    });
+  }
 
   process.nextTick(() => {
     setInterval(async () => {
@@ -222,19 +282,64 @@ export function startCvrSync({
           connection.status !== 'online-host-detected' ||
           !connection.hostAddress
         ) {
+          store.clearSendToAdminAttempts();
           return;
         }
+        // Failed batches and batches still waiting out a retry backoff are
+        // excluded by the store, so neither holds up the batches behind it.
         const batch = store.getNextBatchToSendToAdmin();
         if (!batch) return;
-        await sendBatchToAdmin({
-          store,
-          logger,
-          hostAddress: connection.hostAddress,
-          batch,
-        });
-      } catch (error) {
-        // @coverage-exclude: defensive
-        debug('Error in CVR sync loop: %s', error);
+        store.startSendingBatchToAdmin(batch.id);
+        let outcome: SendBatchOutcome;
+        try {
+          outcome = await sendBatchToAdmin({
+            store,
+            logger,
+            hostAddress: connection.hostAddress,
+            batch,
+          });
+        } catch (error) {
+          // Anything sendBatchToAdmin didn't classify itself (e.g. a failure
+          // reading a sheet image) goes through the same retry flow as a
+          // transient failure, so it's bounded and ends in "Send failed".
+          logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
+            message: `Sending batch ${batch.id} to VxAdmin failed unexpectedly: ${error}`,
+            disposition: 'failure',
+            batchId: batch.id,
+            stack: (error as Partial<Error>).stack,
+          });
+          outcome = {
+            type: 'transient-failure',
+            detail: `unexpected error (${error})`,
+          };
+        }
+        switch (outcome.type) {
+          case 'sent':
+            break;
+          case 'fatal-failure':
+            markBatchFailed(batch.id, outcome.detail);
+            break;
+          case 'transient-failure': {
+            const failures = store.recordBatchSendToAdminFailure(batch.id);
+            if (failures >= MAX_CONSECUTIVE_SEND_FAILURES) {
+              markBatchFailed(
+                batch.id,
+                `sending failed ${failures} times in a row (${outcome.detail})`
+              );
+            } else {
+              // Exponential backoff: 2s after the first failure, then 4s, 8s,
+              // 16s, …, capped at MAX_SEND_RETRY_DELAY_MS.
+              store.deferBatchSendToAdmin(
+                batch.id,
+                Date.now() +
+                  Math.min(2 ** failures * 1000, MAX_SEND_RETRY_DELAY_MS)
+              );
+            }
+            break;
+          }
+          default:
+            throwIllegalValue(outcome);
+        }
       } finally {
         isSending = false;
       }

--- a/apps/central-scan/backend/src/networking.test.ts
+++ b/apps/central-scan/backend/src/networking.test.ts
@@ -213,6 +213,7 @@ test('reports machine-unconfigured when this scanner has no election', async () 
     machineId: DEV_MACHINE_ID,
     codeVersion: 'dev',
     ballotHash: undefined,
+    isTestMode: true,
   });
 });
 
@@ -264,7 +265,45 @@ test('reports host-detected when everything matches', async () => {
     machineId: DEV_MACHINE_ID,
     codeVersion: 'dev',
     ballotHash: readElectionGeneralDefinition().ballotHash,
+    isTestMode: true,
   });
+});
+
+test('reports results-official when the host has marked its results official', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockResolvedValue(
+    err({ type: 'results-official' })
+  );
+  const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-results-official',
+    hostMachineId: '0002',
+  });
+});
+
+test('reports invalid-mode, with the host mode, when the host is locked to the other ballot mode', async () => {
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockResolvedValue(
+    err({ type: 'invalid-mode', currentMode: 'official' })
+  );
+  const store = Store.memoryStore();
+  configureStore(store, readElectionGeneralDefinition());
+  store.setTestMode(true);
+  startScannerNetworking({ logger: mockBaseLogger({ fn: vi.fn }), store });
+  await advancePollingInterval();
+  expect(store.getNetworkConnectionInfo()).toEqual({
+    status: 'online-invalid-mode',
+    hostMachineId: '0002',
+    hostCvrFileMode: 'official',
+  });
+  expect(mockClient.registerScanner).toHaveBeenCalledWith(
+    expect.objectContaining({ isTestMode: true })
+  );
 });
 
 test('logs status transitions and returns to offline when the interface goes down', async () => {

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -13,25 +13,33 @@ import {
 import makeDebug from 'debug';
 import { getMachineConfig } from './machine_config.js';
 import { Store } from './store.js';
-import { NetworkConnectionInfo, NetworkConnectionStatus } from './types.js';
+import { NetworkConnectionInfo } from './types.js';
 
 const debug = makeDebug('scan:networking');
 
-function statusForRegistrationError(
-  error: RegisterScannerError
-): NetworkConnectionStatus {
-  const errorType = error.type;
-  switch (errorType) {
+function connectionInfoForRegistrationError(
+  error: RegisterScannerError,
+  hostMachineId: string
+): NetworkConnectionInfo {
+  switch (error.type) {
     case 'code-version-mismatch':
-      return 'online-code-version-mismatch';
+      return { status: 'online-code-version-mismatch', hostMachineId };
     case 'scanner-unconfigured':
-      return 'online-machine-unconfigured';
+      return { status: 'online-machine-unconfigured', hostMachineId };
     case 'host-unconfigured':
-      return 'online-host-unconfigured';
+      return { status: 'online-host-unconfigured', hostMachineId };
     case 'ballot-hash-mismatch':
-      return 'online-ballot-hash-mismatch';
+      return { status: 'online-ballot-hash-mismatch', hostMachineId };
+    case 'results-official':
+      return { status: 'online-results-official', hostMachineId };
+    case 'invalid-mode':
+      return {
+        status: 'online-invalid-mode',
+        hostMachineId,
+        hostCvrFileMode: error.currentMode,
+      };
     default:
-      return throwIllegalValue(errorType);
+      return throwIllegalValue(error, 'type');
   }
 }
 
@@ -60,7 +68,8 @@ export function startScannerNetworking({
         message: `Scanner connection status changed from ${currentInfo.status} to ${newInfo.status}.`,
         previousStatus: currentInfo.status,
         newStatus: newInfo.status,
-        hostMachineId: newInfo.hostMachineId ?? 'none',
+        hostMachineId:
+          'hostMachineId' in newInfo ? newInfo.hostMachineId : 'none',
       });
     }
     store.setNetworkConnectionInfo(newInfo);
@@ -143,6 +152,7 @@ export function startScannerNetworking({
             ballotHash:
               store.getElectionRecord()?.electionDefinition.ballotHash,
             pollingPlaceId: store.getPollingPlaceId(),
+            isTestMode: store.getTestMode(),
           });
         } catch (error) {
           debug('Host at %s unreachable: %s', hostMachine.address, error);
@@ -153,10 +163,9 @@ export function startScannerNetworking({
         if (registerResult.isErr()) {
           const error = registerResult.err();
           debug('Host %s refused registration: %s', hostMachineId, error.type);
-          setConnectionInfo({
-            status: statusForRegistrationError(error),
-            hostMachineId,
-          });
+          setConnectionInfo(
+            connectionInfoForRegistrationError(error, hostMachineId)
+          );
           return;
         }
 

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -159,14 +159,11 @@ export class Store {
   private networkConnectionInfo: NetworkConnectionInfo = { status: 'offline' };
 
   /**
-   * Batches currently being sent to a VxAdmin host, with their consecutive
-   * transient-failure count and the earliest time to try again. In memory
-   * only: after a restart, sending simply starts over.
+   * The batch whose cast vote records the sync loop is currently sending to a
+   * VxAdmin host (see `BatchInfo.isSendingToAdmin`). In memory only, like the
+   * loop's retry state.
    */
-  private readonly sendToAdminAttempts = new Map<
-    string,
-    { failures: number; nextAttemptAt: number }
-  >();
+  private sendingToAdminBatchId?: string;
 
   getNetworkConnectionInfo(): NetworkConnectionInfo {
     return this.networkConnectionInfo;
@@ -206,7 +203,7 @@ export class Store {
    * Resets the database and any cached data in the store.
    */
   reset(): void {
-    this.sendToAdminAttempts.clear();
+    this.sendingToAdminBatchId = undefined;
     this.client.reset();
   }
 
@@ -720,7 +717,7 @@ export class Store {
 
         this.setScannerBackedUp(false);
       });
-      this.sendToAdminAttempts.clear();
+      this.sendingToAdminBatchId = undefined;
     }
   }
 
@@ -814,7 +811,6 @@ export class Store {
       'update batches set deleted_at = current_timestamp where id = ?',
       batchId
     );
-    this.sendToAdminAttempts.delete(batchId);
     return count > 0;
   }
 
@@ -889,18 +885,17 @@ export class Store {
           DateTime.fromSeconds(Number(info.sentToAdminAt)).toISO()) ||
         undefined,
       sendToAdminError: info.sendToAdminError || undefined,
-      isSendingToAdmin: this.sendToAdminAttempts.has(info.id) || undefined,
+      isSendingToAdmin: info.id === this.sendingToAdminBatchId || undefined,
     }));
   }
 
   /**
-   * Completed batches whose cast vote records have not yet been sent to a
-   * VxAdmin host and are due to be sent now, oldest first. A batch marked
-   * failed is excluded until an operator retries it, and a batch waiting out
-   * a retry backoff is excluded until its next attempt time.
+   * The oldest completed batch whose cast vote records have not yet been sent
+   * to a VxAdmin host. A batch marked failed is excluded until an operator
+   * retries it.
    */
-  getBatchesToSendToAdmin(): BatchInfo[] {
-    const rows = this.client.all(`
+  getNextBatchToSendToAdmin(): Optional<BatchInfo> {
+    const row = this.client.one(`
       select id
       from batches
       where
@@ -909,51 +904,14 @@ export class Store {
         and sent_to_admin_at is null
         and send_to_admin_error is null
       order by started_at asc, batch_number asc
-    `) as Array<{ id: string }>;
-    const now = Date.now();
-    const batches = this.getBatches();
-    return rows
-      .filter(
-        (row) =>
-          (this.sendToAdminAttempts.get(row.id)?.nextAttemptAt ?? 0) <= now
-      )
-      .map((row) => find(batches, (b) => b.id === row.id));
+      limit 1
+    `) as Optional<{ id: string }>;
+    return row && this.getBatch(row.id);
   }
 
-  /** Marks a batch as being sent to a VxAdmin host (see `isSendingToAdmin`). */
-  startSendingBatchToAdmin(batchId: string): void {
-    if (!this.sendToAdminAttempts.has(batchId)) {
-      this.sendToAdminAttempts.set(batchId, {
-        failures: 0,
-        nextAttemptAt: 0,
-      });
-    }
-  }
-
-  /**
-   * Records a transient failure sending a batch and returns its consecutive
-   * failure count.
-   */
-  recordBatchSendToAdminFailure(batchId: string): number {
-    const attempt = assertDefined(this.sendToAdminAttempts.get(batchId));
-    attempt.failures += 1;
-    return attempt.failures;
-  }
-
-  /** Defers the next attempt to send a batch until `nextAttemptAt` (unix ms). */
-  deferBatchSendToAdmin(batchId: string, nextAttemptAt: number): void {
-    assertDefined(this.sendToAdminAttempts.get(batchId)).nextAttemptAt =
-      nextAttemptAt;
-  }
-
-  /** Forgets all in-progress send attempts, e.g. when the host disconnects. */
-  clearSendToAdminAttempts(): void {
-    this.sendToAdminAttempts.clear();
-  }
-
-  /** The oldest batch from {@link getBatchesToSendToAdmin}, if any. */
-  getNextBatchToSendToAdmin(): BatchInfo | undefined {
-    return this.getBatchesToSendToAdmin()[0];
+  /** Records which batch, if any, is being sent to a VxAdmin host. */
+  setSendingToAdminBatchId(batchId?: string): void {
+    this.sendingToAdminBatchId = batchId;
   }
 
   /**
@@ -965,7 +923,6 @@ export class Store {
       'update batches set sent_to_admin_at = current_timestamp, send_to_admin_error = null where id = ?',
       batchId
     );
-    this.sendToAdminAttempts.delete(batchId);
   }
 
   /**
@@ -979,7 +936,6 @@ export class Store {
       error,
       batchId
     );
-    this.sendToAdminAttempts.delete(batchId);
   }
 
   /**

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -158,6 +158,16 @@ export class Store {
    */
   private networkConnectionInfo: NetworkConnectionInfo = { status: 'offline' };
 
+  /**
+   * Batches currently being sent to a VxAdmin host, with their consecutive
+   * transient-failure count and the earliest time to try again. In memory
+   * only: after a restart, sending simply starts over.
+   */
+  private readonly sendToAdminAttempts = new Map<
+    string,
+    { failures: number; nextAttemptAt: number }
+  >();
+
   getNetworkConnectionInfo(): NetworkConnectionInfo {
     return this.networkConnectionInfo;
   }
@@ -196,6 +206,7 @@ export class Store {
    * Resets the database and any cached data in the store.
    */
   reset(): void {
+    this.sendToAdminAttempts.clear();
     this.client.reset();
   }
 
@@ -709,6 +720,7 @@ export class Store {
 
         this.setScannerBackedUp(false);
       });
+      this.sendToAdminAttempts.clear();
     }
   }
 
@@ -802,6 +814,7 @@ export class Store {
       'update batches set deleted_at = current_timestamp where id = ?',
       batchId
     );
+    this.sendToAdminAttempts.delete(batchId);
     return count > 0;
   }
 
@@ -827,6 +840,7 @@ export class Store {
       error: string | null;
       count: number;
       sentToAdminAt: string | null;
+      sendToAdminError: string | null;
     }
     const batchInfo = this.client.all(`
       select
@@ -837,6 +851,7 @@ export class Store {
         strftime('%s', started_at) as startedAt,
         (case when ended_at is null then ended_at else strftime('%s', ended_at) end) as endedAt,
         (case when sent_to_admin_at is null then sent_to_admin_at else strftime('%s', sent_to_admin_at) end) as sentToAdminAt,
+        send_to_admin_error as sendToAdminError,
         error,
         sum(case when sheets.id is null then 0 else 1 end) as count
       from
@@ -873,25 +888,72 @@ export class Store {
           // eslint-disable-next-line vx/gts-safe-number-parse
           DateTime.fromSeconds(Number(info.sentToAdminAt)).toISO()) ||
         undefined,
+      sendToAdminError: info.sendToAdminError || undefined,
+      isSendingToAdmin: this.sendToAdminAttempts.has(info.id) || undefined,
     }));
   }
 
   /**
-   * Returns the oldest completed batch whose cast vote records have not yet
-   * been sent to a VxAdmin host, if any. Batches send strictly oldest-first.
+   * Completed batches whose cast vote records have not yet been sent to a
+   * VxAdmin host and are due to be sent now, oldest first. A batch marked
+   * failed is excluded until an operator retries it, and a batch waiting out
+   * a retry backoff is excluded until its next attempt time.
    */
-  getNextBatchToSendToAdmin(): BatchInfo | undefined {
-    const row = this.client.one(`
+  getBatchesToSendToAdmin(): BatchInfo[] {
+    const rows = this.client.all(`
       select id
       from batches
       where
         ended_at is not null
         and deleted_at is null
         and sent_to_admin_at is null
+        and send_to_admin_error is null
       order by started_at asc, batch_number asc
-      limit 1
-    `) as { id: string } | undefined;
-    return row ? this.getBatch(row.id) : undefined;
+    `) as Array<{ id: string }>;
+    const now = Date.now();
+    const batches = this.getBatches();
+    return rows
+      .filter(
+        (row) =>
+          (this.sendToAdminAttempts.get(row.id)?.nextAttemptAt ?? 0) <= now
+      )
+      .map((row) => find(batches, (b) => b.id === row.id));
+  }
+
+  /** Marks a batch as being sent to a VxAdmin host (see `isSendingToAdmin`). */
+  startSendingBatchToAdmin(batchId: string): void {
+    if (!this.sendToAdminAttempts.has(batchId)) {
+      this.sendToAdminAttempts.set(batchId, {
+        failures: 0,
+        nextAttemptAt: 0,
+      });
+    }
+  }
+
+  /**
+   * Records a transient failure sending a batch and returns its consecutive
+   * failure count.
+   */
+  recordBatchSendToAdminFailure(batchId: string): number {
+    const attempt = assertDefined(this.sendToAdminAttempts.get(batchId));
+    attempt.failures += 1;
+    return attempt.failures;
+  }
+
+  /** Defers the next attempt to send a batch until `nextAttemptAt` (unix ms). */
+  deferBatchSendToAdmin(batchId: string, nextAttemptAt: number): void {
+    assertDefined(this.sendToAdminAttempts.get(batchId)).nextAttemptAt =
+      nextAttemptAt;
+  }
+
+  /** Forgets all in-progress send attempts, e.g. when the host disconnects. */
+  clearSendToAdminAttempts(): void {
+    this.sendToAdminAttempts.clear();
+  }
+
+  /** The oldest batch from {@link getBatchesToSendToAdmin}, if any. */
+  getNextBatchToSendToAdmin(): BatchInfo | undefined {
+    return this.getBatchesToSendToAdmin()[0];
   }
 
   /**
@@ -900,9 +962,24 @@ export class Store {
    */
   setBatchSentToAdmin(batchId: string): void {
     this.client.run(
-      'update batches set sent_to_admin_at = current_timestamp where id = ?',
+      'update batches set sent_to_admin_at = current_timestamp, send_to_admin_error = null where id = ?',
       batchId
     );
+    this.sendToAdminAttempts.delete(batchId);
+  }
+
+  /**
+   * Sets or clears a batch's send-to-VxAdmin failure state. While set, the
+   * batch is skipped by the sync loop (other batches keep sending) until an
+   * operator retries it. Either way the batch's send attempts start over.
+   */
+  setBatchSendToAdminError(batchId: string, error: string | null): void {
+    this.client.run(
+      'update batches set send_to_admin_error = ? where id = ?',
+      error,
+      batchId
+    );
+    this.sendToAdminAttempts.delete(batchId);
   }
 
   /**

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -34,22 +34,46 @@ export type NetworkConnectionStatus =
   | 'online-machine-unconfigured'
   | 'online-host-unconfigured'
   | 'online-ballot-hash-mismatch'
+  /** The host's results are marked official, so it accepts no more CVRs. */
+  | 'online-results-official'
+  /** The host is locked to the other test/official ballot mode. */
+  | 'online-invalid-mode'
   | 'online-host-detected';
 
-/** The scanner's current connection state and the detected host, if any. */
-export interface NetworkConnectionInfo {
-  status: NetworkConnectionStatus;
-  /**
-   * Machine ID of the detected host, parsed from its avahi service name.
-   * Present whenever exactly one host was found on the network.
-   */
-  hostMachineId?: string;
-  /**
-   * Address of the host the scanner is registered with. Present only in the
-   * `online-host-detected` state; used by the CVR sync loop.
-   */
-  hostAddress?: string;
-}
+/**
+ * The scanner's current connection state and, once exactly one host has been
+ * found on the network, details about that host. Discriminated on `status` so
+ * each state carries exactly the details it has.
+ */
+export type NetworkConnectionInfo =
+  | {
+      status:
+        | 'offline'
+        | 'online-waiting-for-host'
+        | 'online-multiple-hosts-detected';
+    }
+  | {
+      status:
+        | 'online-code-version-mismatch'
+        | 'online-machine-unconfigured'
+        | 'online-host-unconfigured'
+        | 'online-ballot-hash-mismatch'
+        | 'online-results-official';
+      /** Machine ID of the detected host, parsed from its avahi service name. */
+      hostMachineId: string;
+    }
+  | {
+      status: 'online-invalid-mode';
+      hostMachineId: string;
+      /** The ballot mode the host's existing CVRs lock it to. */
+      hostCvrFileMode: 'test' | 'official';
+    }
+  | {
+      status: 'online-host-detected';
+      hostMachineId: string;
+      /** Address of the host's peer API, used by the CVR sync loop. */
+      hostAddress: string;
+    };
 
 /** The scanner's network status, as reported to the frontend. */
 export interface NetworkStatus {

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -318,6 +318,18 @@ export const continueScanning = {
   },
 } as const;
 
+export const retrySendBatchToAdmin = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.retrySendBatchToAdmin, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const deleteBatch = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/central-scan/frontend/src/components/network_section.test.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.test.tsx
@@ -55,8 +55,27 @@ const testCases: Array<{
     expectedText: 'VxAdmin (0002) is configured for a different election',
     expectedIcon: 'circle-info',
   },
+  // Refusals explained on the Scan Ballots screen read as connected here
   {
-    connection: { status: 'online-host-detected', hostMachineId: '0002' },
+    connection: { status: 'online-results-official', hostMachineId: '0002' },
+    expectedText: 'Online — VxAdmin (0002) connected on the network',
+    expectedIcon: 'square-check',
+  },
+  {
+    connection: {
+      status: 'online-invalid-mode',
+      hostMachineId: '0002',
+      hostCvrFileMode: 'official',
+    },
+    expectedText: 'Online — VxAdmin (0002) connected on the network',
+    expectedIcon: 'square-check',
+  },
+  {
+    connection: {
+      status: 'online-host-detected',
+      hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
+    },
     expectedText: 'Online — VxAdmin (0002) connected on the network',
     expectedIcon: 'square-check',
   },

--- a/apps/central-scan/frontend/src/components/network_section.tsx
+++ b/apps/central-scan/frontend/src/components/network_section.tsx
@@ -62,6 +62,10 @@ function ConnectionStatusMessage({
           a different election
         </P>
       );
+    // VxAdmin is reachable but won't take this machine's batches; the Scan
+    // Ballots screen explains why, so the connection itself reads as fine.
+    case 'online-results-official':
+    case 'online-invalid-mode':
     case 'online-host-detected':
       return (
         <P>
@@ -70,7 +74,7 @@ function ConnectionStatusMessage({
         </P>
       );
     default:
-      throwIllegalValue(connection.status);
+      throwIllegalValue(connection, 'status');
   }
 }
 

--- a/apps/central-scan/frontend/src/components/network_status_indicator.test.tsx
+++ b/apps/central-scan/frontend/src/components/network_status_indicator.test.tsx
@@ -56,6 +56,21 @@ const testCases: Array<{
     expectedLabel: 'No VxAdmin Connected',
     expectedTreatment: 'warning',
   },
+  // Refusals explained on the Scan Ballots screen read as connected here
+  {
+    connection: { status: 'online-results-official', hostMachineId: '0002' },
+    expectedLabel: 'Connected',
+    expectedTreatment: 'connected',
+  },
+  {
+    connection: {
+      status: 'online-invalid-mode',
+      hostMachineId: '0002',
+      hostCvrFileMode: 'official',
+    },
+    expectedLabel: 'Connected',
+    expectedTreatment: 'connected',
+  },
   {
     connection: { status: 'online-multiple-hosts-detected' },
     expectedLabel: 'Network Error',
@@ -70,7 +85,11 @@ const testCases: Array<{
     expectedTreatment: 'error',
   },
   {
-    connection: { status: 'online-host-detected', hostMachineId: '0002' },
+    connection: {
+      status: 'online-host-detected',
+      hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
+    },
     expectedLabel: 'Connected',
     expectedTreatment: 'connected',
   },

--- a/apps/central-scan/frontend/src/components/network_status_indicator.tsx
+++ b/apps/central-scan/frontend/src/components/network_status_indicator.tsx
@@ -11,7 +11,12 @@ function indicatorStatus(
 ): NetworkIndicatorStatus {
   const { status } = connection;
   switch (status) {
+    // For results-official and invalid-mode, VxAdmin is reachable but won't
+    // take this machine's batches; the Scan Ballots screen explains why, so
+    // the connection itself reads as fine.
     case 'online-host-detected':
+    case 'online-results-official':
+    case 'online-invalid-mode':
       return 'connected';
     case 'offline':
       return 'no-network';

--- a/apps/central-scan/frontend/src/screens/diagnostics_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/diagnostics_screen.test.tsx
@@ -78,7 +78,11 @@ test('shows the network status when networking is enabled', async () => {
 
   apiMock.setNetworkStatus({
     isEnabled: true,
-    connection: { status: 'online-host-detected', hostMachineId: '0002' },
+    connection: {
+      status: 'online-host-detected',
+      hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
+    },
   });
   await screen.findByText(
     'Online — VxAdmin (0002) connected on the network',

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -47,7 +47,11 @@ test('null state', () => {
 test('shows a sent-to-VxAdmin column when networking is enabled', async () => {
   apiMock.setNetworkStatus({
     isEnabled: true,
-    connection: { status: 'online-host-detected', hostMachineId: '0002' },
+    connection: {
+      status: 'online-host-detected',
+      hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
+    },
   });
   const status: ScanStatus = mockStatus({
     batches: [
@@ -65,6 +69,97 @@ test('shows a sent-to-VxAdmin column when networking is enabled', async () => {
   expect(rows[0]).toHaveTextContent('Batch 1');
   expect(rows[0]).not.toHaveTextContent('Not sent');
   expect(rows[1]).toHaveTextContent('Not sent');
+});
+
+test('shows a failed batch with a retry button', async () => {
+  apiMock.setNetworkStatus({
+    isEnabled: true,
+    connection: {
+      status: 'online-host-detected',
+      hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
+    },
+  });
+  const status: ScanStatus = mockStatus({
+    batches: [
+      mockBatch({
+        id: 'failed-batch',
+        label: 'Batch 1',
+        sendToAdminError: 'sending failed 5 times in a row',
+      }),
+    ],
+  });
+  renderScreen({ status });
+  await screen.findByText('Send failed');
+
+  apiMock.apiClient.retrySendBatchToAdmin
+    .expectCallWith({ batchId: 'failed-batch' })
+    .resolves();
+  userEvent.click(screen.getButton('Retry'));
+  await vi.waitFor(() => apiMock.assertComplete());
+});
+
+test('shows a batch waiting to retry as sending', async () => {
+  apiMock.setNetworkStatus({
+    isEnabled: true,
+    connection: {
+      status: 'online-host-detected',
+      hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
+    },
+  });
+  const status: ScanStatus = mockStatus({
+    batches: [
+      mockBatch({
+        id: 'retrying',
+        label: 'Batch 1',
+        isSendingToAdmin: true,
+      }),
+      mockBatch({ id: 'queued', label: 'Batch 2' }),
+    ],
+  });
+  renderScreen({ status });
+  await screen.findByText('Sending…');
+  const rows = screen.getAllByRole('row').slice(1);
+  expect(rows[0]).toHaveTextContent('Sending…');
+  expect(rows[1]).toHaveTextContent('Not sent');
+});
+
+test.each([
+  {
+    hostCvrFileMode: 'official' as const,
+    expectedText:
+      /is tabulating official results, but this machine is in test ballot mode/,
+  },
+  {
+    hostCvrFileMode: 'test' as const,
+    expectedText:
+      /is tabulating test results, but this machine is in official ballot mode/,
+  },
+])(
+  'warns when VxAdmin is locked to $hostCvrFileMode mode',
+  async ({ hostCvrFileMode, expectedText }) => {
+    apiMock.setNetworkStatus({
+      isEnabled: true,
+      connection: {
+        status: 'online-invalid-mode',
+        hostMachineId: '0002',
+        hostCvrFileMode,
+      },
+    });
+    renderScreen({ status: mockStatus({ batches: [mockBatch()] }) });
+    await screen.findByText(expectedText);
+    screen.getByText('Not sent');
+  }
+);
+
+test('warns when VxAdmin results are marked official', async () => {
+  apiMock.setNetworkStatus({
+    isEnabled: true,
+    connection: { status: 'online-results-official', hostMachineId: '0002' },
+  });
+  renderScreen({ status: mockStatus({ batches: [mockBatch()] }) });
+  await screen.findByText(/has marked its results official/);
 });
 
 test('hides the sent-to-VxAdmin column when networking is disabled', () => {

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -14,7 +14,10 @@ import {
 import { BatchInfo } from '@votingworks/types';
 import styled from 'styled-components';
 import { iter } from '@votingworks/basics';
-import type { ScanStatus } from '@votingworks/central-scan-backend';
+import type {
+  NetworkConnectionInfo,
+  ScanStatus,
+} from '@votingworks/central-scan-backend';
 import { format } from '@votingworks/utils';
 import { DeleteBatchModal } from '../components/delete_batch_modal.js';
 import { NavigationScreen } from '../navigation_screen.js';
@@ -103,6 +106,38 @@ export interface ScanBallotsScreenProps {
   status: ScanStatus;
   statusIsStale: boolean;
   isPollingPlaceUnconfigured: boolean;
+}
+
+/**
+ * A screen-level warning for VxAdmin refusing this machine's batches for a
+ * reason that applies to every batch, so it isn't repeated per row.
+ */
+function SendingPausedCallout({
+  connection,
+}: {
+  connection: NetworkConnectionInfo;
+}): JSX.Element | null {
+  switch (connection.status) {
+    case 'online-results-official':
+      return (
+        <Callout color="warning" icon="Warning">
+          VxAdmin ({connection.hostMachineId}) has marked its results official
+          and is not accepting batches. Batches will not be sent to VxAdmin.
+        </Callout>
+      );
+    case 'online-invalid-mode':
+      return (
+        <Callout color="warning" icon="Warning">
+          VxAdmin ({connection.hostMachineId}) is tabulating{' '}
+          {connection.hostCvrFileMode} results, but this machine is in{' '}
+          {connection.hostCvrFileMode === 'official' ? 'test' : 'official'}{' '}
+          ballot mode. Batches will not be sent to VxAdmin until the modes
+          match.
+        </Callout>
+      );
+    default:
+      return null;
+  }
 }
 
 interface BatchSendState {
@@ -194,6 +229,9 @@ export function ScanBallotsScreen({
             No polling place selected. Select a polling place on the Settings
             screen before scanning ballots.
           </Callout>
+        )}
+        {isNetworkingEnabled && networkStatus && (
+          <SendingPausedCallout connection={networkStatus.connection} />
         )}
         <TopBar>
           {batchCount ? (

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -20,7 +20,11 @@ import { DeleteBatchModal } from '../components/delete_batch_modal.js';
 import { NavigationScreen } from '../navigation_screen.js';
 import { ExportResultsModal } from '../components/export_results_modal.js';
 import { ScanButton } from '../components/scan_button.js';
-import { clearBallotData, getNetworkStatus } from '../api.js';
+import {
+  clearBallotData,
+  getNetworkStatus,
+  retrySendBatchToAdmin,
+} from '../api.js';
 
 pluralize.addIrregularRule('requires', 'require');
 pluralize.addIrregularRule('has', 'have');
@@ -36,10 +40,28 @@ function shortDateTime(iso8601Timestamp: string) {
   )} ${d.getHours()}:${z2(d.getMinutes())}:${z2(d.getSeconds())}`;
 }
 
-// Reserves enough width for a full timestamp so the column doesn't resize
-// when a batch flips from "Not sent" to its sent time.
+// Wide enough for a full timestamp on one line so the column doesn't resize
+// when a batch flips from "Not sent" to its sent time; longer status text
+// wraps rather than widening the table.
 const SentAtCell = styled(TD)`
-  min-width: 12rem;
+  width: 10rem;
+  white-space: normal;
+`;
+
+const Timestamp = styled.span`
+  white-space: nowrap;
+`;
+
+// Always wide enough for a send action (Retry/Resend) beside Delete, so the
+// column doesn't resize when one appears.
+const ActionsCell = styled(TD)`
+  min-width: 12.25rem;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.25rem;
 `;
 
 const Content = styled.div`
@@ -83,6 +105,43 @@ export interface ScanBallotsScreenProps {
   isPollingPlaceUnconfigured: boolean;
 }
 
+interface BatchSendState {
+  /** What the "Sent At" cell shows. */
+  contents: JSX.Element;
+  /** An operator action offered beside Delete, if any. */
+  action?: 'retry';
+}
+
+function getBatchSendState(batch: BatchInfo): BatchSendState {
+  if (batch.sentToAdminAt) {
+    return {
+      contents: <Timestamp>{shortDateTime(batch.sentToAdminAt)}</Timestamp>,
+    };
+  }
+  if (batch.sendToAdminError) {
+    return {
+      contents: (
+        <React.Fragment>
+          <Icons.Danger color="danger" /> Send failed
+        </React.Fragment>
+      ),
+      action: 'retry',
+    };
+  }
+  // Covers the attempt in flight and any wait to retry after a transient
+  // failure, so the cell doesn't flicker between attempts.
+  if (batch.isSendingToAdmin) {
+    return {
+      contents: (
+        <Font weight="bold">
+          <Icons.Loading /> Sending…
+        </Font>
+      ),
+    };
+  }
+  return { contents: <Font weight="light">Not sent</Font> };
+}
+
 export function ScanBallotsScreen({
   status,
   statusIsStale,
@@ -99,7 +158,9 @@ export function ScanBallotsScreen({
   const [isExportingCvrs, setIsExportingCvrs] = useState(false);
   const [pendingDeleteBatch, setPendingDeleteBatch] = useState<BatchInfo>();
   const networkStatusQuery = getNetworkStatus.usePollingQuery();
-  const isNetworkingEnabled = networkStatusQuery.data?.isEnabled ?? false;
+  const networkStatus = networkStatusQuery.data;
+  const isNetworkingEnabled = networkStatus?.isEnabled ?? false;
+  const retrySendMutation = retrySendBatchToAdmin.useMutation();
   const [deleteBallotDataFlowState, setDeleteBallotDataFlowState] = useState<
     'confirmation' | 'deleting'
   >();
@@ -187,45 +248,58 @@ export function ScanBallotsScreen({
                   </tr>
                 </thead>
                 <tbody>
-                  {batches.map((batch) => (
-                    <tr key={batch.id}>
-                      <td>{batch.label}</td>
-                      <td>{format.count(batch.count)}</td>
-                      <TD nowrap>{shortDateTime(batch.startedAt)}</TD>
-                      <TD nowrap>
-                        {/* @coverage-defer */}
-                        {isScanning && !batch.endedAt ? (
-                          <Font weight="bold">
-                            <Icons.Loading /> Scanning…
-                          </Font>
-                        ) : batch.endedAt ? (
-                          shortDateTime(batch.endedAt)
-                        ) : null}
-                      </TD>
-                      {isNetworkingEnabled && (
-                        <SentAtCell nowrap>
-                          {batch.sentToAdminAt ? (
-                            shortDateTime(batch.sentToAdminAt)
-                          ) : (
-                            <Font weight="light">Not sent</Font>
-                          )}
-                        </SentAtCell>
-                      )}
-                      <TD narrow>
-                        <Button
-                          icon="Delete"
-                          fill="transparent"
-                          color="danger"
-                          // @coverage-defer
-                          onPress={() => setPendingDeleteBatch(batch)}
-                          style={{ flexWrap: 'nowrap' }}
-                          disabled={isScanning}
-                        >
-                          Delete
-                        </Button>
-                      </TD>
-                    </tr>
-                  ))}
+                  {batches.map((batch) => {
+                    const sendState = isNetworkingEnabled
+                      ? getBatchSendState(batch)
+                      : undefined;
+                    return (
+                      <tr key={batch.id}>
+                        <TD nowrap>{batch.label}</TD>
+                        <td>{format.count(batch.count)}</td>
+                        <TD nowrap>{shortDateTime(batch.startedAt)}</TD>
+                        <TD nowrap>
+                          {/* @coverage-defer */}
+                          {isScanning && !batch.endedAt ? (
+                            <Font weight="bold">
+                              <Icons.Loading /> Scanning…
+                            </Font>
+                          ) : batch.endedAt ? (
+                            shortDateTime(batch.endedAt)
+                          ) : null}
+                        </TD>
+                        {sendState && (
+                          <SentAtCell>{sendState.contents}</SentAtCell>
+                        )}
+                        <ActionsCell narrow>
+                          <Actions>
+                            {sendState?.action === 'retry' && (
+                              <Button
+                                onPress={() =>
+                                  retrySendMutation.mutate({
+                                    batchId: batch.id,
+                                  })
+                                }
+                                disabled={retrySendMutation.isLoading}
+                              >
+                                Retry
+                              </Button>
+                            )}
+                            <Button
+                              icon="Delete"
+                              fill="transparent"
+                              color="danger"
+                              // @coverage-defer
+                              onPress={() => setPendingDeleteBatch(batch)}
+                              style={{ flexWrap: 'nowrap' }}
+                              disabled={isScanning}
+                            >
+                              Delete
+                            </Button>
+                          </Actions>
+                        </ActionsCell>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </Table>
             </div>

--- a/libs/networking/src/vx_admin_host_api.ts
+++ b/libs/networking/src/vx_admin_host_api.ts
@@ -8,12 +8,24 @@ export interface VxAdminHostMachineConfig {
   codeVersion: string;
 }
 
-/** Why a VxAdmin host refused to register a scanner. */
+/**
+ * Why a VxAdmin host refused to register a scanner. Registration is refused
+ * whenever the host could not accept the scanner's cast vote records, so the
+ * scanner's connection status reflects every such condition and no batch is
+ * sent into a known refusal.
+ */
 export type RegisterScannerError =
   | { type: 'code-version-mismatch' }
   | { type: 'scanner-unconfigured' }
   | { type: 'host-unconfigured' }
-  | { type: 'ballot-hash-mismatch' };
+  | { type: 'ballot-hash-mismatch' }
+  /** The host's results have been marked official; it accepts no more CVRs. */
+  | { type: 'results-official' }
+  /**
+   * The host's existing CVRs lock it to `currentMode`, and the scanner is in
+   * the other mode.
+   */
+  | { type: 'invalid-mode'; currentMode: 'test' | 'official' };
 
 /**
  * Manifest describing one scanned batch being transferred to a VxAdmin host.
@@ -31,16 +43,20 @@ export interface CvrTransferManifest {
   isTestMode: boolean;
 }
 
-/** Why a VxAdmin host refused to start a CVR transfer. */
-export type StartCvrTransferError =
-  | RegisterScannerError
-  | { type: 'invalid-mode'; currentMode: 'test' | 'official' };
+/**
+ * Why a VxAdmin host refused to start a CVR transfer. The same checks as
+ * registration, re-run at transfer time because the host's state can change
+ * between heartbeats.
+ */
+export type StartCvrTransferError = RegisterScannerError;
 
 /** Why a VxAdmin host refused to finish a CVR transfer. */
 export type FinishCvrTransferError =
   | { type: 'transfer-not-found' }
   | { type: 'sheet-count-mismatch'; expected: number; received: number }
-  | { type: 'import-failed'; subType: string };
+  | { type: 'import-failed'; subType: string }
+  | { type: 'results-official' }
+  | { type: 'invalid-mode'; currentMode: 'test' | 'official' };
 
 /**
  * The path of the host's (non-grout) CVR upload endpoint. One request per
@@ -71,6 +87,8 @@ export type VxAdminHostApi = Api<{
     ballotHash?: string;
     /** The polling place the scanner is configured for, if any. */
     pollingPlaceId?: string;
+    /** Whether the scanner is in test ballot mode. */
+    isTestMode: boolean;
   }) => Result<VxAdminHostMachineConfig, RegisterScannerError>;
   /**
    * Read-only, side-effect-free method also used by scanners as a

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1480,6 +1480,17 @@ export interface BatchInfo {
    * network. Only used on VxCentralScan.
    */
   sentToAdminAt?: Iso8601Timestamp;
+  /**
+   * Set when sending this batch to a VxAdmin host failed in a way that needs
+   * operator attention. Only used on VxCentralScan.
+   */
+  sendToAdminError?: string;
+  /**
+   * Set while this batch's cast vote records are being sent to a VxAdmin
+   * host, including while waiting to retry after a transient failure. Only
+   * used on VxCentralScan.
+   */
+  isSendingToAdmin?: boolean;
 }
 
 export const BallotCastingModeSchema = z.enum(['early_voting', 'election_day']);


### PR DESCRIPTION
## Overview
Adds more detail and types to the possible network errors that can come from vxadmin. In the case of finalized/official ballots or mismatched live/test mode ballots that is now checked as a part of the regular registerScanner calls (see second commit) and batches won't be sent until those are matched. 

Transient errors in network sends from a mode mismatch are therefore ignored. If an unexpected error occurs more then 5 times (with backoff) a batch will now be marked as failed and require a manual retry, it will be skipped and the next batch will attempt to send. 

Monitoring for missing batches in VxAdmin and allowing Resend will be done in a separate PR. 

## Demo Video or Screenshot
<img width="1352" height="865" alt="Screenshot 2026-09-02 at 4 07 29 PM" src="https://github.com/user-attachments/assets/6c4ec5ff-37c7-4678-a965-4f7401883d05" />
<img width="1350" height="850" alt="Screenshot 2026-09-02 at 4 06 16 PM" src="https://github.com/user-attachments/assets/88b1cd86-42ec-4638-80e1-2bd3f77250ca" />
<img width="1358" height="855" alt="Screenshot 2026-09-02 at 4 03 16 PM" src="https://github.com/user-attachments/assets/f9197266-d749-4333-98b4-e2dc73c756c0" />
<img width="2" height="3" alt="Screenshot 2026-09-02 at 4 03 09 PM" src="https://github.com/user-attachments/assets/927fff6e-aa27-4e77-86f3-e5734ed5cc6e" />
<img width="1357" height="857" alt="Screenshot 2026-09-02 at 4 02 50 PM" src="https://github.com/user-attachments/assets/f718638c-7cff-405d-aa0a-c917e4b2f57b" />
<img width="1349" height="848" alt="Screenshot 2026-09-02 at 3 58 58 PM" src="https://github.com/user-attachments/assets/5c5cfc03-3953-421b-9029-bf5948fd6040" />
<img width="1341" height="848" alt="Screenshot 2026-09-02 at 3 58 30 PM" src="https://github.com/user-attachments/assets/4745688c-b3aa-4077-9007-5e9eb2c0fac9" />


## Testing Plan
Manual testing of simple mode mismatches, hacked in fake errors to test error flows. Ran tests. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
