### PR TITLE
WIP libs/printing job state tracking

### DIFF
--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -17,6 +17,7 @@ import {
   Election,
   getBallotStyle,
   getContests,
+  PrintJobId,
 } from '@votingworks/types';
 import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import {
@@ -50,7 +51,7 @@ export interface PrintBallotProps extends ClientParams {
 
 type PrintBlankBallotProps = Omit<PrintBallotProps, 'votes' | 'languageCode'>;
 
-export async function printBallot(p: PrintBallotProps): Promise<void> {
+export async function printBallot(p: PrintBallotProps): Promise<PrintJobId> {
   const { printer, store, precinctId, ballotStyleId, votes, languageCode } = p;
 
   const systemSettings = assertDefined(store.getSystemSettings());
@@ -231,7 +232,7 @@ function getBaseBallotPdf(
   return { election, baseBallotPdf };
 }
 
-async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
+async function printBubbleBallot(p: PrintBallotProps): Promise<PrintJobId> {
   const { election, baseBallotPdf } = getBaseBallotPdf(
     p.store,
     p.ballotStyleId,
@@ -255,7 +256,7 @@ async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
 
 export async function printBlankBallot(
   p: PrintBlankBallotProps
-): Promise<void> {
+): Promise<PrintJobId> {
   const { election, baseBallotPdf } = getBaseBallotPdf(
     p.store,
     p.ballotStyleId,
@@ -269,7 +270,7 @@ export async function printBlankBallot(
   });
 }
 
-async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
+async function printMarkOverlay(p: PrintBallotProps): Promise<PrintJobId> {
   const { electionDefinition } = assertDefined(p.store.getElectionRecord());
   const { election } = electionDefinition;
 

--- a/libs/printing/src/printer/configure.test.ts
+++ b/libs/printing/src/printer/configure.test.ts
@@ -36,5 +36,7 @@ test('calls lpadmin with expected args', async () => {
     '-P',
     getPpdPath(config),
     '-E',
+    '-o',
+    'printer-error-policy=abort-job',
   ]);
 });

--- a/libs/printing/src/printer/configure.ts
+++ b/libs/printing/src/printer/configure.ts
@@ -24,7 +24,11 @@ export async function configurePrinter({
     uri,
     '-P',
     getPpdPath(config),
-    '-E', // immediately enable the printer
+    '-E',
+    // Abort failed jobs so they don't get retried 5 minutes later, possibly resulting
+    // in unexpectedly printing a ballot
+    '-o',
+    'printer-error-policy=abort-job',
   ];
 
   debug('configuring printer with lpadmin: args=%o', lpadminConfigureArgs);

--- a/libs/printing/src/printer/ipp_queries/get-job-attributes.ipp
+++ b/libs/printing/src/printer/ipp_queries/get-job-attributes.ipp
@@ -1,0 +1,9 @@
+{
+  OPERATION Get-Job-Attributes
+  GROUP operation-attributes-tag
+  ATTR charset attributes-charset utf-8
+  ATTR language attributes-natural-language en
+  ATTR uri printer-uri $uri
+  ATTR integer job-id $job-id
+  ATTR keyword requested-attributes job-state,job-printer-state-message
+}

--- a/libs/printing/src/printer/job_monitor.test.ts
+++ b/libs/printing/src/printer/job_monitor.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { deferred, err, ok } from '@votingworks/basics';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
+import { PrintJobId, PrintJobStatus } from '@votingworks/types';
+import {
+  JOB_POLL_INTERVAL_MS,
+  JOB_TIMEOUT_MS,
+  MAX_CONSECUTIVE_QUERY_FAILURES,
+  TERMINAL_STATUS_RETENTION_MS,
+  startPrintJobMonitor,
+} from './job_monitor';
+import { queryJobStatus } from './job_status';
+
+vi.mock(import('./job_status.js'), async (importActual) => ({
+  ...(await importActual()),
+  queryJobStatus: vi.fn(),
+}));
+
+const queryJobStatusMock = vi.mocked(queryJobStatus);
+
+const JOB_ID: PrintJobId = 42;
+
+let status: PrintJobStatus | undefined;
+let setStatus: (next: PrintJobStatus) => void;
+let clearStatus: () => void;
+let logger: ReturnType<typeof mockBaseLogger>;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: false });
+  status = undefined;
+  setStatus = vi.fn((next: PrintJobStatus) => {
+    status = next;
+  });
+  clearStatus = vi.fn(() => {
+    status = undefined;
+  });
+  logger = mockBaseLogger({ fn: vi.fn });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function start() {
+  return startPrintJobMonitor({
+    jobId: JOB_ID,
+    setStatus,
+    clearStatus,
+    logger,
+  });
+}
+
+/**
+ * The async variant is required so the awaited query settles inside the tick.
+ */
+async function advancePolls(count = 1): Promise<void> {
+  await vi.advanceTimersByTimeAsync(JOB_POLL_INTERVAL_MS * count);
+}
+
+test('records the job as in progress before the first poll', () => {
+  start();
+  expect(status).toEqual({ outcome: 'in-progress' });
+  expect(queryJobStatusMock).not.toHaveBeenCalled();
+});
+
+test('stays in progress while CUPS reports the job in progress', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'in-progress' }));
+  start();
+
+  await advancePolls(3);
+
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(3);
+  expect(status).toEqual({ outcome: 'in-progress' });
+  expect(logger.log).not.toHaveBeenCalled();
+});
+
+test('finishes and stops polling when the job is sent to the printer', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  start();
+
+  await advancePolls();
+
+  expect(status).toEqual({ outcome: 'sent-to-printer' });
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.PrinterPrintComplete,
+    'system',
+    {
+      message: 'CUPS finished sending the print job to the printer.',
+      disposition: 'success',
+      jobId: JOB_ID,
+    }
+  );
+
+  // polling stopped
+  await advancePolls(3);
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(1);
+});
+
+test('reports the diagnostic message when the job fails', async () => {
+  queryJobStatusMock.mockResolvedValue(
+    ok({ outcome: 'failed', reason: 'Unable to send data to printer.' })
+  );
+  start();
+
+  await advancePolls();
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: 'Unable to send data to printer.',
+  });
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.PrinterPrintComplete,
+    'system',
+    {
+      message: 'CUPS did not send the print job to the printer.',
+      disposition: 'failure',
+      jobId: JOB_ID,
+      reason: 'Unable to send data to printer.',
+    }
+  );
+});
+
+test('fails immediately when CUPS has no record of the job', async () => {
+  queryJobStatusMock.mockResolvedValue(
+    err({ type: 'unknown-job', message: 'CUPS did not return job 42' })
+  );
+  start();
+
+  await advancePolls();
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: `CUPS has no record of print job ${JOB_ID}.`,
+  });
+});
+
+test('retries a failed query and recovers', async () => {
+  queryJobStatusMock
+    .mockResolvedValueOnce(err({ type: 'query-failed', message: 'boom' }))
+    .mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  start();
+
+  await advancePolls();
+  expect(status).toEqual({ outcome: 'in-progress' });
+
+  await advancePolls();
+  expect(status).toEqual({ outcome: 'sent-to-printer' });
+});
+
+test('fails after consecutive query failures', async () => {
+  queryJobStatusMock.mockResolvedValue(
+    err({ type: 'query-failed', message: 'connection refused' })
+  );
+  start();
+
+  await advancePolls(MAX_CONSECUTIVE_QUERY_FAILURES - 1);
+  expect(status).toEqual({ outcome: 'in-progress' });
+
+  await advancePolls();
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: 'Unable to reach CUPS for print job status: connection refused',
+  });
+});
+
+test('resets the failure count after a successful query', async () => {
+  queryJobStatusMock
+    .mockResolvedValueOnce(err({ type: 'query-failed', message: 'boom' }))
+    .mockResolvedValueOnce(err({ type: 'query-failed', message: 'boom' }))
+    .mockResolvedValueOnce(ok({ outcome: 'in-progress' }))
+    .mockResolvedValue(err({ type: 'query-failed', message: 'boom' }));
+  start();
+
+  // two failures, then a success, then two more failures: never three in a row
+  await advancePolls(5);
+  expect(status).toEqual({ outcome: 'in-progress' });
+});
+
+test('treats an unparseable response as a failed query', async () => {
+  queryJobStatusMock.mockRejectedValue(new Error('Unable to parse ipptool'));
+  start();
+
+  await advancePolls(MAX_CONSECUTIVE_QUERY_FAILURES);
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason:
+      'Unable to reach CUPS for print job status: Unable to parse ipptool',
+  });
+});
+
+test('an unparseable response after the timeout is ignored', async () => {
+  const query = deferred<Awaited<ReturnType<typeof queryJobStatus>>>();
+  queryJobStatusMock.mockReturnValue(query.promise);
+  start();
+
+  await advancePolls();
+  await vi.advanceTimersByTimeAsync(JOB_TIMEOUT_MS);
+
+  query.reject(new Error('Unable to parse ipptool'));
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: `Print job did not reach a terminal state within ${JOB_TIMEOUT_MS}ms.`,
+  });
+  expect(logger.log).toHaveBeenCalledTimes(1);
+});
+
+test('fails the job if it never reaches a terminal state', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'in-progress' }));
+  start();
+
+  await vi.advanceTimersByTimeAsync(JOB_TIMEOUT_MS);
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: `Print job did not reach a terminal state within ${JOB_TIMEOUT_MS}ms.`,
+  });
+  expect(logger.log).toHaveBeenCalledTimes(1);
+});
+
+test('a query that resolves after the timeout does not overwrite the outcome', async () => {
+  const query = deferred<Awaited<ReturnType<typeof queryJobStatus>>>();
+  queryJobStatusMock.mockReturnValue(query.promise);
+  start();
+
+  // start a poll, then let the timeout fire while it is still in flight
+  await advancePolls();
+  await vi.advanceTimersByTimeAsync(JOB_TIMEOUT_MS);
+  expect(status?.outcome).toEqual('failed');
+
+  query.resolve(ok({ outcome: 'sent-to-printer' }));
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(status?.outcome).toEqual('failed');
+  expect(logger.log).toHaveBeenCalledTimes(1);
+});
+
+test('a query slower than the poll interval does not run concurrently', async () => {
+  const query = deferred<Awaited<ReturnType<typeof queryJobStatus>>>();
+  queryJobStatusMock.mockReturnValue(query.promise);
+  start();
+
+  await advancePolls(3);
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(1);
+
+  query.resolve(ok({ outcome: 'in-progress' }));
+  await vi.advanceTimersByTimeAsync(0);
+
+  await advancePolls();
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(2);
+});
+
+test('forgets the job after the retention window', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  start();
+
+  await advancePolls();
+  expect(clearStatus).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(TERMINAL_STATUS_RETENTION_MS - 1);
+  expect(clearStatus).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(1);
+  expect(clearStatus).toHaveBeenCalled();
+});
+
+test('stop() halts polling without recording an outcome', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  const monitor = start();
+
+  monitor.stop();
+  await advancePolls(3);
+
+  expect(queryJobStatusMock).not.toHaveBeenCalled();
+  expect(status).toEqual({ outcome: 'in-progress' });
+  expect(logger.log).not.toHaveBeenCalled();
+});

