### PR TITLE
test: avoid cache misses by not passing test args to turbo build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,9 +253,14 @@ actual work (tsc/eslint/vitest). In Turbo mode `vx-task` runs
 `build:self`/`^build:self` first, so the task never runs against unbuilt deps);
 when opted out it runs the pnpm equivalent. Extra args pass straight through, so
 `pnpm test:run <file>` and `pnpm test:run -t "pattern"` still work in both
-modes. `validate-monorepo` enforces that any package defining a `:self` task
-delegates its public task to `vx-task`. The dev-time watcher `pnpm test` is not
-a delegated task (it's persistent and interactive); it prefixes
+modes. A test run with extra args is not itself cached, though: Turbo folds
+pass-through args into the hash of every task in the run (dependency builds
+included), which would rebuild the whole dependency graph per distinct argument
+list, so `vx-task` instead builds the deps through Turbo and runs the package's
+`test:run:self`/`test:ci:self` directly with the args. `validate-monorepo`
+enforces that any package defining a `:self` task delegates its public task to
+`vx-task`. The dev-time watcher `pnpm test` is not a delegated task (it's
+persistent and interactive); it prefixes
 `pnpm -w vx-task build $npm_package_name` (which builds deps via Turbo or pnpm
 per the switch) and then execs `vitest` directly, so deps are built once up
 front while the watcher keeps its native UI.

--- a/script/vx-task
+++ b/script/vx-task
@@ -38,8 +38,15 @@ if use_turbo; then
     build) exec turbo run build:self --filter="${pkg}" ;;
     clean) exec turbo run clean:self --filter="${pkg}..." ;;
     lint) exec turbo run lint:self --filter="${pkg}" -- "$@" ;;
-    test:run) exec turbo run test:run:self --filter="${pkg}" -- "$@" ;;
-    test:ci) exec turbo run test:ci:self --filter="${pkg}" -- "$@" ;;
+    test:run | test:ci)
+      # Only pass arguments through to the `test:*` task, not the `build:self`
+      # tasks in order to avoid unnecessary cache misses.
+      if [[ $# -gt 0 ]]; then
+        turbo run build:self --filter="${pkg}"
+        exec pnpm --filter "${pkg}" "${task}:self" "$@"
+      fi
+      exec turbo run "${task}:self" --filter="${pkg}"
+      ;;
     it-deps) exec turbo run build:self --filter="${pkg}^..." ;;
     it-prebuild) exec pnpm --filter "${pkg}" build ;;
     *)


### PR DESCRIPTION
## Overview
When running `turbo` the extra arguments passed are part of the input and change the cache key. Arguments to `test:*:self` only apply to `vitest`, not to the build, so we now split up the build and test commands if there are arguments given.

## Demo Video or Screenshot

