### PR TITLE
test(backend): add coverage for non-`Error` branch

### DIFF
--- a/libs/backend/src/hash.test.ts
+++ b/libs/backend/src/hash.test.ts
@@ -48,22 +48,25 @@ test('HashingPassthrough.digest() asserts stream is fully hashed', () => {
   expect(() => hashingStream.digest('hex')).toThrow(/incomplete hash/);
 });
 
-test('HashingPassthrough - propagates errors', async () => {
-  const error = new Error('something went wrong');
+test.each([new Error('something went wrong'), 'not an Error object'])(
+  'HashingPassthrough - propagates errors',
+  async (error) => {
+    const mockHash = {
+      digest: vi.fn(),
+      update: vi.fn(() => {
+        throw error;
+      }),
+    } as const as unknown as Hash;
 
-  const mockHash = {
-    digest: vi.fn(),
-    update: vi.fn(() => {
-      throw error;
-    }),
-  } as const as unknown as Hash;
+    const hashingStream = new HashingPassthrough(mockHash);
+    hashingStream.write(Buffer.of(0xca, 0xfe));
+    hashingStream.end();
 
-  const hashingStream = new HashingPassthrough(mockHash);
-  hashingStream.write(Buffer.of(0xca, 0xfe));
-  hashingStream.end();
-
-  await expect(async () => await buffer(hashingStream)).rejects.toThrow(error);
-});
+    await expect(async () => await buffer(hashingStream)).rejects.toThrow(
+      error
+    );
+  }
+);
 
 function tempFile(): { outputPath: string; outputStream: WriteStream } {
   const outputPath = makeTemporaryFile();


### PR DESCRIPTION
This fixes a logical merge conflict between #9285 and #9281.

```
  × coverage(uncovered-branch): branch arm (cond-expr) is never taken in tests
    ╭─[src/hash.ts:49:48]
 48 │     } catch (e) {
 49 │       return callback(e instanceof Error ? e : new Error(util.inspect(e)));
    ·                                                ──────────────┬─────────────
    ·                                                              ╰── not covered
 50 │     }
    ╰────
  help: add a test that exercises this code, or mark it with @coverage-defer or @coverage-exclude

☂️ coverage summary: 1 uncovered (29 deferred, 155 excluded)
```