### PR TITLE
VxScan: fujitsu printer - single-pass bit image conversion for smoother printing

### DIFF
--- a/libs/fujitsu-thermal-printer/src/driver/driver.ts
+++ b/libs/fujitsu-thermal-printer/src/driver/driver.ts
@@ -77,7 +77,7 @@ export interface FujitsuThermalPrinterDriverInterface {
   setPrintQuality(printQuality: PrintQuality): Promise<void>;
   getStatus(): Promise<RawPrinterStatus>;
   setReplyParameter(parameter: Uint8): Promise<void>;
-  printBitImage(bitImage: CompressedBitImage): void;
+  printBitImage(bitImage: CompressedBitImage): Promise<void>;
   feedForward(dots: number): Promise<void>;
 }
 

--- a/libs/fujitsu-thermal-printer/src/driver/status.ts
+++ b/libs/fujitsu-thermal-printer/src/driver/status.ts
@@ -38,7 +38,6 @@ export function isInconsistentStatus(status: RawPrinterStatus): boolean {
   );
 }
 
-// @coverage-defer
 export function isPrinterStopped(status: RawPrinterStatus): boolean {
   return (
     isErrorStatus(status) || status.isPaperCoverOpen || status.isPaperAtEnd

--- a/libs/fujitsu-thermal-printer/src/printing.test.ts
+++ b/libs/fujitsu-thermal-printer/src/printing.test.ts
@@ -1,26 +1,35 @@
 /* eslint-disable vx/gts-no-array-constructor */
-import { expect, test, vi } from 'vitest';
+import { expect, Mocked, test, vi } from 'vitest';
 import { Device, findByIds, WebUSBDevice } from 'usb';
 import { LogEventId, mockLogger } from '@votingworks/logging';
+import { readFileSync } from 'node:fs';
 import { createImageData, ImageData } from '@votingworks/image-utils';
-import { iter } from '@votingworks/basics';
+import { assertDefined, iter, ok } from '@votingworks/basics';
 import {
+  BYTES_PER_BIT_IMAGE_ROW,
   chunkImageData,
   compressBitImage,
+  imageDataToBitImage,
   packBitsCompression,
   PAGE_DOTS_WIDTH,
+  printImageData,
+  printPdf,
   trimImageDataToPageWidth,
 } from './printing.js';
 import { getFujitsuThermalPrinter } from './printer.js';
 import {
   CONFIGURATION_NUMBER,
+  FujitsuThermalPrinterDriverInterface,
   INTERFACE_NUMBER,
   PrinterStatusResponse,
   PRODUCT_ID,
   RawPrinterStatus,
   VENDOR_ID,
 } from './driver/index.js';
+import { CompressedBitImage } from './driver/types.js';
+import { IDLE_REPLY_PARAMETER } from './globals.js';
 import { mockMinimalWebUsbDevice } from '../test/mock_minimal_web_usb_device.js';
+import { singlePageReportPath } from '../test/fixtures/index.js';
 
 const LETTER_DOTS_WIDTH = 8.5 * 200;
 const BYTES_PER_PIXEL = 4;
@@ -108,6 +117,87 @@ test('chunkImageData requires page-width image data', () => {
   ).toThrow();
 });
 
+function whiteImage(width: number, height: number): ImageData {
+  const imageData = createImageData(width, height);
+  imageData.data.fill(255);
+  return imageData;
+}
+
+function paintGray(imageData: ImageData, x: number, y: number, gray: number) {
+  imageData.data.set([gray, gray, gray, 255], (y * imageData.width + x) * 4);
+}
+
+function paintBlack(imageData: ImageData, x: number, y: number) {
+  paintGray(imageData, x, y, 0);
+}
+
+/** Asserts the given bytes of a bit image row, and that all others are 0. */
+function expectRowBytes(
+  bitImageData: Uint8Array,
+  row: number,
+  expectedBytes: Record<number, number>
+) {
+  const rowBytes = bitImageData.subarray(
+    row * BYTES_PER_BIT_IMAGE_ROW,
+    (row + 1) * BYTES_PER_BIT_IMAGE_ROW
+  );
+  const expected: number[] = Object.assign(
+    Array(BYTES_PER_BIT_IMAGE_ROW).fill(0),
+    expectedBytes
+  );
+  expect(Array.from(rowBytes)).toEqual(expected);
+}
+
+/** Inverse of `packBitsCompression`. */
+function unpackBits(data: Int8Array): Uint8Array {
+  const out: number[] = [];
+  let i = 0;
+  while (i < data.length) {
+    const header = data[i] as number;
+    if (header >= 0) {
+      out.push(...data.subarray(i + 1, i + 2 + header));
+      i += header + 2;
+    } else {
+      const byte = data[i + 1] as number;
+      for (let n = 0; n < 1 - header; n += 1) out.push(byte);
+      i += 2;
+    }
+  }
+  return new Uint8Array(out);
+}
+
+test('imageDataToBitImage packs pixels MSB-first, black = 1', () => {
+  const imageData = whiteImage(PAGE_DOTS_WIDTH, 4);
+  // row 0: dots 0 and 7 are black
+  paintBlack(imageData, 0, 0);
+  paintBlack(imageData, 7, 0);
+  // row 1: the last dot is black
+  paintBlack(imageData, PAGE_DOTS_WIDTH - 1, 1);
+  // row 2: gray 229 is black, gray 231 is white (230 itself is a hair below
+  // the threshold in floating point)
+  paintGray(imageData, 0, 2, 229);
+  paintGray(imageData, 1, 2, 231);
+  // row 3: dot 8 is the first dot of the second byte
+  paintBlack(imageData, 8, 3);
+
+  const bitImage = imageDataToBitImage(imageData);
+  expect(bitImage.compressed).toEqual(false);
+  expect(bitImage.height).toEqual(4);
+  expect(bitImage.data).toHaveLength(4 * BYTES_PER_BIT_IMAGE_ROW);
+  expectRowBytes(bitImage.data, 0, { 0: 0b1000_0001 });
+  expectRowBytes(bitImage.data, 1, {
+    [BYTES_PER_BIT_IMAGE_ROW - 1]: 0b0000_0001,
+  });
+  expectRowBytes(bitImage.data, 2, { 0: 0b1000_0000 });
+  expectRowBytes(bitImage.data, 3, { 1: 0b1000_0000 });
+});
+
+test('imageDataToBitImage requires page-width image data', () => {
+  expect(() => imageDataToBitImage(whiteImage(LETTER_DOTS_WIDTH, 1))).toThrow(
+    'Image width must be 1696, got 1700'
+  );
+});
+
 test('packBitsCompression', () => {
   const testCases: Array<{ uncompressed: number[]; compressed: number[] }> = [
     {
@@ -134,6 +224,18 @@ test('packBitsCompression', () => {
     { uncompressed: Array(200).fill(4), compressed: [-127, 4, -71, 4] },
     { uncompressed: [3, ...Array(128).fill(4)], compressed: [0, 3, -127, 4] },
     { uncompressed: [...Array(128).fill(4), 3], compressed: [-127, 4, 0, 3] },
+    {
+      uncompressed: Array.from({ length: 130 }, (_, i) => (i % 2) + 1),
+      compressed: [
+        127,
+        ...Array.from({ length: 128 }, (_, i) => (i % 2) + 1),
+        1,
+        1,
+        2,
+      ],
+    },
+    { uncompressed: [200, 200, 201], compressed: [-1, -56, 0, -55] },
+    { uncompressed: [], compressed: [] },
   ];
 
   for (const testCase of testCases) {
@@ -308,4 +410,90 @@ test('disconnected after initially connected', async () => {
       status: '{"state":"idle"}',
     })
   );
+});
+
+const idleRawStatus: RawPrinterStatus = {
+  paperFeedSensor: false,
+  isOffline: false,
+  isBufferFull: false,
+  temperatureError: false,
+  hardwareError: false,
+  isPaperCoverOpen: false,
+  receiveDataError: false,
+  supplyVoltageError: false,
+  isPaperAtEnd: false,
+  markUndetection: false,
+  isPaperNearEnd: false,
+  replyParameter: 0,
+};
+
+/** Driver mock whose status echoes the last reply parameter set. */
+function mockDriver(): Mocked<FujitsuThermalPrinterDriverInterface> {
+  let replyParameter = 0;
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    resetPrinter: vi.fn(),
+    setPrintQuality: vi.fn(),
+    feedForward: vi.fn(),
+    setReplyParameter: vi.fn().mockImplementation((parameter: number) => {
+      replyParameter = parameter;
+      return Promise.resolve();
+    }),
+    getStatus: vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve({ ...idleRawStatus, replyParameter })
+      ),
+    printBitImage: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function printedBitImages(
+  driver: Mocked<FujitsuThermalPrinterDriverInterface>
+): CompressedBitImage[] {
+  return driver.printBitImage.mock.calls.map(([bitImage]) => bitImage);
+}
+
+test('printPdf sends one compressed bit image per 800-row band', async () => {
+  const driver = mockDriver();
+  const result = await printPdf(driver, readFileSync(singlePageReportPath));
+  expect(result).toEqual(ok());
+
+  // 8.5" x 11" at 200 DPI = 1700 x 2200 px
+  const bitImages = printedBitImages(driver);
+  expect(bitImages.map((bitImage) => bitImage.height)).toEqual([800, 800, 600]);
+  for (const bitImage of bitImages) {
+    expect(bitImage.compressed).toEqual(true);
+    const unpacked = unpackBits(bitImage.data);
+    expect(unpacked).toHaveLength(bitImage.height * BYTES_PER_BIT_IMAGE_ROW);
+    expect(unpacked.some((byte) => byte !== 0)).toEqual(true);
+  }
+  expect(driver.setReplyParameter).toHaveBeenLastCalledWith(
+    IDLE_REPLY_PARAMETER
+  );
+});
+
+test('printImageData prints page-width image data', async () => {
+  const imageData = whiteImage(PAGE_DOTS_WIDTH, 5);
+  paintBlack(imageData, PAGE_DOTS_WIDTH - 1, 4);
+
+  const driver = mockDriver();
+  const result = await printImageData(driver, imageData);
+  expect(result).toEqual(ok());
+
+  const [bitImage] = printedBitImages(driver);
+  expect(bitImage?.height).toEqual(5);
+  expectRowBytes(unpackBits(assertDefined(bitImage).data), 4, {
+    [BYTES_PER_BIT_IMAGE_ROW - 1]: 0b0000_0001,
+  });
+  expect(driver.setReplyParameter).toHaveBeenLastCalledWith(
+    IDLE_REPLY_PARAMETER
+  );
+});
+
+test('printImageData requires page-width image data', async () => {
+  await expect(
+    printImageData(mockDriver(), whiteImage(LETTER_DOTS_WIDTH, 1))
+  ).rejects.toThrow('Image width must be 1696, got 1700');
 });

--- a/libs/fujitsu-thermal-printer/src/printing.ts
+++ b/libs/fujitsu-thermal-printer/src/printing.ts
@@ -11,7 +11,6 @@ import {
   FujitsuThermalPrinterDriverInterface,
 } from './driver/driver.js';
 import { CompressedBitImage, UncompressedBitImage } from './driver/types.js';
-import { BitArray, bitArrayToByte } from './bits.js';
 import { rootDebug } from './debug.js';
 import { RawPrinterStatus } from './driver/index.js';
 import {
@@ -24,7 +23,7 @@ import { waitForPrintReadyStatus } from './status.js';
 const debug = rootDebug.extend('printing');
 
 // 1 byte = 1 millimeter
-const BYTES_PER_BIT_IMAGE_ROW = 212;
+export const BYTES_PER_BIT_IMAGE_ROW = 212;
 const DRIVER_BIT_IMAGE_MAX_HEIGHT = 800;
 /**
  * Width in dots of the printer's printable area. Image data printed via
@@ -89,12 +88,6 @@ export function* chunkImageData(imageData: ImageData): Generator<ImageData> {
   }
 }
 
-export interface BinaryBitmap {
-  width: number;
-  height: number;
-  data: boolean[];
-}
-
 /**
  * Converts 8-bit sRGB color values to an 8-bit grayscale value without gamma
  * correction.
@@ -104,7 +97,6 @@ export interface BinaryBitmap {
  * @param b Blue color value from 0 - 255
  * @returns Grayscale color value from 0 - 255
  */
-// @coverage-defer
 export function rgbToGrayscale(r: number, g: number, b: number): number {
   return 0.299 * r + 0.587 * g + 0.114 * b;
 }
@@ -115,54 +107,50 @@ export function rgbToGrayscale(r: number, g: number, b: number): number {
 const GRAYSCALE_WHITE_THRESHOLD = 230;
 
 /**
- * Converts 8-bit sRGB color values to a binary black/white representation.
- * Uses weighted method without gamma correction for speed.
- *
- * @param r Red color value from 0 - 255
- * @param g Green color value from 0 - 255
- * @param b Blue color value from 0 - 255
- * @returns true for black, false for white
+ * Converts page-width image data into a bit image. MSB is the leftmost dot,
+ * 1 = black.
  */
-// @coverage-defer
-function rgbToBinary(r: number, g: number, b: number): boolean {
-  return rgbToGrayscale(r, g, b) < GRAYSCALE_WHITE_THRESHOLD;
-}
+export function imageDataToBitImage(
+  imageData: ImageData
+): UncompressedBitImage {
+  assert(
+    imageData.width === PAGE_DOTS_WIDTH,
+    `Image width must be ${PAGE_DOTS_WIDTH}, got ${imageData.width}`
+  );
 
-// @coverage-defer
-export function imageDataToBinaryBitmap(imageData: ImageData): BinaryBitmap {
-  debug('converting image data to binary bitmap');
+  const { height, data } = imageData;
+  const bitImageBytes = new Uint8Array(height * BYTES_PER_BIT_IMAGE_ROW);
 
-  const data: boolean[] = [];
+  for (let y = 0; y < height; y += 1) {
+    const bitImageRowStart = y * BYTES_PER_BIT_IMAGE_ROW;
+    const imageDataRowStart = y * PAGE_DOTS_WIDTH;
 
-  for (let i = 0; i < imageData.data.length; i += 4) {
-    const r = imageData.data[i] as number;
-    const g = imageData.data[i + 1] as number;
-    const b = imageData.data[i + 2] as number;
-
-    data.push(rgbToBinary(r, g, b));
+    for (
+      let byteIndex = 0;
+      byteIndex < BYTES_PER_BIT_IMAGE_ROW;
+      byteIndex += 1
+    ) {
+      let byte = 0;
+      for (let bit = 0; bit < BITS_PER_BYTE; bit += 1) {
+        const x = byteIndex * BITS_PER_BYTE + bit;
+        const imageDataByteOffset =
+          (imageDataRowStart + x) * IMAGE_DATA_BYTES_PER_PIXEL;
+        const isBlack =
+          rgbToGrayscale(
+            data[imageDataByteOffset] as number,
+            data[imageDataByteOffset + 1] as number,
+            data[imageDataByteOffset + 2] as number
+          ) < GRAYSCALE_WHITE_THRESHOLD;
+        byte <<= 1;
+        if (isBlack) {
+          byte |= 1;
+        }
+      }
+      bitImageBytes[bitImageRowStart + byteIndex] = byte;
+    }
   }
 
-  return {
-    data,
-    width: imageData.width,
-    height: imageData.height,
-  };
-}
-
-// @coverage-defer
-function bitmapToBitImage(bitmap: BinaryBitmap): UncompressedBitImage {
-  debug('converting bitmap to bit image');
-  const byteMap: number[] = [];
-
-  for (let i = 0; i < bitmap.data.length; i += 8) {
-    byteMap.push(bitArrayToByte(bitmap.data.slice(i, i + 8) as BitArray));
-  }
-
-  return {
-    height: bitmap.height,
-    data: new Uint8Array(byteMap),
-    compressed: false,
-  };
+  return { height, data: bitImageBytes, compressed: false };
 }
 
 const MAX_PACKET_DATA_LENGTH = 128;
@@ -171,23 +159,38 @@ const MAX_PACKET_DATA_LENGTH = 128;
  * Compresses the bit image according to the PackBits algorithm that the device uses.
  */
 export function packBitsCompression(data: Uint8Array): Int8Array {
-  const compressedData: number[] = [];
+  // PackBits expands at most 4:3 (1-byte literal then 2-byte run, repeated)
+  const compressed = new Int8Array(data.length * 2);
+  let compressedLength = 0;
 
-  let i = 0;
-  let literalBuffer: number[] = [];
+  let literalStart = 0;
+  let literalLength = 0;
 
   function flushLiteralBuffer() {
-    if (literalBuffer.length === 0) return;
+    if (literalLength === 0) return;
 
-    compressedData.push(literalBuffer.length - 1, ...literalBuffer);
-    literalBuffer = [];
+    compressed[compressedLength] = literalLength - 1;
+    compressed.set(
+      data.subarray(literalStart, literalStart + literalLength),
+      compressedLength + 1
+    );
+    compressedLength += literalLength + 1;
+    literalLength = 0;
   }
 
+  function pushLiteral(index: number) {
+    if (literalLength === 0) {
+      literalStart = index;
+    }
+    literalLength += 1;
+  }
+
+  let i = 0;
   while (i < data.length) {
     const byte = data[i] as number;
     // if a lone final byte, encode as literal
     if (i + 1 >= data.length) {
-      literalBuffer.push(byte);
+      pushLiteral(i);
       flushLiteralBuffer();
       break;
     }
@@ -206,12 +209,13 @@ export function packBitsCompression(data: Uint8Array): Int8Array {
       ) {
         repeats += 1;
       }
-      compressedData.push(1 - repeats, byte);
+      compressed[compressedLength] = 1 - repeats;
+      compressed[compressedLength + 1] = byte;
+      compressedLength += 2;
       i += repeats;
     } else {
-      literalBuffer.push(byte);
-      // @coverage-defer
-      if (literalBuffer.length === MAX_PACKET_DATA_LENGTH) {
+      pushLiteral(i);
+      if (literalLength === MAX_PACKET_DATA_LENGTH) {
         flushLiteralBuffer();
       }
       i += 1;
@@ -220,7 +224,7 @@ export function packBitsCompression(data: Uint8Array): Int8Array {
 
   flushLiteralBuffer();
 
-  return new Int8Array(compressedData);
+  return compressed.slice(0, compressedLength);
 }
 
 export function compressBitImage(
@@ -237,7 +241,6 @@ export function compressBitImage(
 const WAIT_FOR_BUFFER_NOT_FULL_TIMEOUT_MS = 2.5 * 1000;
 const WAIT_FOR_BUFFER_FLUSH_TIMEOUT_MS = 10 * 1000;
 
-// @coverage-defer
 export async function printPageBitImage(
   driver: FujitsuThermalPrinterDriverInterface,
   compressedBitImages: IteratorPlus<CompressedBitImage>
@@ -254,12 +257,12 @@ export async function printPageBitImage(
       timeout: WAIT_FOR_BUFFER_NOT_FULL_TIMEOUT_MS,
       replyParameter: PRINT_ONGOING_REPLY_PARAMETER,
     });
+    // @coverage-defer
     if (waitForPrintReadyResult.isErr()) {
       return waitForPrintReadyResult;
     }
 
-    assert(compressedBitImage);
-    driver.printBitImage(compressedBitImage);
+    await driver.printBitImage(compressedBitImage);
   }
 
   await driver.setReplyParameter(PRINT_PROCESSING_REPLY_PARAMETER);
@@ -268,6 +271,7 @@ export async function printPageBitImage(
     timeout: WAIT_FOR_BUFFER_FLUSH_TIMEOUT_MS,
     replyParameter: PRINT_PROCESSING_REPLY_PARAMETER,
   });
+  // @coverage-defer
   if (waitForPrintFinished.isErr()) {
     return waitForPrintFinished;
   }
@@ -279,7 +283,6 @@ export async function printPageBitImage(
 /**
  * Prints page-width image data ({@link PAGE_DOTS_WIDTH}).
  */
-// @coverage-defer
 async function printImageDataInternal(
   driver: FujitsuThermalPrinterDriverInterface,
   imageData: ImageData
@@ -287,8 +290,7 @@ async function printImageDataInternal(
   return await printPageBitImage(
     driver,
     iter(chunkImageData(imageData))
-      .map((chunk) => imageDataToBinaryBitmap(chunk))
-      .map(bitmapToBitImage)
+      .map(imageDataToBitImage)
       .map(compressBitImage)
   );
 }
@@ -296,7 +298,6 @@ async function printImageDataInternal(
 /**
  * Prints an image that is exactly {@link PAGE_DOTS_WIDTH} dots wide.
  */
-// @coverage-defer
 export async function printImageData(
   driver: FujitsuThermalPrinterDriverInterface,
   imageData: ImageData
@@ -319,7 +320,6 @@ export async function printImageData(
  */
 const PDF_SCALE = 200 / 72;
 
-// @coverage-defer
 export async function printPdf(
   driver: FujitsuThermalPrinterDriverInterface,
   pdfData: Uint8Array
@@ -332,6 +332,7 @@ export async function printPdf(
       driver,
       trimImageDataToPageWidth(page)
     );
+    // @coverage-defer
     if (printPageResult.isErr()) {
       await driver.setReplyParameter(IDLE_REPLY_PARAMETER);
       return printPageResult;


### PR DESCRIPTION
## Overview

Partially addresses #4835 (the VxScan / report-printing half). Rebased onto `main` after #9304 and #9317 merged: the trim and chunk functions from #9317 are kept as-is, and this PR now replaces only the per-chunk conversion behind them.

Report printing on VxScan has a noticeable pause before it starts to print any report section. This is because the conversion code was not efficient. We (or I should say, I, once upon a time) expanded the image into a boolean array with a boolean (which even though it's a boolean, is a full byte allocation, or maybe more) for every bit. Although that didn't happen for the entire document all at once, like it does in VxMarkScan, it's still a 1.5M entry array and for each band of the image we measured it at ~320–400 ms in the VM.

Separately, `printBitImage` was called without `await`. The USB write inside it sits behind `await lock.acquire()`, so the call returned before the write was submitted, and the loop went straight on to converting the next band. JavaScript could not resume the suspended write until the loop next yielded, which was after that conversion, so each band reached the USB stack one conversion late. It is now awaited, which also turns a failed write into a returned error rather than an unhandled rejection.

This PR is is in the spirit of doing fewer obviously stupid things in terms of performance. In short, we combine three functions in the conversion pipeline into one and use bitwise operations to never have to allocate (or iterate over) a byte plus per pixel.

Rust was considered (see the issue) but is not needed here: a typed-array rewrite is already far below the printer's own band time, and it avoids adding a native build to a package consumed by seven workspace packages including two frontends.

### Measurements (dev VM, checked-in `tally-report-single-page.pdf`, 1700×2200 px)

| | before | after |
|---|---|---|
| full-page conversion + compression (3 bands) | ~900 ms | ~35 ms warm, ~55 ms in a cold process |
| first band submitted to USB, after page render | ~790 ms (band 1 and band 2 conversions) | ~20–35 ms (band 1 conversion, includes JIT warm-up) |
| interval between consecutive band submissions | ~300–400 ms | ~5–25 ms (the last band is 600 rows, not 800) |

Old and new implementations produce **byte-identical** compressed output on the fixture (checked by running the previous build's exported functions against the same rendered page).

### Where to look

`printing.ts` and `printing.test.ts` are the review: `imageDataToBinaryBitmap` + `bitmapToBitImage` become `imageDataToBitImage`, `packBitsCompression` writes into a preallocated buffer, and `printPageBitImage` awaits the write. `driver.ts` is a one-line interface type fix and `status.ts` drops a `@coverage-defer` marker that the new tests made stale.

## Demo Video or Screenshot

N/A — no UI change. Needs a check on real VxScan hardware that the initial pause is reduced.

## Testing Plan

- [x] New unit tests in `printing.test.ts`
- [ ] Print a polls-closed tally report on a VxScan and confirm the printout advances continuously with no pause between bands.

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions. (No new user actions.)
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