```
###
# PR branch (note all "cache hit")
###

$ pnpm test:run --coverage

> @votingworks/basics@1.0.0 test:run /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics
> pnpm -w vx-task test:run $npm_package_name --coverage


> vxsuite@ vx-task /home/vx/code/vxsuite-brian-turbo-caching-broken-locally
> script/vx-task test:run @votingworks/basics --coverage

• turbo 2.10.5

   • Packages in scope: @votingworks/basics
   • Running build:self in 1 packages
   • Remote caching disabled, using shared worktree cache

@votingworks/coverage-check:build:self: cache hit, replaying logs 2b4ec7e69a7d20fc
@votingworks/coverage-check:build:self:
@votingworks/coverage-check:build:self: > @votingworks/coverage-check@1.0.0 build:self /home/vx/code/vxsuite-brian-test-backend-fix-coverage-conflict-9281-9285/libs/coverage-check
@votingworks/coverage-check:build:self: > tsc --build tsconfig.build.json
@votingworks/coverage-check:build:self:
eslint-plugin-vx:build:self: cache hit, replaying logs c667572c93e9707c
eslint-plugin-vx:build:self:
eslint-plugin-vx:build:self: > eslint-plugin-vx@1.0.0 build:self /home/vx/code/vxsuite-brian-test-backend-fix-coverage-conflict-9281-9285/libs/eslint-plugin-vx
eslint-plugin-vx:build:self: > tsc --build tsconfig.build.json
eslint-plugin-vx:build:self:
@votingworks/basics:build:self: cache hit, replaying logs 2f7db2e671fae38c
@votingworks/basics:build:self:
@votingworks/basics:build:self: > @votingworks/basics@1.0.0 build:self /home/vx/code/vxsuite-brian-test-backend-fix-coverage-conflict-9281-9285/libs/basics
@votingworks/basics:build:self: > tsc --build tsconfig.build.json
@votingworks/basics:build:self:

 Tasks:    3 successful, 3 total
Cached:    3 cached, 3 total
  Time:    22ms >>> FULL TURBO


> @votingworks/basics@1.0.0 test:run:self /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics
> vitest run --coverage


 RUN  v4.1.6 /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics
      Coverage enabled with istanbul

 ✓ src/deferred.test.ts > resolves with value passed to resolve 1ms
 ✓ src/deferred.test.ts > rejects with value passed to reject 1ms
 ✓ src/deferred.test.ts > queue isEmpty 0ms
[...SNIP...]
 ✓ src/iterators/async_iterator_plus.test.ts > reduce 11ms
 ✓ src/iterators/async_iterator_plus.test.ts > single ownership 0ms
 ✓ src/iterators/async_iterator_plus.test.ts > cycle 13ms

 Test Files  24 passed (24)
      Tests  221 passed (221)
   Start at  11:03:32
   Duration  991ms (transform 5.87s, setup 0ms, import 8.15s, tests 398ms, environment 2ms)

JUNIT report written to /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics/reports/junit.xml

☂️ coverage summary: 0 uncovered (6 excluded)


###
# BACK TO `main`
###

$ git reset --hard origin/main
HEAD is now at 2622098d86 test: always use `verbose` mode (#9294)

###
# WITHOUT FIX (note all "cache miss")
###

$ pnpm test:run --coverage

> @votingworks/basics@1.0.0 test:run /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics
> pnpm -w vx-task test:run $npm_package_name --coverage


> vxsuite@ vx-task /home/vx/code/vxsuite-brian-turbo-caching-broken-locally
> script/vx-task test:run @votingworks/basics --coverage

• turbo 2.10.5

   • Packages in scope: @votingworks/basics
   • Running test:run:self in 1 packages
   • Remote caching disabled, using shared worktree cache

@votingworks/coverage-check:build:self: cache miss, executing 689e217151552ad8
@votingworks/coverage-check:build:self:
@votingworks/coverage-check:build:self: > @votingworks/coverage-check@1.0.0 build:self /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/coverage-check
@votingworks/coverage-check:build:self: > tsc --build tsconfig.build.json
@votingworks/coverage-check:build:self:
eslint-plugin-vx:build:self: cache miss, executing 5e61cd20720a31e8
eslint-plugin-vx:build:self:
eslint-plugin-vx:build:self: > eslint-plugin-vx@1.0.0 build:self /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/eslint-plugin-vx
eslint-plugin-vx:build:self: > tsc --build tsconfig.build.json
eslint-plugin-vx:build:self:
@votingworks/basics:build:self: cache miss, executing 171b5e772810cc1c
@votingworks/basics:build:self:
@votingworks/basics:build:self: > @votingworks/basics@1.0.0 build:self /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics
@votingworks/basics:build:self: > tsc --build tsconfig.build.json
@votingworks/basics:build:self:
@votingworks/basics:test:run:self: cache miss, executing bc4982f868237567
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self: > @votingworks/basics@1.0.0 test:run:self /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics
@votingworks/basics:test:run:self: > vitest run --coverage
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self:  RUN  v4.1.6 /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics
@votingworks/basics:test:run:self:       Coverage enabled with istanbul
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self:  ✓ src/range.test.ts > range 2ms
@votingworks/basics:test:run:self:  ✓ src/sleep.test.ts > sleep 2ms
@votingworks/basics:test:run:self:  ✓ src/deferred.test.ts > resolves with value passed to resolve 2ms
@votingworks/basics:test:run:self:  ✓ src/deferred.test.ts > rejects with value passed to reject 1ms
@votingworks/basics:test:run:self:  ✓ src/deferred.test.ts > queue isEmpty 0ms
[...SNIP...]
@votingworks/basics:test:run:self:  ✓ src/iterators/iterator_plus.test.ts > reduce 7ms
@votingworks/basics:test:run:self:  ✓ src/iterators/iterator_plus.test.ts > single ownership 0ms
@votingworks/basics:test:run:self:  ✓ src/iterators/iterator_plus.test.ts > cycle 10ms
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self:  Test Files  24 passed (24)
@votingworks/basics:test:run:self:       Tests  221 passed (221)
@votingworks/basics:test:run:self:    Start at  11:04:18
@votingworks/basics:test:run:self:    Duration  948ms (transform 5.08s, setup 0ms, import 7.25s, tests 454ms, environment 2ms)
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self: JUNIT report written to /home/vx/code/vxsuite-brian-turbo-caching-broken-locally/libs/basics/reports/junit.xml
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self: ☂️ coverage summary: 0 uncovered (6 excluded)
@votingworks/basics:test:run:self:
@votingworks/basics:test:run:self:

 Tasks:    4 successful, 4 total
Cached:    0 cached, 4 total
  Time:    2.727s
```

## Testing Plan
Ran locally in `libs/basics`. See above.