### PR TITLE
VxScan: fujitsu printer - remove unused image conversion options

### DIFF
--- a/libs/fujitsu-thermal-printer/src/printing.ts
+++ b/libs/fujitsu-thermal-printer/src/printing.ts
@@ -78,52 +78,6 @@ export interface BinaryBitmap {
   data: boolean[];
 }
 
-// Grayscale conversion algorithm used is from
-// https://en.wikipedia.org/wiki/Grayscale#Colorimetric_(perceptual_luminance-preserving)_conversion_to_grayscale
-
-/**
- *
- * @param x Gamma-compressed color value
- * @returns
- */
-// @coverage-defer
-function gammaExpand(x: number) {
-  if (x < 0.04045) {
-    return x / 12.92;
-  }
-
-  return ((x + 0.055) / 1.055) ** 2.4;
-}
-
-// @coverage-defer
-function gammaCompress(x: number) {
-  if (x < 0.0031308) {
-    return x * 12.92;
-  }
-
-  return 1.055 * x ** (1 / 1.24) - 0.055;
-}
-
-/**
- * Converts 8-bit sRGB color values to an 8-bit grayscale value with gamma
- * correction.
- *
- * @param r Red color value from 0 - 255
- * @param g Green color value from 0 - 255
- * @param b Blue color value from 0 - 255
- * @returns Grayscale color value from 0 - 255
- */
-// @coverage-defer
-export function rgbToGrayscaleGamma(r: number, g: number, b: number): number {
-  return (
-    gammaCompress(
-      0.2126 * gammaExpand(r / 256) +
-        0.7152 * gammaExpand(g / 256) +
-        0.0722 * gammaExpand(b / 256)
-    ) * 256
-  );
-}
-
 /**
  * Converts 8-bit sRGB color values to an 8-bit grayscale value without gamma
  * correction.
@@ -141,18 +95,7 @@ export function rgbToGrayscale(r: number, g: number, b: number): number {
 /**
  * Below this value, we consider the grayscale to be black. Otherwise, white.
  */
-const DEFAULT_GRAYSCALE_WHITE_THRESHOLD = 230;
-
-export interface ImageConversionOptions {
-  useGammaConversion: boolean;
-  // number in [0, 256), above which the grayscale will be considered white
-  whiteThreshold: number;
-}
-
-export const DEFAULT_IMAGE_CONVERSION_OPTIONS: ImageConversionOptions = {
-  useGammaConversion: false,
-  whiteThreshold: DEFAULT_GRAYSCALE_WHITE_THRESHOLD,
-};
+const GRAYSCALE_WHITE_THRESHOLD = 230;
 
 /**
  * Converts 8-bit sRGB color values to a binary black/white representation.
@@ -164,29 +107,13 @@ export const DEFAULT_IMAGE_CONVERSION_OPTIONS: ImageConversionOptions = {
  * @returns true for black, false for white
  */
 // @coverage-defer
-function rgbToBinary(
-  r: number,
-  g: number,
-  b: number,
-  options: ImageConversionOptions
-): boolean {
-  const grayscaleValue = (
-    options.useGammaConversion ? rgbToGrayscaleGamma : rgbToGrayscale
-  )(r, g, b);
-  return grayscaleValue < options.whiteThreshold;
+function rgbToBinary(r: number, g: number, b: number): boolean {
+  return rgbToGrayscale(r, g, b) < GRAYSCALE_WHITE_THRESHOLD;
 }
 
 // @coverage-defer
-export function imageDataToBinaryBitmap(
-  imageData: ImageData,
-  // @coverage-defer
-  overrideOptions: Partial<ImageConversionOptions> = {}
-): BinaryBitmap {
+export function imageDataToBinaryBitmap(imageData: ImageData): BinaryBitmap {
   debug('converting image data to binary bitmap');
-  const options: ImageConversionOptions = {
-    ...DEFAULT_IMAGE_CONVERSION_OPTIONS,
-    ...overrideOptions,
-  };
 
   const data: boolean[] = [];
 
@@ -195,7 +122,7 @@ export function imageDataToBinaryBitmap(
     const g = imageData.data[i + 1] as number;
     const b = imageData.data[i + 2] as number;
 
-    data.push(rgbToBinary(r, g, b, options));
+    data.push(rgbToBinary(r, g, b));
   }
 
   return {
@@ -343,7 +270,7 @@ async function printImageDataInternal(
   return await printPageBitImage(
     driver,
     iter(trimAndChunkImageData(imageData))
-      .map((chunk) => imageDataToBinaryBitmap(chunk, {}))
+      .map(imageDataToBinaryBitmap)
       .map(bitmapToBitImage)
       .map(compressBitImage)
   );


### PR DESCRIPTION
Prep for the report-printing performance change (VxScan half of #4835), split out so that PR is a smaller diff against a smaller file.

`ImageConversionOptions` in `libs/fujitsu-thermal-printer/src/printing.ts` offered a gamma-corrected grayscale path and a configurable white threshold. Neither has ever been used, so they were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