--- a/libs/printing/src/printer/job_monitor.ts
+++ b/libs/printing/src/printer/job_monitor.ts
@@ -1,0 +1,172 @@
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { PrintJobId, PrintJobStatus } from '@votingworks/types';
+import { extractErrorMessage } from '@votingworks/basics';
+import { rootDebug } from '../utils/debug';
+import { queryJobStatus } from './job_status';
+
+const debug = rootDebug.extend('job-monitor');
+
+/**
+ * How often to ask CUPS about a job.
+ */
+export const JOB_POLL_INTERVAL_MS = 500;
+
+/**
+ * How long a job may go without reaching a terminal state before we give up on
+ * it. This is a failsafe in case a job hangs and CUPS never reports it failed.
+ *
+ * Note that because jobs reach a terminal state after CUPS transmits the job
+ * and its data to the printer, the timeout is not concerned with how long the
+ * actual job takes. 2 minutes is not always enough time to physically complete
+ * the print job, but should be plenty to transmit the job.
+ */
+export const JOB_TIMEOUT_MS = 2 * 60 * 1000;
+
+/**
+ * How long a job's terminal status stays readable after the job finishes, so a
+ * caller polling for the result still observes it before the entry is dropped.
+ */
+export const TERMINAL_STATUS_RETENTION_MS = 5 * 60 * 1000;
+
+/**
+ * How many consecutive failed queries mean CUPS is permanently, rather than
+ * momentarily, intermittently unavailable.
+ * See {@link getConnectedDeviceUris} for details about why CUPS may be
+ * momentarily unavailable.
+ */
+export const MAX_CONSECUTIVE_QUERY_FAILURES = 3;
+
+export interface PrintJobMonitorContext {
+  jobId: PrintJobId;
+  setStatus: (status: PrintJobStatus) => void;
+  clearStatus: () => void;
+  logger: BaseLogger;
+}
+
+/**
+ * Watches a single CUPS print job until it reaches a terminal outcome,
+ * reporting status through `setStatus` and logging the result.
+ *
+ * `setStatus` is called synchronously before polling begins, so a caller that
+ * reads status immediately after submitting a job sees `in-progress` rather
+ * than nothing. `clearStatus` is called once the retention window elapses.
+ */
+export function startPrintJobMonitor({
+  jobId,
+  setStatus,
+  clearStatus,
+  logger,
+}: PrintJobMonitorContext): { stop(): void } {
+  setStatus({ outcome: 'in-progress' });
+
+  let finished = false;
+  let isPolling = false;
+  let consecutiveQueryFailures = 0;
+  let pollTimer: NodeJS.Timeout;
+  let timeoutTimer: NodeJS.Timeout;
+
+  function stopTimers(): void {
+    finished = true;
+    clearInterval(pollTimer);
+    clearTimeout(timeoutTimer);
+  }
+
+  function finish(status: PrintJobStatus): void {
+    // @coverage-exclude: defensive. Every caller already checks `finished`.
+    if (finished) {
+      return;
+    }
+    stopTimers();
+
+    debug('job %d finished: %o', jobId, status);
+    setStatus(status);
+    logger.log(LogEventId.PrinterPrintComplete, 'system', {
+      message:
+        status.outcome === 'sent-to-printer'
+          ? 'CUPS finished sending the print job to the printer.'
+          : 'CUPS did not send the print job to the printer.',
+      disposition: status.outcome === 'sent-to-printer' ? 'success' : 'failure',
+      jobId,
+      reason: status.reason,
+    });
+
+    setTimeout(clearStatus, TERMINAL_STATUS_RETENTION_MS);
+  }
+
+  function onQueryFailure(message: string): void {
+    consecutiveQueryFailures += 1;
+    debug(
+      'job %d query failed (%d/%d): %s',
+      jobId,
+      consecutiveQueryFailures,
+      MAX_CONSECUTIVE_QUERY_FAILURES,
+      message
+    );
+    if (consecutiveQueryFailures >= MAX_CONSECUTIVE_QUERY_FAILURES) {
+      finish({
+        outcome: 'failed',
+        reason: `Unable to reach CUPS for print job status: ${message}`,
+      });
+    }
+  }
+
+  async function poll(): Promise<void> {
+    if (finished || isPolling) {
+      return;
+    }
+    isPolling = true;
+
+    try {
+      const result = await queryJobStatus(jobId);
+
+      // The timeout may have fired while the query was in flight, in which case
+      // the job already has a terminal status that must not be overwritten.
+      if (finished) {
+        return;
+      }
+
+      if (result.isErr()) {
+        const error = result.err();
+        if (error.type === 'unknown-job') {
+          finish({
+            outcome: 'failed',
+            reason: `CUPS has no record of print job ${jobId}.`,
+          });
+          return;
+        }
+        onQueryFailure(error.message);
+        return;
+      }
+
+      consecutiveQueryFailures = 0;
+      const status = result.ok();
+      if (status.outcome === 'in-progress') {
+        setStatus(status);
+        return;
+      }
+
+      finish(status);
+    } catch (error) {
+      if (!finished) {
+        onQueryFailure(extractErrorMessage(error));
+      }
+    } finally {
+      isPolling = false;
+    }
+  }
+
+  pollTimer = setInterval(() => {
+    void poll();
+  }, JOB_POLL_INTERVAL_MS);
+
+  timeoutTimer = setTimeout(() => {
+    finish({
+      outcome: 'failed',
+      reason: `Print job did not reach a terminal state within ${JOB_TIMEOUT_MS}ms.`,
+    });
+  }, JOB_TIMEOUT_MS);
+
+  return {
+    stop: stopTimers,
+  };
+}

