### PR TITLE
Fix pnpm test:run command in libs/logging

### DIFF
--- a/libs/logging/package.json
+++ b/libs/logging/package.json
@@ -24,7 +24,7 @@
     "lint:self": "pnpm type-check && eslint --cache .",
     "test": "pnpm -w vx-task build $npm_package_name && TZ=America/Anchorage vitest",
     "test:run": "pnpm -w vx-task test:run $npm_package_name",
-    "test:run:self": "TZ=America/Anchorage vitest run && pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check",
+    "test:run:self": "pnpm build:generate-typescript-types --check && pnpm build:generate-rust-types --check && TZ=America/Anchorage vitest run",
     "type-check": "tsc --build"
   },
   "dependencies": {

--- a/libs/logging/scripts/generate_documentation.ts
+++ b/libs/logging/scripts/generate_documentation.ts
@@ -38,30 +38,30 @@ interface GenerateDocumentationFileArguments {
   app?: string;
   model?: string;
 }
-const args: GenerateDocumentationFileArguments = yargs(
-  process.argv.slice(2)
-).options({
-  output: {
-    type: 'string',
-    alias: 'o',
-    description: 'Path to write output file to',
-  },
-  format: {
-    choices: ['cdf', 'markdown'] as const,
-    alias: 'f',
-    default: 'markdown',
-  },
-  app: {
-    type: 'string',
-    description:
-      'When writing in the CDF format you must specify which frontend app to build the documentation for.',
-  },
-  model: {
-    type: 'string',
-    description:
-      'When writing in the CDF format you must specify a model name such as VxAdmin 1.0 .',
-  },
-}).argv as GenerateDocumentationFileArguments;
+const args: GenerateDocumentationFileArguments = yargs(process.argv.slice(2))
+  .strict()
+  .options({
+    output: {
+      type: 'string',
+      alias: 'o',
+      description: 'Path to write output file to',
+    },
+    format: {
+      choices: ['cdf', 'markdown'] as const,
+      alias: 'f',
+      default: 'markdown',
+    },
+    app: {
+      type: 'string',
+      description:
+        'When writing in the CDF format you must specify which frontend app to build the documentation for.',
+    },
+    model: {
+      type: 'string',
+      description:
+        'When writing in the CDF format you must specify a model name such as VxAdmin 1.0 .',
+    },
+  }).argv as GenerateDocumentationFileArguments;
 
 function validateAppInput(name?: string): AppName {
   if (name === undefined) {

--- a/libs/logging/scripts/generate_rust_enums_from_toml.ts
+++ b/libs/logging/scripts/generate_rust_enums_from_toml.ts
@@ -106,13 +106,15 @@ function* generateLogEventIdEnum(config: LoggingConfig): Generator<string> {
   yield 'derive_display!(EventId);';
 }
 
-const argv: GenerateTypesArgs = yargs(process.argv.slice(2)).options({
-  check: {
-    type: 'boolean',
-    description:
-      'Check that generated output equals the existing file on disk. Does not overwrite existing file.',
-  },
-}).argv as GenerateTypesArgs;
+const argv: GenerateTypesArgs = yargs(process.argv.slice(2))
+  .strict()
+  .options({
+    check: {
+      type: 'boolean',
+      description:
+        'Check that generated output equals the existing file on disk. Does not overwrite existing file.',
+    },
+  }).argv as GenerateTypesArgs;
 
 async function main(): Promise<void> {
   const { check } = argv;

--- a/libs/logging/scripts/generate_types_from_toml.ts
+++ b/libs/logging/scripts/generate_types_from_toml.ts
@@ -124,13 +124,15 @@ function* generateGetLogEventTypeDocumentation(
   }`;
 }
 
-const argv: GenerateTypesArgs = yargs(process.argv.slice(2)).options({
-  check: {
-    type: 'boolean',
-    description:
-      'Check that generated output equals the existing file on disk. Does not overwrite existing file.',
-  },
-}).argv as GenerateTypesArgs;
+const argv: GenerateTypesArgs = yargs(process.argv.slice(2))
+  .strict()
+  .options({
+    check: {
+      type: 'boolean',
+      description:
+        'Check that generated output equals the existing file on disk. Does not overwrite existing file.',
+    },
+  }).argv as GenerateTypesArgs;
 
 async function main(): Promise<void> {
   const { check } = argv;


### PR DESCRIPTION
🤖 Generated with Claude Code

## Overview

Our method of running test coverage locally is to run `pnpm test:run --coverage` in a package. In libs/logging, the test script chained `vitest run && <two type generator --check commands>`, so the `--coverage` was getting passed to the `--check` command instead of `vitest`. The `--check` command silently ignored unknown flags, so tests passed but coverage never ran.

This PR reorders the commands so `vitest` is at the end. It also switches libs/logging's three yargs scripts to `.strict()`, so unknown arguments now fail loudly.

## Demo Video or Screenshot

N/A

## Testing Plan

- Manually tested this script
- Checked the rest of the repo. The other three chained test scripts already have vitest last and chain `cargo test`, which rejects unknown flags on its own.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
