### PR TITLE
test: fix latent races and gaps in react-query-backed tests

### DIFF
--- a/apps/mark-scan/frontend/src/app.test.tsx
+++ b/apps/mark-scan/frontend/src/app.test.tsx
@@ -8,7 +8,7 @@ import {
   useBallotStyleManager,
   useSessionSettingsManager,
 } from '@votingworks/mark-flow-ui';
-import { screen } from '../test/react_testing_library.js';
+import { screen, waitFor } from '../test/react_testing_library.js';
 import { advanceTimersAndPromises } from '../test/helpers/timers.js';
 import { render } from '../test/test_utils.js';
 import { App } from './app.js';
@@ -128,10 +128,12 @@ test('uses ballot style management hook', async () => {
 
   await advanceTimersAndPromises();
 
-  expect(vi.mocked(useBallotStyleManager)).toBeCalledWith(
-    expect.objectContaining({
-      currentBallotStyleId: '1_en',
-      electionDefinition: electionGeneralDefinition,
-    })
+  await waitFor(() =>
+    expect(vi.mocked(useBallotStyleManager)).toBeCalledWith(
+      expect.objectContaining({
+        currentBallotStyleId: '1_en',
+        electionDefinition: electionGeneralDefinition,
+      })
+    )
   );
 });

--- a/apps/mark-scan/frontend/src/app_visual_mode_disabled.test.tsx
+++ b/apps/mark-scan/frontend/src/app_visual_mode_disabled.test.tsx
@@ -1,10 +1,27 @@
-import { test } from 'vitest';
+import { afterEach, beforeEach, test } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { App } from './app.js';
 import { render, screen } from '../test/react_testing_library.js';
+import { ApiMock, createApiMock } from '../test/helpers/mock_api_client.js';
+
+let apiMock: ApiMock;
+
+beforeEach(() => {
+  apiMock = createApiMock();
+  apiMock.expectGetMachineConfig();
+  apiMock.expectGetSystemSettings();
+  apiMock.expectGetElectionRecord(null);
+  apiMock.expectGetElectionState();
+  apiMock.setPaperHandlerState('no_hardware');
+  apiMock.setDiskSpaceSummary();
+});
+
+afterEach(() => {
+  apiMock.mockApiClient.assertComplete();
+});
 
 test('renders overlay when audio-only mode is enabled', () => {
-  render(<App />, {
+  render(<App apiClient={apiMock.mockApiClient} />, {
     vxTheme: { isVisualModeDisabled: true },
   });
 

--- a/apps/mark-scan/frontend/test/test_utils.tsx
+++ b/apps/mark-scan/frontend/test/test_utils.tsx
@@ -7,6 +7,7 @@ import {
   Contest,
   ElectionDefinition,
   PartyId,
+  DEFAULT_SYSTEM_SETTINGS,
   PrecinctId,
   VotesDict,
 } from '@votingworks/types';
@@ -60,6 +61,13 @@ export function render(
     apiMock?: ApiMock;
   } = {}
 ): ReturnType<typeof testRender> {
+  apiMock.mockApiClient.getSystemSettings
+    .expectOptionalRepeatedCallsWith()
+    .resolves(DEFAULT_SYSTEM_SETTINGS);
+  apiMock.mockApiClient.getUsbPortStatus
+    .expectOptionalRepeatedCallsWith()
+    .resolves({ enabled: true });
+
   return {
     ...testRender(
       <ApiProvider apiClient={apiMock.mockApiClient}>

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -9,7 +9,7 @@ import {
   useSessionSettingsManager,
 } from '@votingworks/mark-flow-ui';
 import userEvent from '@testing-library/user-event';
-import { screen } from '../test/react_testing_library.js';
+import { screen, waitFor } from '../test/react_testing_library.js';
 import { advanceTimersAndPromises } from '../test/helpers/timers.js';
 import { render } from '../test/test_utils.js';
 import { App } from './app.js';
@@ -129,11 +129,13 @@ test('uses ballot style management hook', async () => {
 
   await advanceTimersAndPromises();
 
-  expect(useBallotStyleManager).toBeCalledWith(
-    expect.objectContaining({
-      currentBallotStyleId: '1_G_es-US',
-      electionDefinition: electionGeneralDefinition,
-    })
+  await waitFor(() =>
+    expect(useBallotStyleManager).toBeCalledWith(
+      expect.objectContaining({
+        currentBallotStyleId: '1_G_es-US',
+        electionDefinition: electionGeneralDefinition,
+      })
+    )
   );
 });
 

--- a/libs/dev-dock/frontend/src/dev_dock.tsx
+++ b/libs/dev-dock/frontend/src/dev_dock.tsx
@@ -1418,13 +1418,15 @@ function DevDockWrapper({
    */
   enableAccessibleNav?: boolean;
 }): JSX.Element | null {
+  const [queryClient] = useState(createQueryClient);
+
   // We use a wrapper component to make sure that not only is the dock not
   // inserted into the DOM, but its keyboard listeners are not registered
   // either.
   return isFeatureFlagEnabled(
     BooleanEnvironmentVariableName.ENABLE_DEV_DOCK
   ) ? (
-    <QueryClientProvider client={createQueryClient()}>
+    <QueryClientProvider client={queryClient}>
       <VxThemeProvider colorMode="desktop" sizeMode="desktop">
         <ApiClientContext.Provider value={apiClient}>
           <DevDock enableAccessibleNav={enableAccessibleNav} />

--- a/libs/ui/src/ui_strings/language_context.test.tsx
+++ b/libs/ui/src/ui_strings/language_context.test.tsx
@@ -50,24 +50,28 @@ test('setLanguage', async () => {
   expect(getLanguageContext()?.currentLanguageCode).toEqual(
     DEFAULT_LANGUAGE_CODE
   );
-  expect(
-    getLanguageContext()?.i18next.getResourceBundle(
-      DEFAULT_LANGUAGE_CODE,
-      DEFAULT_I18NEXT_NAMESPACE
-    )
-  ).toEqual(TEST_UI_STRING_TRANSLATIONS[DEFAULT_LANGUAGE_CODE]);
+  await waitFor(() =>
+    expect(
+      getLanguageContext()?.i18next.getResourceBundle(
+        DEFAULT_LANGUAGE_CODE,
+        DEFAULT_I18NEXT_NAMESPACE
+      )
+    ).toEqual(TEST_UI_STRING_TRANSLATIONS[DEFAULT_LANGUAGE_CODE])
+  );
 
   act(() => getLanguageContext()?.setLanguage('zh-Hant'));
 
   await waitFor(() =>
     expect(getLanguageContext()?.currentLanguageCode).toEqual('zh-Hant')
   );
-  expect(
-    getLanguageContext()?.i18next.getResourceBundle(
-      'zh-Hant',
-      DEFAULT_I18NEXT_NAMESPACE
-    )
-  ).toEqual(TEST_UI_STRING_TRANSLATIONS['zh-Hant']);
+  await waitFor(() =>
+    expect(
+      getLanguageContext()?.i18next.getResourceBundle(
+        'zh-Hant',
+        DEFAULT_I18NEXT_NAMESPACE
+      )
+    ).toEqual(TEST_UI_STRING_TRANSLATIONS['zh-Hant'])
+  );
 });
 
 test('resets language cache when backend data changes', async () => {
@@ -92,12 +96,14 @@ test('resets language cache when backend data changes', async () => {
 
   // Verify that i18next cache persists after re-render:
   rerender(<div>foo</div>);
-  expect(
-    getLanguageContext()?.i18next.getResourceBundle(
-      DEFAULT_LANGUAGE_CODE,
-      DEFAULT_I18NEXT_NAMESPACE
-    )
-  ).toEqual(TEST_UI_STRING_TRANSLATIONS[DEFAULT_LANGUAGE_CODE]);
+  await waitFor(() =>
+    expect(
+      getLanguageContext()?.i18next.getResourceBundle(
+        DEFAULT_LANGUAGE_CODE,
+        DEFAULT_I18NEXT_NAMESPACE
+      )
+    ).toEqual(TEST_UI_STRING_TRANSLATIONS[DEFAULT_LANGUAGE_CODE])
+  );
 
   // Simulate machine getting unconfigured/re-configured with no translations:
   mockApiClient.getUiStrings.mockResolvedValue(null);


### PR DESCRIPTION
## Overview
These all pass today only because react-query happens to deliver query results before the assertion runs, or because a query does not get far enough to reach a mock. None of them depend on the react-query version; they were found while upgrading to v5, which shifts that timing and turns each one into a failure.

## Testing Plan
Existing automated tests.