### PR TITLE
VxAdmin: harden the CVR upload endpoint against malformed zips

### DIFF
--- a/apps/admin/backend/src/network_cvr_transfer.ts
+++ b/apps/admin/backend/src/network_cvr_transfer.ts
@@ -21,7 +21,7 @@ import {
   Tabulation,
 } from '@votingworks/types';
 import { z } from 'zod/v4';
-import { getEntries, openZip, readEntry } from '@votingworks/utils';
+import { getEntries, getEntryStream, openZip } from '@votingworks/utils';
 import {
   prepareCastVoteRecord,
   PreparedCastVoteRecord,
@@ -36,6 +36,21 @@ import { Workspace } from './util/workspace.js';
 const debug = rootDebug.extend('network-cvr-transfer');
 
 const TRANSFER_MANIFEST_FILE_NAME = 'manifest.json';
+
+/**
+ * A cast vote record's file set is a report, two images, and at most two
+ * layout files; anything bigger is malformed.
+ */
+const MAX_UPLOAD_ZIP_ENTRIES = 8;
+
+/**
+ * Uploads are capped well above the ~1MB a full-image cast vote record
+ * occupies. Entries are decompressed incrementally and abandoned once they
+ * pass the cap, so a crafted highly-compressed upload can't balloon in memory.
+ */
+const MAX_UPLOAD_ENTRY_BYTES = 15 * 1024 * 1024;
+
+type ZipEntry = ReturnType<typeof getEntries>[number];
 
 const CvrTransferManifestSchema: z.ZodType<CvrTransferManifest> = z.object({
   machineId: z.string(),
@@ -209,6 +224,33 @@ export async function startCvrTransfer(
 }
 
 /**
+ * Decompresses a zip entry, giving up as soon as its output passes `maxBytes`
+ * so the size declared in the zip header never has to be trusted. jszip also
+ * rejects an entry whose output doesn't match its declared size.
+ */
+function readEntryUpTo(
+  entry: ZipEntry,
+  maxBytes: number
+): Promise<Result<Buffer, 'zip entry too large' | 'invalid zip'>> {
+  return new Promise((resolve) => {
+    const stream = getEntryStream(entry);
+    const chunks: Buffer[] = [];
+    let byteLength = 0;
+    stream.on('data', (chunk: Buffer) => {
+      byteLength += chunk.length;
+      if (byteLength > maxBytes) {
+        stream.pause();
+        resolve(err('zip entry too large'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    stream.on('end', () => resolve(ok(Buffer.concat(chunks))));
+    stream.on('error', () => resolve(err('invalid zip')));
+  });
+}
+
+/**
  * Receives one cast vote record's zipped file set, validates it fully (the
  * same parsing, election checks, and image hash verification as a USB
  * import), and stages it — invisible to every other consumer — for the
@@ -251,19 +293,25 @@ export async function receiveCvrTransferUpload(
   const { adminAdjudicationReasons, markThresholds } =
     store.getSystemSettings(electionId);
 
-  let entries: Awaited<ReturnType<typeof getEntries>>;
+  let entries: ZipEntry[];
   try {
     entries = getEntries(await openZip(zipData)).filter((entry) => !entry.dir);
   } catch {
     return err('invalid zip');
   }
+  if (entries.length > MAX_UPLOAD_ZIP_ENTRIES) {
+    return err('too many zip entries');
+  }
   if (entries.some((entry) => !isSafeId(entry.name))) {
     return err('invalid zip entry name');
   }
-
   const files: Record<string, Buffer> = {};
   for (const entry of entries) {
-    files[entry.name] = await readEntry(entry);
+    const entryResult = await readEntryUpTo(entry, MAX_UPLOAD_ENTRY_BYTES);
+    if (entryResult.isErr()) {
+      return entryResult;
+    }
+    files[entry.name] = entryResult.ok();
   }
 
   const readResult = await readCastVoteRecordFromSource(

--- a/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
+++ b/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
@@ -451,6 +451,56 @@ test('upload endpoint rejects invalid requests', async () => {
   );
   expect(wrongType.status).toEqual(400);
 
+  // Too many zip entries
+  const bloatedResponse = await fetch(
+    baseUrl + getCvrTransferUploadPath(SCANNER_ID, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(
+        await zipFile(
+          Object.fromEntries(
+            Array.from({ length: 10 }, (_, i) => [`file-${i}.json`, '{}'])
+          )
+        )
+      ),
+    }
+  );
+  expect(bloatedResponse.status).toEqual(400);
+
+  // Zip entry that decompresses far larger than any real cast vote record
+  const bombResponse = await fetch(
+    baseUrl + getCvrTransferUploadPath(SCANNER_ID, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(
+        await zipFile({ 'bomb.json': Buffer.alloc(16 * 1024 * 1024) })
+      ),
+    }
+  );
+  expect(bombResponse.status).toEqual(400);
+  expect(await bombResponse.json()).toEqual({ error: 'zip entry too large' });
+
+  // A zip whose central directory understates an entry's size; jszip catches
+  // the mismatch once the entry is fully decompressed.
+  const lyingZip = await zipFile({ 'lying.json': Buffer.alloc(4096) });
+  const centralDirectoryOffset = lyingZip.indexOf(
+    Buffer.from([0x50, 0x4b, 0x01, 0x02])
+  );
+  // Uncompressed size is 4 bytes at offset 24 of the central directory entry
+  lyingZip.writeUInt32LE(1024, centralDirectoryOffset + 24);
+  const lyingResponse = await fetch(
+    baseUrl + getCvrTransferUploadPath(SCANNER_ID, batch.batchId, cvr.id),
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: new Uint8Array(lyingZip),
+    }
+  );
+  expect(lyingResponse.status).toEqual(400);
+  expect(await lyingResponse.json()).toEqual({ error: 'invalid zip' });
+
   // Zip entry with an unsafe (path-traversing) name. Note jszip sanitizes
   // leading `../` on load, so use a nested path to exercise the guard.
   const evilResponse = await fetch(


### PR DESCRIPTION

## Overview
Based on claudes suggestions, adds some hardening and malformed zip handling to VxAdmins upload cvr endpoint. 

It could be argued that this is unnecessary since the endpoint is only hit over the trusted network by trusted VxCentralScan's, we do not do a similar validation when importing election packages from vxdesign which is a less trusted path. However, seems like a safe defense in depth. 

## Demo Video or Screenshot
N/A

## Testing Plan
Ran Tests

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