--- a/libs/printing/src/printer/job_status.test.ts
+++ b/libs/printing/src/printer/job_status.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { err, ok } from '@votingworks/basics';
+import { IppJobState, PrintJobOutcome } from '@votingworks/types';
+import {
+  CUPS_SCHEDULER_IPP_URI,
+  GET_JOB_ATTRIBUTES_QUERY_PATH,
+  classifyJobState,
+  queryJobStatus,
+} from './job_status';
+import { exec } from '../utils/exec';
+
+vi.mock('../utils/exec', async () => ({
+  ...(await vi.importActual('../utils/exec')),
+  exec: vi.fn(),
+}));
+
+const execMock = vi.mocked(exec);
+
+beforeEach(() => {
+  execMock.mockReset();
+});
+
+function mockIpptoolStdout({
+  statusLine = 'status-code = successful-ok (successful-ok)',
+  body = '',
+}: { statusLine?: string; body?: string } = {}): string {
+  return `"/tmp/query":
+      Get-Job-Attributes:
+          attributes-charset (charset) = utf-8
+      /tmp/query                                                           [PASS]
+          RECEIVED: 121 bytes in response
+          ${statusLine}
+          attributes-charset (charset) = utf-8
+          attributes-natural-language (naturalLanguage) = en
+${body}`;
+}
+
+function mockJobResponse(state: IppJobState, message = ''): void {
+  execMock.mockResolvedValue(
+    ok({
+      stdout: mockIpptoolStdout({
+        body: `          job-state (enum) = ${state}
+          job-printer-state-message (textWithoutLanguage) =${
+            message ? ` ${message}` : ''
+          }`,
+      }),
+      stderr: '',
+    })
+  );
+}
+
+test('queries the CUPS scheduler for the given job', async () => {
+  mockJobResponse('completed');
+
+  expect((await queryJobStatus(42)).unsafeUnwrap()).toEqual({
+    outcome: 'sent-to-printer',
+    reason: undefined,
+  });
+
+  expect(execMock).toHaveBeenCalledWith('ipptool', [
+    '-T',
+    '5',
+    '-tv',
+    '-d',
+    'job-id=42',
+    CUPS_SCHEDULER_IPP_URI,
+    GET_JOB_ATTRIBUTES_QUERY_PATH,
+  ]);
+});
+
+test('reports the diagnostic message for a failed job', async () => {
+  mockJobResponse('aborted', 'Unable to send data to printer.');
+
+  expect((await queryJobStatus(42)).unsafeUnwrap()).toEqual({
+    outcome: 'failed',
+    reason: 'Unable to send data to printer.',
+  });
+});
+
+test('returns an error when CUPS does not know the job', async () => {
+  execMock.mockResolvedValue(
+    ok({
+      stdout: mockIpptoolStdout({
+        statusLine:
+          'status-code = client-error-not-found (Job #999 does not exist.)',
+        body: '          status-message (textWithoutLanguage) = Job #999 does not exist.',
+      }),
+      stderr: '',
+    })
+  );
+
+  const result = await queryJobStatus(999);
+  expect(result.err()).toEqual({
+    type: 'unknown-job',
+    message:
+      'CUPS did not return job 999: status-code = client-error-not-found (Job #999 does not exist.)',
+  });
+});
+
+test('returns an error when ipptool itself fails', async () => {
+  execMock.mockResolvedValue(
+    err({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: 'ipptool: Unable to connect\n',
+      cmd: 'ipptool',
+    })
+  );
+
+  const result = await queryJobStatus(42);
+  expect(result.err()).toEqual({
+    type: 'query-failed',
+    message: 'ipptool failed: ipptool: Unable to connect',
+  });
+});
+
+test.each<[IppJobState, PrintJobOutcome]>([
+  ['pending', 'in-progress'],
+  ['pending-held', 'in-progress'],
+  ['processing', 'in-progress'],
+  ['processing-stopped', 'in-progress'],
+  ['completed', 'sent-to-printer'],
+  ['canceled', 'failed'],
+  ['aborted', 'failed'],
+])('classifies %s as %s', (state, outcome) => {
+  expect(classifyJobState(state)).toEqual(outcome);
+});

