### PR TITLE
test: always use `verbose` mode

### DIFF
--- a/vitest.config.shared.mts
+++ b/vitest.config.shared.mts
@@ -55,7 +55,7 @@ export const base: vitest.ViteUserConfig = {
     // `store_test_results` with nothing to upload. It writes to the file
     // rather than the console, so local output is unaffected (`junit.xml` is
     // gitignored).
-    reporters: isCI ? ['verbose', 'junit'] : ['junit'],
+    reporters: ['verbose', 'junit'],
     outputFile: 'reports/junit.xml',
     // 10s everywhere. A full-workspace `pnpm test` runs many suites at once and
     // briefly oversubscribes the CPU, so a tighter budget would flake


### PR DESCRIPTION
## Overview

`CI` is not set locally, so test output is only written to the junit file when running tests locally. That's clearly not ideal.

## Demo Video or Screenshot

**Before:**

```
cache miss, executing da98692aa6048207

> @votingworks/backend@1.0.0 test:run:self /home/vx/code/vxsuite/libs/backend
> TZ=America/Anchorage vitest run

JUNIT report written to /home/vx/code/vxsuite/libs/backend/reports/junit.xml

 Tasks:    17 successful, 17 total
Cached:    16 cached, 17 total
```

**After:**

```
...
 ✓ src/cast_vote_records/export.test.ts > doesUsbDriveRequireCastVoteRecordSync - 'cast vote record root hash in metadat…' 177mss/backend:test:run:self:
 ✓ src/cast_vote_records/export.test.ts > doesUsbDriveRequireCastVoteRecordSync caching works 2ms
 ✓ src/cast_vote_records/export.test.ts > change in USB drive status clears doesUsbDriveRequireCastVoteRecordSync cache 1msgworks/backend:test:run:self:
 ✓ src/cast_vote_records/export.test.ts > full cast vote record export on precinct scanner clears doesUsbDriveRequireCastVoteRecordSync cache 525msself:
 ✓ src/cast_vote_records/export.test.ts > tracking pending continuous export operations 581ms
 ✓ src/cast_vote_records/export.test.ts > export and subsequent import of that export 978ms
 ✓ src/cast_vote_records/export.test.ts > recovery export 853ms
 ✓ src/cast_vote_records/export.test.ts > recovery export expectedly errors if USB drive has been swapped 172ms
 ✓ src/cast_vote_records/export.test.ts > recovery export expectedly errors if hash check fails 206ms
 ✓ src/cast_vote_records/export.test.ts > ballot_casting_mode is not exported for central scanners 231ms
 ✓ src/cast_vote_records/export.test.ts > ballot_casting_mode is exported per batch for precinct scanners - continuous export 256msackend:test:run:self:
 ✓ src/cast_vote_records/export.test.ts > ballot_casting_mode is exported per batch for precinct scanners - full export 224msorks/backend:test:run:self:
 ✓ src/cast_vote_records/export.test.ts > ballot_casting_mode is preserved from batch creation - polls closing export 238msgworks/backend:test:run:self:

 Test Files  47 passed (47)
      Tests  383 passed (383)
   Start at  09:38:10
   Duration  13.01s (transform 3.35s, setup 9.13s, import 8.08s, tests 18.25s, environment 4ms)

JUNIT report written to /home/vx/code/vxsuite-brian-test-backend-fix-coverage-conflict-9281-9285/libs/backend/reports/junit.xml

 Tasks:    17 successful, 17 total
Cached:    17 cached, 17 total
```

## Testing Plan
Ran locally, see above.
