### PR TITLE
[VxCentralScan] Monitor for and allow resends of batches deleted on VxAdmin

### DIFF
--- a/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
+++ b/apps/admin/backend/src/peer_app.cvr_transfer.test.ts
@@ -415,6 +415,58 @@ test('startCvrTransfer enforces the test/official mode lock', async () => {
   ).toEqual(err({ type: 'invalid-mode', currentMode: 'test' }));
 });
 
+test('registerScanner reports the batches imported from the scanner', async () => {
+  const { apiClient, auth, peerApiClient, peerServer, workspace } =
+    buildTestEnvironment();
+  await configureMachine(apiClient, auth, electionDefinition);
+  const electionId = assertDefined(workspace.store.getCurrentElectionId());
+  const batch = await loadFixtureBatch();
+  const baseUrl = peerBaseUrl(peerServer);
+
+  function register() {
+    return peerApiClient.registerScanner({
+      machineId: SCANNER_ID,
+      codeVersion: 'dev',
+      ballotHash: electionDefinition.ballotHash,
+      isTestMode: true,
+    });
+  }
+  expect((await register()).unsafeUnwrap().importedBatchIds).toEqual([]);
+
+  (await peerApiClient.startCvrTransfer(startInput(batch))).unsafeUnwrap();
+  for (const cvr of batch.cvrs) {
+    expect((await uploadCvr(baseUrl, batch, cvr)).status).toEqual(200);
+  }
+  // Staged records don't count until the import completes
+  expect((await register()).unsafeUnwrap().importedBatchIds).toEqual([]);
+  (
+    await peerApiClient.finishCvrTransfer({
+      machineId: SCANNER_ID,
+      batchId: batch.batchId,
+    })
+  ).unsafeUnwrap();
+  expect((await register()).unsafeUnwrap().importedBatchIds).toEqual([
+    batch.batchId,
+  ]);
+
+  // Removing the import on the host drops it from the list, and the host
+  // accepts the batch again
+  mockElectionManagerAuth(auth, electionDefinition.election);
+  await apiClient.deleteCvrFile({
+    fileId: assertDefined(
+      workspace.store.getNetworkCvrImportId(
+        electionId,
+        SCANNER_ID,
+        batch.batchId
+      )
+    ),
+  });
+  expect((await register()).unsafeUnwrap().importedBatchIds).toEqual([]);
+  expect(await peerApiClient.startCvrTransfer(startInput(batch))).toEqual(
+    ok({ alreadyComplete: false })
+  );
+});
+
 test('transfers are refused once results are marked official', async () => {
   const { apiClient, auth, peerApiClient, peerServer, workspace } =
     buildTestEnvironment();

--- a/apps/admin/backend/src/peer_app.test.ts
+++ b/apps/admin/backend/src/peer_app.test.ts
@@ -256,6 +256,7 @@ test('registerScanner records the scanner and returns the host machine config', 
     ok({
       machineId: DEV_MACHINE_ID,
       codeVersion: 'dev',
+      importedBatchIds: [],
     })
   );
   expect(workspace.store.getMachines()).toEqual([
@@ -346,6 +347,7 @@ test('registerScanner refuses a scanner in the other ballot mode once CVRs lock 
   const registered = ok({
     machineId: DEV_MACHINE_ID,
     codeVersion: 'dev',
+    importedBatchIds: [],
   });
   // With no CVRs loaded yet, a scanner in either mode registers
   expect(await register(false)).toEqual(registered);

--- a/apps/admin/backend/src/peer_app.ts
+++ b/apps/admin/backend/src/peer_app.ts
@@ -22,6 +22,7 @@ import type {
   CvrTransferManifest,
   FinishCvrTransferError,
   RegisterScannerError,
+  ScannerRegistration,
   StartCvrTransferError,
   VxAdminHostApi,
 } from '@votingworks/networking';
@@ -84,7 +85,7 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       ballotHash?: string;
       pollingPlaceId?: string;
       isTestMode: boolean;
-    }): Result<MachineConfig, RegisterScannerError> {
+    }): Result<ScannerRegistration, RegisterScannerError> {
       const machineConfig = getMachineConfig();
 
       function recordScanner(
@@ -104,7 +105,7 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
         error: RegisterScannerError,
         details: string,
         extra: Record<string, string> = {}
-      ): Result<MachineConfig, RegisterScannerError> {
+      ): Result<ScannerRegistration, RegisterScannerError> {
         logger.log(LogEventId.AdminNetworkStatus, 'system', {
           message: `Rejected registration from scanner ${input.machineId}: ${details}`,
           disposition: 'failure',
@@ -179,7 +180,13 @@ function buildPeerApi({ workspace, logger, machineId }: PeerAppContext) {
       }
       debug('Scanner %s registered with host', input.machineId);
       recordScanner(null);
-      return ok(machineConfig);
+      return ok({
+        ...machineConfig,
+        importedBatchIds: store.getNetworkCvrImportBatchIds(
+          currentElectionId,
+          input.machineId
+        ),
+      });
     },
 
     registerAdjudicationStation(input: {

--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -1403,6 +1403,26 @@ export class Store implements BaseStore {
     return row?.id;
   }
 
+  /**
+   * IDs of the given scanner's batches that were imported over the network
+   * for the given election.
+   */
+  getNetworkCvrImportBatchIds(electionId: Id, scannerId: string): string[] {
+    const rows = this.client.all(
+      `
+        select network_batch_id as batchId
+        from cvr_files
+        where
+          election_id = ?
+          and source = 'network'
+          and network_scanner_id = ?
+      `,
+      electionId,
+      scannerId
+    ) as Array<{ batchId: string }>;
+    return rows.map((row) => row.batchId);
+  }
+
   updateCastVoteRecordFileRecord({
     id,
     precinctIds,

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -27,7 +27,11 @@ create table batches (
   -- Set when sending this batch to a VxAdmin host failed in a way that needs
   -- operator attention. The batch is skipped (other batches keep sending)
   -- until the operator retries it.
-  send_to_admin_error text
+  send_to_admin_error text,
+  -- When the VxAdmin host this batch was sent to reported no longer holding
+  -- its cast vote records (e.g. they were removed on the host). Null until
+  -- then; cleared when the operator sends the batch again.
+  removed_from_admin_at text
 ) strict;
 
 create index idx_batches_unsent_to_admin on batches (started_at)

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -244,6 +244,36 @@ test('retrySendBatchToAdmin clears a batch send failure', async () => {
   });
 });
 
+test('resendBatchToAdmin queues a sent batch to be sent again', async () => {
+  const electionDefinition =
+    electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
+
+  await withApp(async ({ apiClient, importer, store }) => {
+    importer.configure(
+      electionDefinition,
+      jurisdiction,
+      'test-election-package-hash'
+    );
+    store.setPollingPlaceId(anyPollingPlace(electionDefinition.election).id);
+
+    const batchId = store.addBatch();
+    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.finishBatch({ batchId });
+    store.setBatchSentToAdmin(batchId);
+    expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
+
+    store.markBatchesRemovedFromAdmin([], Date.now() + 5_000);
+    expect(store.getBatch(batchId).removedFromAdminAt).toBeDefined();
+
+    await apiClient.resendBatchToAdmin({ batchId });
+    expect(store.getNextBatchToSendToAdmin()?.id).toEqual(batchId);
+    expect(store.getBatch(batchId)).toMatchObject({
+      sentToAdminAt: undefined,
+      removedFromAdminAt: undefined,
+    });
+  });
+});
+
 test('clearing scanning data', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -137,6 +137,14 @@ function buildApi({
       });
     },
 
+    async resendBatchToAdmin({ batchId }: { batchId: string }) {
+      workspace.store.setBatchUnsentToAdmin(batchId);
+      await logger.logAsCurrentRole(LogEventId.CentralScanNetworkStatus, {
+        message: `User requested that batch ${batchId} be sent to VxAdmin again.`,
+        batchId,
+      });
+    },
+
     async deleteBatch({ batchId }: { batchId: string }) {
       const numberOfBallotsInBatch = workspace.store
         .getBatches()

--- a/apps/central-scan/backend/src/networking.test.ts
+++ b/apps/central-scan/backend/src/networking.test.ts
@@ -7,12 +7,13 @@ import {
   NETWORK_POLLING_INTERVAL_MS,
   VxAdminHostMachine,
 } from '@votingworks/networking';
-import { mockBaseLogger } from '@votingworks/logging';
+import { mockBaseLogger, LogEventId } from '@votingworks/logging';
 import { readElectionGeneralDefinition } from '@votingworks/fixtures';
 import {
   DEV_MACHINE_ID,
   ElectionDefinition,
   TEST_JURISDICTION,
+  anyPollingPlace,
 } from '@votingworks/types';
 import { startScannerNetworking } from './networking.js';
 import { Store } from './store.js';
@@ -43,6 +44,7 @@ function buildMockHostApiClient(): MockHostApiClient {
       ok({
         machineId: HOST_MACHINE.machineId,
         codeVersion: 'dev',
+        importedBatchIds: [],
       })
     ),
     getCurrentElectionMetadata: vi.fn().mockResolvedValue(undefined),
@@ -304,6 +306,50 @@ test('reports invalid-mode, with the host mode, when the host is locked to the o
   expect(mockClient.registerScanner).toHaveBeenCalledWith(
     expect.objectContaining({ isTestMode: true })
   );
+});
+
+test('tracks the batches the host holds without logging a status change', async () => {
+  const logger = mockBaseLogger({ fn: vi.fn });
+  vi.mocked(findAllVxAdminHostMachines).mockResolvedValue([HOST_MACHINE]);
+  const mockClient = createMockHostApiClient();
+  mockClient.registerScanner.mockResolvedValue(
+    ok({ machineId: '0002', codeVersion: 'dev', importedBatchIds: [] })
+  );
+  const store = Store.memoryStore();
+  const electionDefinition = readElectionGeneralDefinition();
+  configureStore(store, electionDefinition);
+  store.setPollingPlaceId(anyPollingPlace(electionDefinition.election).id);
+  const batchId = store.addBatch();
+  store.setBatchSentToAdmin(batchId);
+  // Heartbeats sent in a later second than the batch was sent can vouch for
+  // whether the host holds it
+  vi.advanceTimersByTime(2_000);
+  startScannerNetworking({ logger, store });
+  await advancePollingInterval();
+  expect(store.getBatch(batchId).removedFromAdminAt).toBeDefined();
+  expect(logger.log).toHaveBeenCalledWith(
+    LogEventId.CentralScanNetworkStatus,
+    'system',
+    expect.objectContaining({
+      disposition: 'failure',
+      batchId,
+      hostMachineId: '0002',
+    })
+  );
+
+  // Marked once, not on every heartbeat
+  await advancePollingInterval();
+  expect(
+    vi
+      .mocked(logger.log)
+      .mock.calls.filter(([, , details]) => details?.['batchId'] === batchId)
+  ).toHaveLength(1);
+  // Only the offline → connected transition was logged
+  expect(
+    vi
+      .mocked(logger.log)
+      .mock.calls.filter(([, , details]) => details?.['newStatus'])
+  ).toHaveLength(1);
 });
 
 test('logs status transitions and returns to offline when the interface goes down', async () => {

--- a/apps/central-scan/backend/src/networking.ts
+++ b/apps/central-scan/backend/src/networking.ts
@@ -1,4 +1,4 @@
-import { deepEqual, throwIllegalValue } from '@votingworks/basics';
+import { Optional, throwIllegalValue } from '@votingworks/basics';
 import * as grout from '@votingworks/grout';
 import { BaseLogger, LogEventId } from '@votingworks/logging';
 import {
@@ -61,15 +61,23 @@ export function startScannerNetworking({
     message: 'Starting VxAdmin host discovery.',
   });
 
+  function hostMachineIdOf(info: NetworkConnectionInfo): Optional<string> {
+    return 'hostMachineId' in info ? info.hostMachineId : undefined;
+  }
+
+  // Logs only status and host changes, not every heartbeat's refresh of the
+  // host's imported-batch list.
   function setConnectionInfo(newInfo: NetworkConnectionInfo): void {
     const currentInfo = store.getNetworkConnectionInfo();
-    if (!deepEqual(currentInfo, newInfo)) {
+    if (
+      currentInfo.status !== newInfo.status ||
+      hostMachineIdOf(currentInfo) !== hostMachineIdOf(newInfo)
+    ) {
       logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
         message: `Scanner connection status changed from ${currentInfo.status} to ${newInfo.status}.`,
         previousStatus: currentInfo.status,
         newStatus: newInfo.status,
-        hostMachineId:
-          'hostMachineId' in newInfo ? newInfo.hostMachineId : 'none',
+        hostMachineId: hostMachineIdOf(newInfo) ?? 'none',
       });
     }
     store.setNetworkConnectionInfo(newInfo);
@@ -145,6 +153,7 @@ export function startScannerNetworking({
 
         const { machineId, codeVersion } = getMachineConfig();
         let registerResult;
+        const registerRequestedAt = Date.now();
         try {
           registerResult = await apiClient.registerScanner({
             machineId,
@@ -174,6 +183,18 @@ export function startScannerNetworking({
           hostMachineId,
           hostAddress: hostMachine.address,
         });
+        const removedBatches = store.markBatchesRemovedFromAdmin(
+          registerResult.ok().importedBatchIds,
+          registerRequestedAt
+        );
+        for (const batch of removedBatches) {
+          logger.log(LogEventId.CentralScanNetworkStatus, 'system', {
+            message: `${batch.label} was sent to VxAdmin ${hostMachineId}, but the host no longer holds its cast vote records. It can be sent again from the Scan Ballots screen.`,
+            disposition: 'failure',
+            batchId: batch.id,
+            hostMachineId,
+          });
+        }
       } catch (error) {
         // @coverage-exclude: defensive
         debug('Error in scanner networking loop: %s', error);

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -283,6 +283,44 @@ test('getBatches', () => {
   expect(batches).toHaveLength(0);
 });
 
+test('markBatchesRemovedFromAdmin', () => {
+  const store = Store.memoryStore();
+  store.setElectionAndJurisdiction({
+    electionData,
+    jurisdiction,
+    electionPackageHash,
+  });
+  store.setPollingPlaceId(anyPollingPlace(election).id);
+  const sentBatchId = store.addBatch();
+  store.setBatchSentToAdmin(sentBatchId);
+  const unsentBatchId = store.addBatch();
+  const earlierHeartbeat = Date.now() - 5_000;
+  const laterHeartbeat = Date.now() + 5_000;
+
+  // A heartbeat sent before the batch was sent can't know about it yet
+  expect(store.markBatchesRemovedFromAdmin([], earlierHeartbeat)).toEqual([]);
+  // The host holds the batch
+  expect(
+    store.markBatchesRemovedFromAdmin([sentBatchId], laterHeartbeat)
+  ).toEqual([]);
+  expect(store.getBatch(sentBatchId).removedFromAdminAt).toBeUndefined();
+
+  // A later heartbeat reports the host doesn't hold it; unsent batches are
+  // never involved
+  expect(store.markBatchesRemovedFromAdmin([], laterHeartbeat)).toEqual([
+    { id: sentBatchId, label: store.getBatch(sentBatchId).label },
+  ]);
+  expect(store.getBatch(sentBatchId).removedFromAdminAt).toBeDefined();
+  expect(store.getBatch(unsentBatchId).removedFromAdminAt).toBeUndefined();
+
+  // Already marked, so not reported again
+  expect(store.markBatchesRemovedFromAdmin([], laterHeartbeat)).toEqual([]);
+
+  // Sending the batch again clears the mark
+  store.setBatchUnsentToAdmin(sentBatchId);
+  expect(store.getBatch(sentBatchId).removedFromAdminAt).toBeUndefined();
+});
+
 test('canUnconfigure in test mode', () => {
   const store = Store.memoryStore();
   store.setElectionAndJurisdiction({

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -837,6 +837,7 @@ export class Store {
       count: number;
       sentToAdminAt: string | null;
       sendToAdminError: string | null;
+      removedFromAdminAt: string | null;
     }
     const batchInfo = this.client.all(`
       select
@@ -848,6 +849,7 @@ export class Store {
         (case when ended_at is null then ended_at else strftime('%s', ended_at) end) as endedAt,
         (case when sent_to_admin_at is null then sent_to_admin_at else strftime('%s', sent_to_admin_at) end) as sentToAdminAt,
         send_to_admin_error as sendToAdminError,
+        (case when removed_from_admin_at is null then removed_from_admin_at else strftime('%s', removed_from_admin_at) end) as removedFromAdminAt,
         error,
         sum(case when sheets.id is null then 0 else 1 end) as count
       from
@@ -886,6 +888,11 @@ export class Store {
         undefined,
       sendToAdminError: info.sendToAdminError || undefined,
       isSendingToAdmin: info.id === this.sendingToAdminBatchId || undefined,
+      removedFromAdminAt:
+        (info.removedFromAdminAt &&
+          // eslint-disable-next-line vx/gts-safe-number-parse
+          DateTime.fromSeconds(Number(info.removedFromAdminAt)).toISO()) ||
+        undefined,
     }));
   }
 
@@ -923,6 +930,50 @@ export class Store {
       'update batches set sent_to_admin_at = current_timestamp, send_to_admin_error = null where id = ?',
       batchId
     );
+  }
+
+  /**
+   * Clears a batch's sent-to-VxAdmin state so the sync loop sends it again,
+   * e.g. after its import was removed on the host.
+   */
+  setBatchUnsentToAdmin(batchId: string): void {
+    this.client.run(
+      `
+        update batches
+        set sent_to_admin_at = null, send_to_admin_error = null, removed_from_admin_at = null
+        where id = ?
+      `,
+      batchId
+    );
+  }
+
+  /**
+   * Marks as removed from the host any sent batch missing from the batches the
+   * VxAdmin host reported holding in a heartbeat sent at `requestedAt` (epoch
+   * milliseconds), and returns the newly marked batches. A batch sent after
+   * the heartbeat was requested doesn't count as missing, since the host may
+   * have committed it only after answering. `sent_to_admin_at` has one-second
+   * resolution, so the times are compared in whole seconds.
+   */
+  markBatchesRemovedFromAdmin(
+    hostBatchIds: string[],
+    requestedAt: number
+  ): Array<{ id: string; label: string }> {
+    return this.client.all(
+      `
+        update batches
+        set removed_from_admin_at = current_timestamp
+        where
+          deleted_at is null
+          and sent_to_admin_at is not null
+          and removed_from_admin_at is null
+          and cast(strftime('%s', sent_to_admin_at) as integer) < ?
+          and id not in (select value from json_each(?))
+        returning id, label
+      `,
+      Math.floor(requestedAt / 1000),
+      JSON.stringify(hostBatchIds)
+    ) as Array<{ id: string; label: string }>;
   }
 
   /**

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -330,6 +330,18 @@ export const retrySendBatchToAdmin = {
   },
 } as const;
 
+export const resendBatchToAdmin = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.resendBatchToAdmin, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
 export const deleteBatch = {
   useMutation() {
     const apiClient = useApiClient();

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -125,6 +125,44 @@ test('shows a batch waiting to retry as sending', async () => {
   expect(rows[1]).toHaveTextContent('Not sent');
 });
 
+test('shows a batch removed from VxAdmin with a resend button', async () => {
+  apiMock.setNetworkStatus({
+    isEnabled: true,
+    connection: {
+      status: 'online-host-detected',
+      hostMachineId: '0002',
+      hostAddress: 'http://169.254.10.20:3002',
+    },
+  });
+  const sentAt = new Date(2026, 7, 25, 10, 0).toISOString();
+  const status: ScanStatus = mockStatus({
+    batches: [
+      mockBatch({
+        id: 'still-on-admin',
+        label: 'Batch 1',
+        sentToAdminAt: sentAt,
+      }),
+      mockBatch({
+        id: 'removed',
+        label: 'Batch 2',
+        sentToAdminAt: sentAt,
+        removedFromAdminAt: sentAt,
+      }),
+    ],
+  });
+  renderScreen({ status });
+  await screen.findByText('Removed from VxAdmin');
+  const rows = screen.getAllByRole('row').slice(1);
+  expect(rows[0]).not.toHaveTextContent('Removed from VxAdmin');
+  expect(rows[1]).toHaveTextContent('Removed from VxAdmin');
+
+  apiMock.apiClient.resendBatchToAdmin
+    .expectCallWith({ batchId: 'removed' })
+    .resolves();
+  userEvent.click(screen.getButton('Resend'));
+  await vi.waitFor(() => apiMock.assertComplete());
+});
+
 test.each([
   {
     hostCvrFileMode: 'official' as const,

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -26,6 +26,7 @@ import { ScanButton } from '../components/scan_button.js';
 import {
   clearBallotData,
   getNetworkStatus,
+  resendBatchToAdmin,
   retrySendBatchToAdmin,
 } from '../api.js';
 
@@ -144,11 +145,21 @@ interface BatchSendState {
   /** What the "Sent At" cell shows. */
   contents: JSX.Element;
   /** An operator action offered beside Delete, if any. */
-  action?: 'retry';
+  action?: 'retry' | 'resend';
 }
 
 function getBatchSendState(batch: BatchInfo): BatchSendState {
   if (batch.sentToAdminAt) {
+    if (batch.removedFromAdminAt) {
+      return {
+        contents: (
+          <React.Fragment>
+            <Icons.Warning color="warning" /> Removed from VxAdmin
+          </React.Fragment>
+        ),
+        action: 'resend',
+      };
+    }
     return {
       contents: <Timestamp>{shortDateTime(batch.sentToAdminAt)}</Timestamp>,
     };
@@ -196,6 +207,7 @@ export function ScanBallotsScreen({
   const networkStatus = networkStatusQuery.data;
   const isNetworkingEnabled = networkStatus?.isEnabled ?? false;
   const retrySendMutation = retrySendBatchToAdmin.useMutation();
+  const resendMutation = resendBatchToAdmin.useMutation();
   const [deleteBallotDataFlowState, setDeleteBallotDataFlowState] = useState<
     'confirmation' | 'deleting'
   >();
@@ -320,6 +332,16 @@ export function ScanBallotsScreen({
                                 disabled={retrySendMutation.isLoading}
                               >
                                 Retry
+                              </Button>
+                            )}
+                            {sendState?.action === 'resend' && (
+                              <Button
+                                onPress={() =>
+                                  resendMutation.mutate({ batchId: batch.id })
+                                }
+                                disabled={resendMutation.isLoading}
+                              >
+                                Resend
                               </Button>
                             )}
                             <Button

--- a/libs/networking/src/index.ts
+++ b/libs/networking/src/index.ts
@@ -18,6 +18,7 @@ export type {
   CvrTransferManifest,
   FinishCvrTransferError,
   RegisterScannerError,
+  ScannerRegistration,
   StartCvrTransferError,
   VxAdminHostApi,
   VxAdminHostMachineConfig,

--- a/libs/networking/src/vx_admin_host_api.ts
+++ b/libs/networking/src/vx_admin_host_api.ts
@@ -27,6 +27,15 @@ export type RegisterScannerError =
    */
   | { type: 'invalid-mode'; currentMode: 'test' | 'official' };
 
+/** What a VxAdmin host returns to a scanner it has registered. */
+export interface ScannerRegistration extends VxAdminHostMachineConfig {
+  /**
+   * IDs of this scanner's batches whose cast vote records the host currently
+   * holds. Lets the scanner notice a batch that was removed on the host.
+   */
+  importedBatchIds: string[];
+}
+
 /**
  * Manifest describing one scanned batch being transferred to a VxAdmin host.
  * Mirrors the per-batch entries in a USB cast vote record export's batch
@@ -89,7 +98,7 @@ export type VxAdminHostApi = Api<{
     pollingPlaceId?: string;
     /** Whether the scanner is in test ballot mode. */
     isTestMode: boolean;
-  }) => Result<VxAdminHostMachineConfig, RegisterScannerError>;
+  }) => Result<ScannerRegistration, RegisterScannerError>;
   /**
    * Read-only, side-effect-free method also used by scanners as a
    * reachability probe when verifying advertised hosts.

--- a/libs/types/src/election.ts
+++ b/libs/types/src/election.ts
@@ -1491,6 +1491,12 @@ export interface BatchInfo {
    * used on VxCentralScan.
    */
   isSendingToAdmin?: boolean;
+  /**
+   * When the VxAdmin host this batch was sent to reported no longer holding
+   * its cast vote records, e.g. because they were removed on the host. Only
+   * used on VxCentralScan.
+   */
+  removedFromAdminAt?: Iso8601Timestamp;
 }
 
 export const BallotCastingModeSchema = z.enum(['early_voting', 'election_day']);


### PR DESCRIPTION
## Overview
Closes https://github.com/votingworks/vxsuite/issues/9029 
Adds to the heartbeat of VxAdmin a list of all of its imported batches per scanner. This allows VxCentralScan to monitor for any batches that have been deleted by VxAdmin and surface a warning and the ability to resend if there are missing batches. 

I am a little concerned about:
1. Returning the list of batchIds per scanner on every heartbeat request  and
2. On central-scan side scanning our batch table for missing row from the response on every heartbeat request

But in reality we only expect up to 500-1000 batches so the data taken to transfer that many uuids is still very small, and in basic testing the db queries are all still very fast. Claude estimates it won't become problematic unless a single scanner is handling tens of thousands of batches. 

If we are concerned about the cost of monitoring we could just add "resend" as an option to all batches (maybe under EM only) to still allow manually recovery for this scenario. 

If all CVRs are removed from VxAdmin then VxCentralScan will show "Removed from VxAdmin" on all batch rows, we could special case this scenario but I think this is fine for now. 

## Demo Video or Screenshot

https://github.com/user-attachments/assets/fb4c50d0-6b2b-455e-88b2-2df5a90bd7ee



## Testing Plan
See demo video. 

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