--- a/libs/printing/src/printer/job_status.ts
+++ b/libs/printing/src/printer/job_status.ts
@@ -1,0 +1,116 @@
+import { join } from 'node:path';
+import { Result, err, ok, throwIllegalValue } from '@votingworks/basics';
+import {
+  IppJobState,
+  PrintJobId,
+  PrintJobOutcome,
+  PrintJobStatus,
+} from '@votingworks/types';
+import { exec } from '../utils/exec';
+import { rootDebug } from '../utils/debug';
+import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
+import { IPPTOOL_SUCCESS_STATUS_LINE, parseIpptoolOutput } from './status';
+
+const debug = rootDebug.extend('job-status');
+
+/**
+ * :631 is the CUPS scheduler's IPP endpoint, where our print jobs live. Not to be
+ * confused with {@link CUPS_DEFAULT_IPP_URI}, which addresses the printer
+ * itself via the `ipp-usb` daemon and numbers its jobs independently of CUPS —
+ * a job id from `lp` means nothing there.
+ */
+export const CUPS_SCHEDULER_IPP_URI = `ipp://localhost:631/printers/${DEFAULT_MANAGED_PRINTER_NAME}`;
+
+const RELATIVE_PATH_TO_IPP_QUERIES = './ipp_queries';
+
+export const GET_JOB_ATTRIBUTES_QUERY_PATH = join(
+  __dirname,
+  RELATIVE_PATH_TO_IPP_QUERIES,
+  'get-job-attributes.ipp'
+);
+
+const IPPTOOL_TIMEOUT_SECONDS = '5';
+
+/**
+ * Reduces IPP job states to what VxSuite business logic needs to know.
+ */
+export function classifyJobState(state: IppJobState): PrintJobOutcome {
+  switch (state) {
+    case 'completed':
+      return 'sent-to-printer';
+    case 'canceled':
+    case 'aborted':
+      return 'failed';
+    case 'pending':
+    case 'pending-held':
+    case 'processing':
+    case 'processing-stopped':
+      return 'in-progress';
+    /* istanbul ignore next - @preserve */
+    default:
+      return throwIllegalValue(state);
+  }
+}
+
+/**
+ * Why a job status query did not produce a status.
+ * `query-failed` means CUPS is unreachable or `ipptool` timed out.
+ * `unknown-job` means CUPS answered that it has no record of the
+ * job, which happens once the job ages out of its history.
+ */
+export type JobStatusQueryError =
+  | { type: 'query-failed'; message: string }
+  | { type: 'unknown-job'; message: string };
+
+/**
+ * Asks the CUPS scheduler for the status of a single job.
+ */
+export async function queryJobStatus(
+  jobId: PrintJobId
+): Promise<Result<PrintJobStatus, JobStatusQueryError>> {
+  const ipptoolArgs = [
+    '-T',
+    IPPTOOL_TIMEOUT_SECONDS,
+    // `-t` selects CUPS test report output and `-v` includes the response
+    // attributes in it. Together they produce the format parseIpptoolOutput
+    // expects; `-v` alone does nothing.
+    '-tv',
+    '-d',
+    `job-id=${jobId}`,
+    CUPS_SCHEDULER_IPP_URI,
+    GET_JOB_ATTRIBUTES_QUERY_PATH,
+  ];
+
+  debug('querying job %d status, args=%o', jobId, ipptoolArgs);
+  const ipptoolResult = await exec('ipptool', ipptoolArgs);
+  // Query failed to run; job status unknown
+  if (ipptoolResult.isErr()) {
+    return err({
+      type: 'query-failed',
+      message: `ipptool failed: ${ipptoolResult.err().stderr.trim()}`,
+    });
+  }
+
+  const { statusLine, attributes } = parseIpptoolOutput(
+    ipptoolResult.ok().stdout,
+    { allowFailureStatus: true }
+  );
+  if (statusLine !== IPPTOOL_SUCCESS_STATUS_LINE) {
+    return err({
+      type: 'unknown-job',
+      message: `CUPS did not return job ${jobId}: ${statusLine}`,
+    });
+  }
+
+  const state = attributes['job-state'] as IppJobState;
+  // job-printer-state-message is empty for any job that did not fault.
+  // Collapse it so callers see an absent reason rather than an empty string.
+  const message =
+    (attributes['job-printer-state-message'] as string) || undefined;
+  debug('job %d state=%s message=%s', jobId, state, message);
+
+  return ok({
+    outcome: classifyJobState(state),
+    reason: message,
+  });
+}

--- a/libs/printing/src/printer/mocks/file_printer.test.ts
+++ b/libs/printing/src/printer/mocks/file_printer.test.ts
@@ -7,7 +7,7 @@ import {
   readdirSync,
   writeFileSync,
 } from 'node:fs';
-import { sleep } from '@votingworks/basics';
+import { err, sleep } from '@votingworks/basics';
 import { PDFDocument } from 'pdf-lib';
 import { PrinterStatus } from '@votingworks/types';
 import {
@@ -164,4 +164,22 @@ test('trimOldPrints removes oldest files when over 100', () => {
   getMockFilePrinterHandler();
 
   expect(readdirSync(MOCK_PRINTER_OUTPUT_DIR)).toHaveLength(100);
+});
+
+test('tracks each print as sent to the printer', async () => {
+  const filePrinter = new MockFilePrinter();
+  getMockFilePrinterHandler().connectPrinter(HP_4001_PRINTER_CONFIG);
+
+  const jobId = await filePrinter.print({ data: Buffer.from('test') });
+
+  expect(filePrinter.getJobStatus(jobId).unsafeUnwrap()).toEqual({
+    outcome: 'sent-to-printer',
+  });
+  expect(filePrinter.getJobStatus(jobId + 1000)).toEqual(
+    err(expect.any(Error))
+  );
+});
+
+test('clearing the job queue is a no-op', async () => {
+  await expect(new MockFilePrinter().clearJobQueue()).resolves.toBeUndefined();
 });

--- a/libs/printing/src/printer/mocks/file_printer.ts
+++ b/libs/printing/src/printer/mocks/file_printer.ts
@@ -13,10 +13,10 @@ import {
 import { Optional, assert, iter } from '@votingworks/basics';
 import { writeFile } from 'node:fs/promises';
 import { PDFDocument } from 'pdf-lib';
-import { PrinterConfig, PrinterStatus } from '@votingworks/types';
+import { PrinterConfig, PrinterStatus, PrintJobId } from '@votingworks/types';
 import { getMockStateRootDir } from '@votingworks/utils';
 import { PrintProps, PrintSides, Printer } from '../types';
-import { getMockConnectedPrinterStatus } from './fixtures';
+import { createMockJobId, getMockConnectedPrinterStatus } from './fixtures';
 
 export const MOCK_PRINTER_STATE_FILENAME = 'state.json';
 // libs/printing/src/printer/mocks/ is 5 levels below the repo root
@@ -128,7 +128,7 @@ export class MockFilePrinter implements Printer {
     return Promise.resolve(readFromMockFile());
   }
 
-  async print(props: PrintProps): Promise<void> {
+  async print(props: PrintProps): Promise<PrintJobId> {
     const status = readFromMockFile();
     if (!status.connected) {
       throw new Error('cannot print without printer connected');
@@ -160,13 +160,14 @@ export class MockFilePrinter implements Printer {
         }
         const modifiedBytes = await pdf.save();
         await writeFile(filename, modifiedBytes);
-        return;
+        return createMockJobId();
       } catch {
         // Data is not a valid PDF, write as-is
       }
     }
 
     await writeFile(filename, data);
+    return createMockJobId();
   }
 }
 

--- a/libs/printing/src/printer/mocks/file_printer.ts
+++ b/libs/printing/src/printer/mocks/file_printer.ts
@@ -10,10 +10,15 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { Optional, assert, iter } from '@votingworks/basics';
+import { Optional, Result, assert, err, iter, ok } from '@votingworks/basics';
 import { writeFile } from 'node:fs/promises';
 import { PDFDocument } from 'pdf-lib';
-import { PrinterConfig, PrinterStatus, PrintJobId } from '@votingworks/types';
+import {
+  PrinterConfig,
+  PrinterStatus,
+  PrintJobId,
+  PrintJobStatus,
+} from '@votingworks/types';
 import { getMockStateRootDir } from '@votingworks/utils';
 import { PrintProps, PrintSides, Printer } from '../types';
 import { createMockJobId, getMockConnectedPrinterStatus } from './fixtures';
@@ -124,8 +129,21 @@ function readFromMockFile(): MockStateFileContents {
 }
 
 export class MockFilePrinter implements Printer {
+  private readonly jobs = new Map<PrintJobId, PrintJobStatus>();
+
   status(): Promise<PrinterStatus> {
     return Promise.resolve(readFromMockFile());
+  }
+
+  getJobStatus(jobId: PrintJobId): Result<PrintJobStatus, Error> {
+    const status = this.jobs.get(jobId);
+    return status
+      ? ok(status)
+      : err(new Error(`no status tracked for print job ${jobId}`));
+  }
+
+  clearJobQueue(): Promise<void> {
+    return Promise.resolve();
   }
 
   async print(props: PrintProps): Promise<PrintJobId> {
@@ -160,14 +178,20 @@ export class MockFilePrinter implements Printer {
         }
         const modifiedBytes = await pdf.save();
         await writeFile(filename, modifiedBytes);
-        return createMockJobId();
+        return this.trackCompletedJob();
       } catch {
         // Data is not a valid PDF, write as-is
       }
     }
 
     await writeFile(filename, data);
-    return createMockJobId();
+    return this.trackCompletedJob();
+  }
+
+  private trackCompletedJob(): PrintJobId {
+    const jobId = createMockJobId();
+    this.jobs.set(jobId, { outcome: 'sent-to-printer' });
+    return jobId;
   }
 }
 

