### PR TITLE
VxMarkScan: remove unused image conversion options

### DIFF
--- a/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/application_driver.ts
@@ -2,7 +2,6 @@ import { assert, iter, sleep } from '@votingworks/basics';
 import makeDebug from 'debug';
 
 import {
-  ImageConversionOptions,
   PaperHandlerDriverInterface,
   VERTICAL_DOTS_IN_CHUNK,
   chunkBinaryBitmap,
@@ -14,7 +13,11 @@ import {
 } from '@votingworks/custom-paper-handler';
 import { pdfToImages } from '@votingworks/image-utils';
 import { tmpNameSync } from 'tmp';
-import { PRINT_DPI, PAPER_HANDLER_RESET_DELAY_MS, SCAN_DPI } from './constants.js';
+import {
+  PRINT_DPI,
+  PAPER_HANDLER_RESET_DELAY_MS,
+  SCAN_DPI,
+} from './constants.js';
 
 const debug = makeDebug('mark-scan:custom-paper-handler:application-driver');
 
@@ -41,8 +44,7 @@ export async function setDefaults(
 
 export async function printBallotChunks(
   driver: PaperHandlerDriverInterface,
-  pdfData: Uint8Array,
-  options: Partial<ImageConversionOptions> = {}
+  pdfData: Uint8Array
 ): Promise<void> {
   debug('+printBallotChunks');
   const enablePrintPromise = driver.enablePrint();
@@ -67,7 +69,7 @@ export async function printBallotChunks(
     return;
   }
 
-  const ballotBinaryBitmap = imageDataToBinaryBitmap(page, options);
+  const ballotBinaryBitmap = imageDataToBinaryBitmap(page);
   const customChunkedBitmaps = chunkBinaryBitmap(ballotBinaryBitmap);
 
   await enablePrintPromise;

--- a/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
+++ b/apps/mark-scan/backend/src/custom-paper-handler/state_machine.ts
@@ -775,7 +775,7 @@ export function buildMachine(
                   id: 'printBallot',
                   src: (context, event) => {
                     assert(event.type === 'VOTER_INITIATED_PRINT');
-                    return printBallotChunks(context.driver, event.pdfData, {});
+                    return printBallotChunks(context.driver, event.pdfData);
                   },
                   onDone: 'scanning',
                   onError: {
@@ -1203,7 +1203,7 @@ export function buildMachine(
                   );
                   return renderDiagnosticMockBallot(electionDefinition).then(
                     (ballotData) =>
-                      printBallotChunks(context.driver, ballotData, {})
+                      printBallotChunks(context.driver, ballotData)
                   );
                 },
                 onDone: 'scan_ballot',

--- a/apps/mark-scan/backend/src/electrical_testing/background.ts
+++ b/apps/mark-scan/backend/src/electrical_testing/background.ts
@@ -301,7 +301,7 @@ export async function runPrintAndScanTask({
     await logger.logAsCurrentRole(LogEventId.BackgroundTaskStatus, {
       message: `Printing ${testPdfBytes.length} bytes`,
     });
-    await printBallotChunks(driver, testPdfBytes, {});
+    await printBallotChunks(driver, testPdfBytes);
     // Disable print mode to prepare to scan.
     await driver.disablePrint();
     if ((await errorIfPaperJam()).isErr()) {

--- a/libs/custom-paper-handler/src/printing.ts
+++ b/libs/custom-paper-handler/src/printing.ts
@@ -15,49 +15,6 @@ export interface PaperHandlerBitmapExt extends PaperHandlerBitmap {
   empty?: boolean;
 }
 
-// Grayscale conversion algorithm used is from
-// https://en.wikipedia.org/wiki/Grayscale#Colorimetric_(perceptual_luminance-preserving)_conversion_to_grayscale
-
-/**
- *
- * @param x Gamma-compressed color value
- * @returns
- */
-function gammaExpand(x: number) {
-  if (x < 0.04045) {
-    return x / 12.92;
-  }
-
-  return ((x + 0.055) / 1.055) ** 2.4;
-}
-
-function gammaCompress(x: number) {
-  if (x < 0.0031308) {
-    return x * 12.92;
-  }
-
-  return 1.055 * x ** (1 / 1.24) - 0.055;
-}
-
-/**
- * Converts 8-bit sRGB color values to an 8-bit grayscale value with gamma
- * correction.
- *
- * @param r Red color value from 0 - 255
- * @param g Green color value from 0 - 255
- * @param b Blue color value from 0 - 255
- * @returns Grayscale color value from 0 - 255
- */
-export function rgbToGrayscaleGamma(r: number, g: number, b: number): number {
-  return (
-    gammaCompress(
-      0.2126 * gammaExpand(r / 256) +
-        0.7152 * gammaExpand(g / 256) +
-        0.0722 * gammaExpand(b / 256)
-    ) * 256
-  );
-}
-
 /**
  * Converts 8-bit sRGB color values to an 8-bit grayscale value without gamma
  * correction.
@@ -74,18 +31,7 @@ export function rgbToGrayscale(r: number, g: number, b: number): number {
 /**
  * Below this value, we consider the grayscale to be black. Otherwise, white.
  */
-const DEFAULT_GRAYSCALE_WHITE_THRESHOLD = 230;
-
-export interface ImageConversionOptions {
-  useGammaConversion: boolean;
-  // number in [0, 256), above which the grayscale will be considered white
-  whiteThreshold: number;
-}
-
-export const DEFAULT_IMAGE_CONVERSION_OPTIONS: ImageConversionOptions = {
-  useGammaConversion: false,
-  whiteThreshold: DEFAULT_GRAYSCALE_WHITE_THRESHOLD,
-};
+const GRAYSCALE_WHITE_THRESHOLD = 230;
 
 /**
  * Converts 8-bit sRGB color values to a binary black/white representation.
@@ -96,27 +42,11 @@ export const DEFAULT_IMAGE_CONVERSION_OPTIONS: ImageConversionOptions = {
  * @param b Blue color value from 0 - 255
  * @returns true for black, false for white
  */
-function rgbToBinary(
-  r: number,
-  g: number,
-  b: number,
-  options: ImageConversionOptions
-): boolean {
-  const grayscaleValue = (
-    options.useGammaConversion ? rgbToGrayscaleGamma : rgbToGrayscale
-  )(r, g, b);
-  return grayscaleValue < options.whiteThreshold;
+function rgbToBinary(r: number, g: number, b: number): boolean {
+  return rgbToGrayscale(r, g, b) < GRAYSCALE_WHITE_THRESHOLD;
 }
 
-export function imageDataToBinaryBitmap(
-  imageData: ImageData,
-  overrideOptions: Partial<ImageConversionOptions> = {}
-): BinaryBitmap {
-  const options: ImageConversionOptions = {
-    ...DEFAULT_IMAGE_CONVERSION_OPTIONS,
-    ...overrideOptions,
-  };
-
+export function imageDataToBinaryBitmap(imageData: ImageData): BinaryBitmap {
   const data: boolean[] = [];
 
   let r = 0;
@@ -136,7 +66,7 @@ export function imageDataToBinaryBitmap(
         b = element;
         return;
       case 3:
-        data.push(rgbToBinary(r, g, b, options));
+        data.push(rgbToBinary(r, g, b));
     }
   });
 


### PR DESCRIPTION
## Overview

Prep for the ballot-printing performance change (VxMarkScan half of #4835), split out so that PR is a smaller diff against a smaller file. Same shape as #9304 was for VxScan.

`ImageConversionOptions` in `libs/custom-paper-handler/src/printing.ts` offered a gamma-corrected grayscale path and a configurable white threshold. Neither has ever been used: `printBallotChunks` accepted the options and every caller (the voting state machine, the diagnostic state, and electrical testing) passed `{}`.

## Demo Video or Screenshot

N/A — pure deletion, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