--- a/libs/printing/src/printer/mocks/fixtures.ts
+++ b/libs/printing/src/printer/mocks/fixtures.ts
@@ -3,6 +3,7 @@ import {
   PrinterConfig,
   PrinterRichStatus,
   PrinterStatus,
+  PrintJobId,
 } from '@votingworks/types';
 
 export const MOCK_MARKER_INFO: IppMarkerInfo = {
@@ -35,4 +36,12 @@ export function getMockConnectedPrinterStatus(
     connected: true,
     config,
   };
+}
+
+let nextMockJobId = 1;
+
+export function createMockJobId(): PrintJobId {
+  const jobId = nextMockJobId;
+  nextMockJobId += 1;
+  return jobId;
 }

--- a/libs/printing/src/printer/mocks/memory_printer.test.ts
+++ b/libs/printing/src/printer/mocks/memory_printer.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { err } from '@votingworks/basics';
 import { Buffer } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
@@ -59,4 +60,33 @@ test('memory printer', async () => {
   printerHandler.cleanup();
   expect(existsSync(printJob1.filename)).toEqual(false);
   expect(existsSync(printJob2.filename)).toEqual(false);
+});
+
+test('tracks job status and lets tests override it', async () => {
+  const printerHandler = createMockPrinterHandler();
+  const { printer } = printerHandler;
+  printerHandler.connectPrinter(HP_4001_PRINTER_CONFIG);
+
+  const jobId = await printer.print({ data: Buffer.from('print') });
+  expect(printer.getJobStatus(jobId).unsafeUnwrap()).toEqual({
+    outcome: 'sent-to-printer',
+  });
+
+  expect(printer.getJobStatus(jobId + 1000)).toEqual(err(expect.any(Error)));
+
+  printerHandler.setJobStatus(jobId, {
+    outcome: 'failed',
+    reason: 'Unable to send data to printer.',
+  });
+  expect(printer.getJobStatus(jobId).unsafeUnwrap()).toEqual({
+    outcome: 'failed',
+    reason: 'Unable to send data to printer.',
+  });
+
+  printerHandler.cleanup();
+});
+
+test('clearing the job queue is a no-op', async () => {
+  const { printer } = createMockPrinterHandler();
+  await expect(printer.clearJobQueue()).resolves.toBeUndefined();
 });

--- a/libs/printing/src/printer/mocks/memory_printer.ts
+++ b/libs/printing/src/printer/mocks/memory_printer.ts
@@ -1,9 +1,9 @@
 import { tmpName } from 'tmp-promise';
 import { writeFile } from 'node:fs/promises';
 import { rmSync } from 'node:fs';
-import { PrinterConfig, PrinterStatus } from '@votingworks/types';
+import { PrinterConfig, PrinterStatus, PrintJobId } from '@votingworks/types';
 import { MockPrintJob, PrintProps, Printer } from '../types';
-import { getMockConnectedPrinterStatus } from './fixtures';
+import { createMockJobId, getMockConnectedPrinterStatus } from './fixtures';
 
 /**
  * A mock of the UsbDrive interface. See createMockUsbDrive for details.
@@ -34,7 +34,7 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
     printJobHistory: [],
   };
 
-  async function mockPrint(props: PrintProps): Promise<void> {
+  async function mockPrint(props: PrintProps): Promise<PrintJobId> {
     if (!mockPrinterState.status.connected) {
       throw new Error('cannot print without printer connected');
     }
@@ -52,6 +52,8 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
       filename,
       options,
     });
+
+    return createMockJobId();
   }
 
   const printer: Printer = {

--- a/libs/printing/src/printer/mocks/memory_printer.ts
+++ b/libs/printing/src/printer/mocks/memory_printer.ts
@@ -1,7 +1,13 @@
+import { err, ok } from '@votingworks/basics';
 import { tmpName } from 'tmp-promise';
 import { writeFile } from 'node:fs/promises';
 import { rmSync } from 'node:fs';
-import { PrinterConfig, PrinterStatus, PrintJobId } from '@votingworks/types';
+import {
+  PrinterConfig,
+  PrinterStatus,
+  PrintJobId,
+  PrintJobStatus,
+} from '@votingworks/types';
 import { MockPrintJob, PrintProps, Printer } from '../types';
 import { createMockJobId, getMockConnectedPrinterStatus } from './fixtures';
 
@@ -13,6 +19,7 @@ export interface MemoryPrinterHandler {
   connectPrinter(config: PrinterConfig): void;
   disconnectPrinter(): void;
   getPrintJobHistory(): MockPrintJob[];
+  setJobStatus(jobId: PrintJobId, status: PrintJobStatus): void;
   getLastPrintPath(): string | undefined;
   cleanup(): void;
 }
@@ -20,6 +27,7 @@ export interface MemoryPrinterHandler {
 interface MockPrinterState {
   status: PrinterStatus;
   printJobHistory: MockPrintJob[];
+  jobs: Map<PrintJobId, PrintJobStatus>;
 }
 
 /**
@@ -32,6 +40,7 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
       connected: false,
     },
     printJobHistory: [],
+    jobs: new Map(),
   };
 
   async function mockPrint(props: PrintProps): Promise<PrintJobId> {
@@ -53,12 +62,21 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
       options,
     });
 
-    return createMockJobId();
+    const jobId = createMockJobId();
+    mockPrinterState.jobs.set(jobId, { outcome: 'sent-to-printer' });
+    return jobId;
   }
 
   const printer: Printer = {
     status: () => Promise.resolve(mockPrinterState.status),
     print: mockPrint,
+    getJobStatus: (jobId) => {
+      const status = mockPrinterState.jobs.get(jobId);
+      return status
+        ? ok(status)
+        : err(new Error(`no status tracked for print job ${jobId}`));
+    },
+    clearJobQueue: () => Promise.resolve(),
   } satisfies Printer;
 
   return {
@@ -77,6 +95,10 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
 
     getPrintJobHistory() {
       return mockPrinterState.printJobHistory;
+    },
+
+    setJobStatus(jobId: PrintJobId, status: PrintJobStatus) {
+      mockPrinterState.jobs.set(jobId, status);
     },
 
     getLastPrintPath() {

--- a/libs/printing/src/printer/print.test.ts
+++ b/libs/printing/src/printer/print.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, expect, test, vi } from 'vitest';
-import { ok } from '@votingworks/basics';
-import { exec } from '../utils/exec';
+import { err, ok } from '@votingworks/basics';
+import { ExecError, exec } from '../utils/exec';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
 import { cancelAllJobs, print } from './print';
 import { PrintSides } from './types';
@@ -158,10 +158,23 @@ test('fails fast if the job id cannot be parsed from lp output', async () => {
 test('cancels all queued jobs', async () => {
   vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
 
-  await cancelAllJobs();
+  expect(await cancelAllJobs()).toEqual(ok());
 
   expect(exec).toHaveBeenCalledWith('cancel', [
     '-a',
     DEFAULT_MANAGED_PRINTER_NAME,
   ]);
+});
+
+test('returns an error when cancelling fails', async () => {
+  const execError: ExecError = {
+    code: 1,
+    signal: null,
+    stdout: '',
+    stderr: 'cancel: Error - unknown destination "VxPrinter".\n',
+    cmd: 'cancel',
+  };
+  vi.mocked(exec).mockResolvedValueOnce(err(execError));
+
+  expect(await cancelAllJobs()).toEqual(err(execError));
 });

--- a/libs/printing/src/printer/print.test.ts
+++ b/libs/printing/src/printer/print.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { ok } from '@votingworks/basics';
 import { exec } from '../utils/exec';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
-import { print } from './print';
+import { cancelAllJobs, print } from './print';
 import { PrintSides } from './types';
 
 vi.mock('../utils/exec');
@@ -153,4 +153,15 @@ test('fails fast if the job id cannot be parsed from lp output', async () => {
   await expect(print({ data: Uint8Array.of(0xca, 0xfe) })).rejects.toThrow(
     'unable to parse job id from lp output: something unexpected'
   );
+});
+
+test('cancels all queued jobs', async () => {
+  vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
+
+  await cancelAllJobs();
+
+  expect(exec).toHaveBeenCalledWith('cancel', [
+    '-a',
+    DEFAULT_MANAGED_PRINTER_NAME,
+  ]);
 });

--- a/libs/printing/src/printer/print.ts
+++ b/libs/printing/src/printer/print.ts
@@ -50,3 +50,9 @@ export async function print({
   assert(jobIdMatch, `unable to parse job id from lp output: ${stdout}`);
   return safeParseInt(jobIdMatch[1]).unsafeUnwrap();
 }
+
+export async function cancelAllJobs(): Promise<void> {
+  const cancelArgs = ['-a', DEFAULT_MANAGED_PRINTER_NAME];
+  debug('cancelling all jobs: args=%o', cancelArgs);
+  (await exec('cancel', cancelArgs)).unsafeUnwrap();
+}

--- a/libs/printing/src/printer/print.ts
+++ b/libs/printing/src/printer/print.ts
@@ -1,17 +1,11 @@
 import { assert } from '@votingworks/basics';
-import { safeParseInt } from '@votingworks/types';
+import { PrintJobId, safeParseInt } from '@votingworks/types';
 import { rootDebug } from '../utils/debug';
 import { PrintProps, PrintSides } from './types';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
 import { exec } from '../utils/exec';
 
 const debug = rootDebug.extend('status');
-
-/**
- * The id CUPS assigned to a submitted print job, unique per queue. Can be used
- * to query the job's status on the CUPS server.
- */
-export type PrintJobId = number;
 
 // `lp` reports the assigned job id on stdout, e.g. "request id is
 // VxPrinter-42 (1 file(s))". The sentence is localized but the

--- a/libs/printing/src/printer/print.ts
+++ b/libs/printing/src/printer/print.ts
@@ -1,9 +1,9 @@
-import { assert } from '@votingworks/basics';
+import { Result, assert, err, ok } from '@votingworks/basics';
 import { PrintJobId, safeParseInt } from '@votingworks/types';
 import { rootDebug } from '../utils/debug';
 import { PrintProps, PrintSides } from './types';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
-import { exec } from '../utils/exec';
+import { ExecError, exec } from '../utils/exec';
 
 const debug = rootDebug.extend('status');
 
@@ -51,8 +51,12 @@ export async function print({
   return safeParseInt(jobIdMatch[1]).unsafeUnwrap();
 }
 
-export async function cancelAllJobs(): Promise<void> {
+export async function cancelAllJobs(): Promise<Result<void, ExecError>> {
   const cancelArgs = ['-a', DEFAULT_MANAGED_PRINTER_NAME];
   debug('cancelling all jobs: args=%o', cancelArgs);
-  (await exec('cancel', cancelArgs)).unsafeUnwrap();
+  const cancelResult = await exec('cancel', cancelArgs);
+  if (cancelResult.isErr()) {
+    return err(cancelResult.err());
+  }
+  return ok();
 }

--- a/libs/printing/src/printer/printer.test.ts
+++ b/libs/printing/src/printer/printer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { Buffer } from 'node:buffer';
+import { err, ok } from '@votingworks/basics';
 import { mockFunction } from '@votingworks/test-utils';
 import { LogEventId, mockBaseLogger } from '@votingworks/logging';
 import {
@@ -59,19 +60,32 @@ vi.mock(
 );
 
 const mockPrintData = mockFunction('mockPrintData');
+const mockCancelAllJobs = mockFunction('cancelAllJobs');
 vi.mock(
   import('./print.js'),
   async (importActual): Promise<typeof import('./print')> => ({
     ...(await importActual()),
     print: (props) => mockPrintData(props),
+    cancelAllJobs: () => mockCancelAllJobs(),
   })
 );
+
+vi.mock(import('./job_monitor.js'), async (importActual) => ({
+  ...(await importActual()),
+  startPrintJobMonitor: vi.fn(({ setStatus }) => {
+    setStatus({ outcome: 'in-progress' });
+    return { stop: vi.fn() };
+  }),
+}));
+
+const MOCK_JOB_ID = 1;
 
 beforeEach(() => {
   mockConfigurePrinter.reset();
   mockGetConnectedDeviceUris.reset();
   mockGetPrinterRichStatus.reset();
   mockPrintData.reset();
+  mockCancelAllJobs.reset();
   isDeviceAttachedMock.mockReturnValue(true);
 });
 
@@ -80,6 +94,7 @@ afterEach(() => {
   mockGetConnectedDeviceUris.assertComplete();
   mockGetPrinterRichStatus.assertComplete();
   mockPrintData.assertComplete();
+  mockCancelAllJobs.assertComplete();
 });
 
 test('status and configuration', async () => {
@@ -125,7 +140,7 @@ test('status and configuration', async () => {
 
   mockPrintData
     .expectCallWith({ data: Buffer.of(), raw: {} })
-    .returns(undefined);
+    .returns(MOCK_JOB_ID);
   await printer.print({ data: Buffer.of() });
 
   // supported printer does not configure again
@@ -154,6 +169,7 @@ test('status and configuration', async () => {
   // printer detached is registered when isDeviceAttached shows it is gone
   mockGetConnectedDeviceUris.expectCallWith().returns([]);
   isDeviceAttachedMock.mockReturnValue(false);
+  mockCancelAllJobs.expectCallWith().returns(ok());
   expect(await printer.status()).toEqual({ connected: false });
   expect(logger.log).toHaveBeenCalledTimes(2);
   expect(logger.log).toHaveBeenLastCalledWith(
@@ -240,7 +256,7 @@ describe('printer-specific print options', () => {
         data: Buffer.of(),
         raw: { 'pdftops-renderer': 'pdftops' },
       })
-      .returns(undefined);
+      .returns(MOCK_JOB_ID);
     await printer.print({ data: Buffer.of() });
   });
 
@@ -256,7 +272,7 @@ describe('printer-specific print options', () => {
 
     mockPrintData
       .expectCallWith({ data: Buffer.of(), raw: {} })
-      .returns(undefined);
+      .returns(MOCK_JOB_ID);
     await printer.print({ data: Buffer.of() });
   });
 
@@ -275,7 +291,7 @@ describe('printer-specific print options', () => {
         data: Buffer.of(),
         raw: { InputSlot: 'M404_Tray2' },
       })
-      .returns(undefined);
+      .returns(MOCK_JOB_ID);
     await printer.print({ data: Buffer.of() });
   });
 
@@ -284,7 +300,7 @@ describe('printer-specific print options', () => {
 
     mockPrintData
       .expectCallWith({ data: Buffer.of(), raw: {} })
-      .returns(undefined);
+      .returns(MOCK_JOB_ID);
     await printer.print({ data: Buffer.of() });
   });
 
@@ -303,10 +319,63 @@ describe('printer-specific print options', () => {
         data: Buffer.of(),
         raw: { 'pdftops-renderer': 'gs' },
       })
-      .returns(undefined);
+      .returns(MOCK_JOB_ID);
     await printer.print({
       data: Buffer.of(),
       raw: { 'pdftops-renderer': 'gs' },
     });
   });
+});
+
+test('job status tracking', async () => {
+  const printer = detectPrinter(mockBaseLogger({ fn: vi.fn }));
+
+  const uri = `${HP_4001_PRINTER_CONFIG.baseDeviceUri}/serial=1234`;
+  mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+  mockConfigurePrinter
+    .expectCallWith({ uri, config: HP_4001_PRINTER_CONFIG })
+    .returns(undefined);
+  mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+  await printer.status();
+
+  expect(printer.getJobStatus(MOCK_JOB_ID)).toEqual(err(expect.any(Error)));
+
+  mockPrintData
+    .expectCallWith({ data: Buffer.of(), raw: {} })
+    .returns(MOCK_JOB_ID);
+  const jobId = await printer.print({ data: Buffer.of() });
+
+  expect(printer.getJobStatus(jobId)).toEqual(ok({ outcome: 'in-progress' }));
+
+  mockCancelAllJobs.expectCallWith().returns(ok());
+  await printer.clearJobQueue();
+});
+
+test('still reports the disconnect when clearing the queue fails', async () => {
+  const printer = detectPrinter(mockBaseLogger({ fn: vi.fn }));
+
+  const uri = `${HP_4001_PRINTER_CONFIG.baseDeviceUri}/serial=1234`;
+  mockGetConnectedDeviceUris.expectCallWith().returns([uri]);
+  mockConfigurePrinter
+    .expectCallWith({ uri, config: HP_4001_PRINTER_CONFIG })
+    .returns(undefined);
+  mockGetPrinterRichStatus.expectCallWith().returns(undefined);
+  expect(await printer.status()).toEqual({
+    connected: true,
+    config: HP_4001_PRINTER_CONFIG,
+  });
+
+  mockGetConnectedDeviceUris.expectCallWith().returns([]);
+  isDeviceAttachedMock.mockReturnValue(false);
+  mockCancelAllJobs.expectCallWith().returns(
+    err({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: 'cancel: Error - unknown destination "VxPrinter".\n',
+      cmd: 'cancel',
+    })
+  );
+
+  expect(await printer.status()).toEqual({ connected: false });
 });

--- a/libs/printing/src/printer/printer.ts
+++ b/libs/printing/src/printer/printer.ts
@@ -108,8 +108,7 @@ export function detectPrinter(logger: BaseLogger): Printer {
             assertDefined(getPrinterConfig(printerDevice.uri))
           )
         : {};
-      // the job id is not yet consumed; CUPS-side job tracking will use it
-      await printData({ ...props, raw: { ...printerOptions, ...raw } });
+      return printData({ ...props, raw: { ...printerOptions, ...raw } });
     },
   };
 }

--- a/libs/printing/src/printer/printer.ts
+++ b/libs/printing/src/printer/printer.ts
@@ -1,6 +1,7 @@
 import { isDeviceAttached, type Device } from '@votingworks/backend';
-import { assertDefined } from '@votingworks/basics';
+import { assertDefined, err, ok } from '@votingworks/basics';
 import { LogEventId, BaseLogger } from '@votingworks/logging';
+import { PrintJobId, PrintJobStatus } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
@@ -9,7 +10,8 @@ import { rootDebug } from '../utils/debug';
 import { getConnectedDeviceUris } from './device_uri';
 import { configurePrinter } from './configure';
 import { Printer } from './types';
-import { print as printData } from './print';
+import { cancelAllJobs, print as printData } from './print';
+import { startPrintJobMonitor } from './job_monitor';
 import { getPrinterConfig, getPrinterSpecificOptions } from './supported';
 import { MockFilePrinter } from './mocks/file_printer';
 import { CUPS_DEFAULT_IPP_URI, getPrinterRichStatus } from './status';
@@ -19,6 +21,7 @@ const debug = rootDebug.extend('manager');
 interface PrinterDevice {
   uri?: string;
   lastPrint: number;
+  jobs: Map<PrintJobId, PrintJobStatus>;
 }
 
 export function detectPrinter(logger: BaseLogger): Printer {
@@ -27,7 +30,7 @@ export function detectPrinter(logger: BaseLogger): Printer {
     return new MockFilePrinter();
   }
 
-  const printerDevice: PrinterDevice = { lastPrint: 0 };
+  const printerDevice: PrinterDevice = { lastPrint: 0, jobs: new Map() };
 
   return {
     status: async () => {
@@ -64,6 +67,13 @@ export function detectPrinter(logger: BaseLogger): Printer {
             uri: printerDevice.uri,
           });
           printerDevice.uri = undefined;
+          const cancelResult = await cancelAllJobs();
+          if (cancelResult.isErr()) {
+            debug(
+              'failed to clear the print queue on disconnect: %s',
+              cancelResult.err().stderr.trim()
+            );
+          }
         }
       }
 
@@ -108,7 +118,28 @@ export function detectPrinter(logger: BaseLogger): Printer {
             assertDefined(getPrinterConfig(printerDevice.uri))
           )
         : {};
-      return printData({ ...props, raw: { ...printerOptions, ...raw } });
+      const jobId = await printData({
+        ...props,
+        raw: { ...printerOptions, ...raw },
+      });
+      startPrintJobMonitor({
+        jobId,
+        setStatus: (status) => printerDevice.jobs.set(jobId, status),
+        clearStatus: () => printerDevice.jobs.delete(jobId),
+        logger,
+      });
+      return jobId;
+    },
+
+    getJobStatus: (jobId) => {
+      const status = printerDevice.jobs.get(jobId);
+      return status
+        ? ok(status)
+        : err(new Error(`no status tracked for print job ${jobId}`));
+    },
+
+    clearJobQueue: async () => {
+      (await cancelAllJobs()).unsafeUnwrap();
     },
   };
 }

--- a/libs/printing/src/printer/status.test.ts
+++ b/libs/printing/src/printer/status.test.ts
@@ -253,7 +253,7 @@ test('throws error if ipptool output cannot be parsed', async () => {
     ],
     [
       mockIpptoolStdout({ 'printer-state': '(enum) = ' }),
-      'Unable to parse ipptool output line: printer-state (enum) =',
+      'Unexpected undefined value in line: printer-state (enum) =',
     ],
     [
       mockIpptoolStdout({ 'printer-state': '(badType) = idle' }),

--- a/libs/printing/src/printer/status.ts
+++ b/libs/printing/src/printer/status.ts
@@ -13,9 +13,23 @@ import { rootDebug } from '../utils/debug';
 
 const debug = rootDebug.extend('status');
 
-interface IppAttributes {
+export interface IppAttributes {
   [attribute: string]: string | string[] | number | number[];
 }
+
+/**
+ * A parsed `ipptool` response. `statusLine` is exposed raw rather than as a
+ * bare status code so callers can decide how strict to be: the printer status
+ * path treats anything but success as a fault, while job queries expect
+ * `client-error-not-found` for jobs that have aged out of CUPS's history.
+ */
+export interface IpptoolResponse {
+  statusLine: string;
+  attributes: IppAttributes;
+}
+
+export const IPPTOOL_SUCCESS_STATUS_LINE =
+  'status-code = successful-ok (successful-ok)';
 
 export const IPP_ATTRIBUTES_TO_QUERY = [
   'printer-state',
@@ -54,7 +68,10 @@ export const IPP_QUERY = `{
  *          printer-state (enum) = stopped
  *          printer-state-reasons (1setOf keyword) = media-empty-error,media-needed-error,media-empty-error
  */
-function parseIpptoolOutput(output: string): IppAttributes {
+export function parseIpptoolOutput(
+  output: string,
+  { allowFailureStatus }: { allowFailureStatus?: boolean } = {}
+): IpptoolResponse {
   const allLines = output.split('\n');
   assert(allLines.length > 0, 'ipptool output is empty');
 
@@ -65,10 +82,13 @@ function parseIpptoolOutput(output: string): IppAttributes {
   const statusLine = responseLines.shift();
   const characterSetLine = responseLines.shift();
   const languageLine = responseLines.shift();
-  assert(
-    statusLine === 'status-code = successful-ok (successful-ok)',
-    `Unsuccessful ipptool response: ${statusLine ?? '<empty>'}`
-  );
+  assert(statusLine !== undefined, 'Unsuccessful ipptool response: <empty>');
+  if (!allowFailureStatus) {
+    assert(
+      statusLine === IPPTOOL_SUCCESS_STATUS_LINE,
+      `Unsuccessful ipptool response: ${statusLine}`
+    );
+  }
   assert(
     characterSetLine === 'attributes-charset (charset) = utf-8',
     'Invalid character set line'
@@ -78,11 +98,21 @@ function parseIpptoolOutput(output: string): IppAttributes {
     'Invalid default language line'
   );
 
-  const lineRegex = /^(.+) \((.+)\) = (.+)$/;
+  // This regex must allow properties with no values. A query for job status
+  // will return `job-printer-state-message (textWithoutLanguage) =` when the job
+  // is a success.
+  const lineRegex = /^(.+) \((.+)\) =(?: (.*))?$/;
   const attributes = responseLines.reduce<IppAttributes>((attrs, line) => {
     const matches = lineRegex.exec(line);
     assert(matches, `Unable to parse ipptool output line: ${line}`);
     const [, attribute, type, value] = matches;
+    if (value === undefined) {
+      assert(
+        type === 'textWithoutLanguage' || type === 'nameWithoutLanguage',
+        `Unexpected undefined value in line: ${line}`
+      );
+      return { ...attrs, [attribute]: '' };
+    }
     switch (type) {
       case 'keyword':
       case 'enum':
@@ -107,7 +137,7 @@ function parseIpptoolOutput(output: string): IppAttributes {
         throw new Error(`Unsupported IPP attribute type: ${type}`);
     }
   }, {});
-  return attributes;
+  return { statusLine, attributes };
 }
 
 /**
@@ -144,7 +174,7 @@ async function getPrinterIppAttributes(
   debug('ipptool stdout:\n%s', stdout);
   debug('ipptool stderr:\n%s', stderr);
 
-  const attributes = parseIpptoolOutput(stdout);
+  const { attributes } = parseIpptoolOutput(stdout);
   debug('parsed ipptool attributes: %O', attributes);
   return attributes;
 }

--- a/libs/printing/src/printer/types.ts
+++ b/libs/printing/src/printer/types.ts
@@ -1,4 +1,8 @@
-import { HmpbBallotPaperSize, PrinterStatus } from '@votingworks/types';
+import {
+  HmpbBallotPaperSize,
+  PrinterStatus,
+  PrintJobId,
+} from '@votingworks/types';
 
 export enum PrintSides {
   /**
@@ -38,7 +42,7 @@ export type PrintProps = PrintOptions & {
     | AsyncIterable<Uint8Array>;
 };
 
-export type PrintFunction = (props: PrintProps) => Promise<void>;
+export type PrintFunction = (props: PrintProps) => Promise<PrintJobId>;
 
 export interface Printer {
   status: () => Promise<PrinterStatus>;

--- a/libs/printing/src/printer/types.ts
+++ b/libs/printing/src/printer/types.ts
@@ -1,7 +1,9 @@
+import { Result } from '@votingworks/basics';
 import {
   HmpbBallotPaperSize,
   PrinterStatus,
   PrintJobId,
+  PrintJobStatus,
 } from '@votingworks/types';
 
 export enum PrintSides {
@@ -47,6 +49,8 @@ export type PrintFunction = (props: PrintProps) => Promise<PrintJobId>;
 export interface Printer {
   status: () => Promise<PrinterStatus>;
   print: PrintFunction;
+  getJobStatus: (jobId: PrintJobId) => Result<PrintJobStatus, Error>;
+  clearJobQueue: () => Promise<void>;
 }
 
 export interface MockPrintJob {

--- a/libs/types/src/ipp_printing.ts
+++ b/libs/types/src/ipp_printing.ts
@@ -107,3 +107,37 @@ export interface PrinterRichStatus {
   stateReasons: IppPrinterStateReason[];
   markerInfos: IppMarkerInfo[];
 }
+
+/**
+ * The id CUPS assigned to a submitted print job, unique per queue. Can be used
+ * to query the job's status on the CUPS server.
+ */
+export type PrintJobId = number;
+
+/**
+ * IPP `job-state` prop identifies the basic status of a print job.
+ * https://datatracker.ietf.org/doc/html/rfc2911#section-4.3.7
+ */
+export type IppJobState =
+  | 'pending'
+  | 'pending-held'
+  | 'processing'
+  | 'processing-stopped'
+  | 'canceled'
+  | 'aborted'
+  | 'completed';
+
+/**
+ * What a print job means to the application, derived from {@link IppJobState}.
+ * `sent-to-printer` means CUPS finished transferring the job to the printer.
+ * It does not mean the pages have physically printed.
+ */
+export type PrintJobOutcome = 'in-progress' | 'sent-to-printer' | 'failed';
+
+/**
+ * The status of a print job as tracked by `libs/printing`.
+ */
+export interface PrintJobStatus {
+  outcome: PrintJobOutcome;
+  reason?: string;
+}

--- a/specs/0008-print-job-tracking.md
+++ b/specs/0008-print-job-tracking.md
@@ -297,7 +297,10 @@ In `libs/printing`:
 
 In `VxMark` and `VxPrint`:
 
-1. TODO
+VxPrint uses `PrinterPrintRequest` for app-domain logs that have knowledge of
+ballot styles and number of ballots printed. Since `PrinterPrintRequest` will be
+moved to `libs/printing`, and to avoid redundancy, we'll add a `BallotPrinted`
+log event for use in VxPrint.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
## Overview

Relates to https://github.com/votingworks/vxsuite/issues/9186. Extends `libs/printing` to support print status tracking behavior in VxMark/VxPrint

See the complete spec in https://github.com/votingworks/vxsuite/pull/9241

* Sets up various parts of `libs/printing` to support querying CUPS for job status (this is mostly IPP-related changes in earlier commits)
* Adds job monitor to monitor a single print job and store its status
* Updates `Printer` to manage job monitors and expose methods needed by upstream VxSuite apps

## Demo Video or Screenshot

N/A; lib changes only

## Testing Plan

Added unit tests

## Checklist
All N/A

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
