### PR TITLE
`libs/printing`: plumbing to support print job status interactions

### DIFF
--- a/apps/mark/backend/src/util/print_ballot.tsx
+++ b/apps/mark/backend/src/util/print_ballot.tsx
@@ -17,6 +17,7 @@ import {
   Election,
   getBallotStyle,
   getContests,
+  PrintJobId,
 } from '@votingworks/types';
 import { encodeSummaryBallotPage } from '@votingworks/ballot-encoder';
 import {
@@ -50,7 +51,7 @@ export interface PrintBallotProps extends ClientParams {
 
 type PrintBlankBallotProps = Omit<PrintBallotProps, 'votes' | 'languageCode'>;
 
-export async function printBallot(p: PrintBallotProps): Promise<void> {
+export async function printBallot(p: PrintBallotProps): Promise<PrintJobId> {
   const { printer, store, precinctId, ballotStyleId, votes, languageCode } = p;
 
   const systemSettings = assertDefined(store.getSystemSettings());
@@ -231,7 +232,7 @@ function getBaseBallotPdf(
   return { election, baseBallotPdf };
 }
 
-async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
+async function printBubbleBallot(p: PrintBallotProps): Promise<PrintJobId> {
   const { election, baseBallotPdf } = getBaseBallotPdf(
     p.store,
     p.ballotStyleId,
@@ -255,7 +256,7 @@ async function printBubbleBallot(p: PrintBallotProps): Promise<void> {
 
 export async function printBlankBallot(
   p: PrintBlankBallotProps
-): Promise<void> {
+): Promise<PrintJobId> {
   const { election, baseBallotPdf } = getBaseBallotPdf(
     p.store,
     p.ballotStyleId,
@@ -269,7 +270,7 @@ export async function printBlankBallot(
   });
 }
 
-async function printMarkOverlay(p: PrintBallotProps): Promise<void> {
+async function printMarkOverlay(p: PrintBallotProps): Promise<PrintJobId> {
   const { electionDefinition } = assertDefined(p.store.getElectionRecord());
   const { election } = electionDefinition;
 

--- a/libs/printing/src/printer/configure.test.ts
+++ b/libs/printing/src/printer/configure.test.ts
@@ -36,5 +36,7 @@ test('calls lpadmin with expected args', async () => {
     '-P',
     getPpdPath(config),
     '-E',
+    '-o',
+    'printer-error-policy=abort-job',
   ]);
 });

--- a/libs/printing/src/printer/configure.ts
+++ b/libs/printing/src/printer/configure.ts
@@ -24,7 +24,11 @@ export async function configurePrinter({
     uri,
     '-P',
     getPpdPath(config),
-    '-E', // immediately enable the printer
+    '-E',
+    // Abort failed jobs so they don't get retried 5 minutes later, possibly resulting
+    // in unexpectedly printing a ballot
+    '-o',
+    'printer-error-policy=abort-job',
   ];
 
   debug('configuring printer with lpadmin: args=%o', lpadminConfigureArgs);

--- a/libs/printing/src/printer/ipp_queries/get-job-attributes.ipp
+++ b/libs/printing/src/printer/ipp_queries/get-job-attributes.ipp
@@ -1,0 +1,9 @@
+{
+  OPERATION Get-Job-Attributes
+  GROUP operation-attributes-tag
+  ATTR charset attributes-charset utf-8
+  ATTR language attributes-natural-language en
+  ATTR uri printer-uri $uri
+  ATTR integer job-id $job-id
+  ATTR keyword requested-attributes job-state,job-printer-state-message
+}

--- a/libs/printing/src/printer/job_status.test.ts
+++ b/libs/printing/src/printer/job_status.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { err, ok } from '@votingworks/basics';
+import { IppJobState, PrintJobOutcome } from '@votingworks/types';
+import {
+  CUPS_SCHEDULER_IPP_URI,
+  GET_JOB_ATTRIBUTES_QUERY_PATH,
+  classifyJobState,
+  queryJobStatus,
+} from './job_status';
+import { exec } from '../utils/exec';
+
+vi.mock('../utils/exec', async () => ({
+  ...(await vi.importActual('../utils/exec')),
+  exec: vi.fn(),
+}));
+
+const execMock = vi.mocked(exec);
+
+beforeEach(() => {
+  execMock.mockReset();
+});
+
+function mockIpptoolStdout({
+  statusLine = 'status-code = successful-ok (successful-ok)',
+  body = '',
+}: { statusLine?: string; body?: string } = {}): string {
+  return `"/tmp/query":
+      Get-Job-Attributes:
+          attributes-charset (charset) = utf-8
+      /tmp/query                                                           [PASS]
+          RECEIVED: 121 bytes in response
+          ${statusLine}
+          attributes-charset (charset) = utf-8
+          attributes-natural-language (naturalLanguage) = en
+${body}`;
+}
+
+function mockJobResponse(state: IppJobState, message = ''): void {
+  execMock.mockResolvedValue(
+    ok({
+      stdout: mockIpptoolStdout({
+        body: `          job-state (enum) = ${state}
+          job-printer-state-message (textWithoutLanguage) =${
+            message ? ` ${message}` : ''
+          }`,
+      }),
+      stderr: '',
+    })
+  );
+}
+
+test('queries the CUPS scheduler for the given job', async () => {
+  mockJobResponse('completed');
+
+  expect((await queryJobStatus(42)).unsafeUnwrap()).toEqual({
+    outcome: 'sent-to-printer',
+    reason: undefined,
+  });
+
+  expect(execMock).toHaveBeenCalledWith('ipptool', [
+    '-T',
+    '5',
+    '-tv',
+    '-d',
+    'job-id=42',
+    CUPS_SCHEDULER_IPP_URI,
+    GET_JOB_ATTRIBUTES_QUERY_PATH,
+  ]);
+});
+
+test('reports the diagnostic message for a failed job', async () => {
+  mockJobResponse('aborted', 'Unable to send data to printer.');
+
+  expect((await queryJobStatus(42)).unsafeUnwrap()).toEqual({
+    outcome: 'failed',
+    reason: 'Unable to send data to printer.',
+  });
+});
+
+test('returns an error when CUPS does not know the job', async () => {
+  execMock.mockResolvedValue(
+    ok({
+      stdout: mockIpptoolStdout({
+        statusLine:
+          'status-code = client-error-not-found (Job #999 does not exist.)',
+        body: '          status-message (textWithoutLanguage) = Job #999 does not exist.',
+      }),
+      stderr: '',
+    })
+  );
+
+  const result = await queryJobStatus(999);
+  expect(result.err()).toEqual({
+    type: 'unknown-job',
+    message:
+      'CUPS did not return job 999: status-code = client-error-not-found (Job #999 does not exist.)',
+  });
+});
+
+test('returns an error when ipptool itself fails', async () => {
+  execMock.mockResolvedValue(
+    err({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: 'ipptool: Unable to connect\n',
+      cmd: 'ipptool',
+    })
+  );
+
+  const result = await queryJobStatus(42);
+  expect(result.err()).toEqual({
+    type: 'query-failed',
+    message: 'ipptool failed: ipptool: Unable to connect',
+  });
+});
+
+test.each<[IppJobState, PrintJobOutcome]>([
+  ['pending', 'in-progress'],
+  ['pending-held', 'in-progress'],
+  ['processing', 'in-progress'],
+  ['processing-stopped', 'in-progress'],
+  ['completed', 'sent-to-printer'],
+  ['canceled', 'failed'],
+  ['aborted', 'failed'],
+])('classifies %s as %s', (state, outcome) => {
+  expect(classifyJobState(state)).toEqual(outcome);
+});

--- a/libs/printing/src/printer/job_status.test.ts
+++ b/libs/printing/src/printer/job_status.test.ts
@@ -6,8 +6,8 @@ import {
   GET_JOB_ATTRIBUTES_QUERY_PATH,
   classifyJobState,
   queryJobStatus,
-} from './job_status';
-import { exec } from '../utils/exec';
+} from './job_status.js';
+import { exec } from '../utils/exec.js';
 
 vi.mock('../utils/exec', async () => ({
   ...(await vi.importActual('../utils/exec')),

--- a/libs/printing/src/printer/job_status.ts
+++ b/libs/printing/src/printer/job_status.ts
@@ -1,0 +1,116 @@
+import { join } from 'node:path';
+import { Result, err, ok, throwIllegalValue } from '@votingworks/basics';
+import {
+  IppJobState,
+  PrintJobId,
+  PrintJobOutcome,
+  PrintJobStatus,
+} from '@votingworks/types';
+import { exec } from '../utils/exec';
+import { rootDebug } from '../utils/debug';
+import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
+import { IPPTOOL_SUCCESS_STATUS_LINE, parseIpptoolOutput } from './status';
+
+const debug = rootDebug.extend('job-status');
+
+/**
+ * :631 is the CUPS scheduler's IPP endpoint, where our print jobs live. Not to be
+ * confused with {@link CUPS_DEFAULT_IPP_URI}, which addresses the printer
+ * itself via the `ipp-usb` daemon and numbers its jobs independently of CUPS —
+ * a job id from `lp` means nothing there.
+ */
+export const CUPS_SCHEDULER_IPP_URI = `ipp://localhost:631/printers/${DEFAULT_MANAGED_PRINTER_NAME}`;
+
+const RELATIVE_PATH_TO_IPP_QUERIES = './ipp_queries';
+
+export const GET_JOB_ATTRIBUTES_QUERY_PATH = join(
+  __dirname,
+  RELATIVE_PATH_TO_IPP_QUERIES,
+  'get-job-attributes.ipp'
+);
+
+const IPPTOOL_TIMEOUT_SECONDS = '5';
+
+/**
+ * Reduces IPP job states to what VxSuite business logic needs to know.
+ */
+export function classifyJobState(state: IppJobState): PrintJobOutcome {
+  switch (state) {
+    case 'completed':
+      return 'sent-to-printer';
+    case 'canceled':
+    case 'aborted':
+      return 'failed';
+    case 'pending':
+    case 'pending-held':
+    case 'processing':
+    case 'processing-stopped':
+      return 'in-progress';
+    /* istanbul ignore next - @preserve */
+    default:
+      return throwIllegalValue(state);
+  }
+}
+
+/**
+ * Why a job status query did not produce a status.
+ * `query-failed` means CUPS is unreachable or `ipptool` timed out.
+ * `unknown-job` means CUPS answered that it has no record of the
+ * job, which happens once the job ages out of its history.
+ */
+export type JobStatusQueryError =
+  | { type: 'query-failed'; message: string }
+  | { type: 'unknown-job'; message: string };
+
+/**
+ * Asks the CUPS scheduler for the status of a single job.
+ */
+export async function queryJobStatus(
+  jobId: PrintJobId
+): Promise<Result<PrintJobStatus, JobStatusQueryError>> {
+  const ipptoolArgs = [
+    '-T',
+    IPPTOOL_TIMEOUT_SECONDS,
+    // `-t` selects CUPS test report output and `-v` includes the response
+    // attributes in it. Together they produce the format parseIpptoolOutput
+    // expects; `-v` alone does nothing.
+    '-tv',
+    '-d',
+    `job-id=${jobId}`,
+    CUPS_SCHEDULER_IPP_URI,
+    GET_JOB_ATTRIBUTES_QUERY_PATH,
+  ];
+
+  debug('querying job %d status, args=%o', jobId, ipptoolArgs);
+  const ipptoolResult = await exec('ipptool', ipptoolArgs);
+  // Query failed to run; job status unknown
+  if (ipptoolResult.isErr()) {
+    return err({
+      type: 'query-failed',
+      message: `ipptool failed: ${ipptoolResult.err().stderr.trim()}`,
+    });
+  }
+
+  const { statusLine, attributes } = parseIpptoolOutput(
+    ipptoolResult.ok().stdout,
+    { allowFailureStatus: true }
+  );
+  if (statusLine !== IPPTOOL_SUCCESS_STATUS_LINE) {
+    return err({
+      type: 'unknown-job',
+      message: `CUPS did not return job ${jobId}: ${statusLine}`,
+    });
+  }
+
+  const state = attributes['job-state'] as IppJobState;
+  // job-printer-state-message is empty for any job that did not fault.
+  // Collapse it so callers see an absent reason rather than an empty string.
+  const message =
+    (attributes['job-printer-state-message'] as string) || undefined;
+  debug('job %d state=%s message=%s', jobId, state, message);
+
+  return ok({
+    outcome: classifyJobState(state),
+    reason: message,
+  });
+}

--- a/libs/printing/src/printer/job_status.ts
+++ b/libs/printing/src/printer/job_status.ts
@@ -6,10 +6,10 @@ import {
   PrintJobOutcome,
   PrintJobStatus,
 } from '@votingworks/types';
-import { exec } from '../utils/exec';
-import { rootDebug } from '../utils/debug';
-import { DEFAULT_MANAGED_PRINTER_NAME } from './configure';
-import { IPPTOOL_SUCCESS_STATUS_LINE, parseIpptoolOutput } from './status';
+import { exec } from '../utils/exec.js';
+import { rootDebug } from '../utils/debug.js';
+import { DEFAULT_MANAGED_PRINTER_NAME } from './configure.js';
+import { IPPTOOL_SUCCESS_STATUS_LINE, parseIpptoolOutput } from './status.js';
 
 const debug = rootDebug.extend('job-status');
 

--- a/libs/printing/src/printer/mocks/file_printer.ts
+++ b/libs/printing/src/printer/mocks/file_printer.ts
@@ -13,10 +13,10 @@ import {
 import { Optional, assert, iter } from '@votingworks/basics';
 import { writeFile } from 'node:fs/promises';
 import { PDFDocument } from 'pdf-lib';
-import { PrinterConfig, PrinterStatus } from '@votingworks/types';
+import { PrinterConfig, PrinterStatus, PrintJobId } from '@votingworks/types';
 import { getMockStateRootDir } from '@votingworks/utils';
 import { PrintProps, PrintSides, Printer } from '../types.js';
-import { getMockConnectedPrinterStatus } from './fixtures.js';
+import { createMockJobId, getMockConnectedPrinterStatus } from './fixtures.js';
 
 export const MOCK_PRINTER_STATE_FILENAME = 'state.json';
 // libs/printing/src/printer/mocks/ is 5 levels below the repo root
@@ -128,7 +128,7 @@ export class MockFilePrinter implements Printer {
     return Promise.resolve(readFromMockFile());
   }
 
-  async print(props: PrintProps): Promise<void> {
+  async print(props: PrintProps): Promise<PrintJobId> {
     const status = readFromMockFile();
     if (!status.connected) {
       throw new Error('cannot print without printer connected');
@@ -160,13 +160,14 @@ export class MockFilePrinter implements Printer {
         }
         const modifiedBytes = await pdf.save();
         await writeFile(filename, modifiedBytes);
-        return;
+        return createMockJobId();
       } catch {
         // Data is not a valid PDF, write as-is
       }
     }
 
     await writeFile(filename, data);
+    return createMockJobId();
   }
 }
 

--- a/libs/printing/src/printer/mocks/fixtures.ts
+++ b/libs/printing/src/printer/mocks/fixtures.ts
@@ -3,6 +3,7 @@ import {
   PrinterConfig,
   PrinterRichStatus,
   PrinterStatus,
+  PrintJobId,
 } from '@votingworks/types';
 
 export const MOCK_MARKER_INFO: IppMarkerInfo = {
@@ -35,4 +36,12 @@ export function getMockConnectedPrinterStatus(
     connected: true,
     config,
   };
+}
+
+let nextMockJobId = 1;
+
+export function createMockJobId(): PrintJobId {
+  const jobId = nextMockJobId;
+  nextMockJobId += 1;
+  return jobId;
 }

--- a/libs/printing/src/printer/mocks/memory_printer.ts
+++ b/libs/printing/src/printer/mocks/memory_printer.ts
@@ -1,9 +1,9 @@
 import { tmpName } from 'tmp-promise';
 import { writeFile } from 'node:fs/promises';
 import { rmSync } from 'node:fs';
-import { PrinterConfig, PrinterStatus } from '@votingworks/types';
+import { PrinterConfig, PrinterStatus, PrintJobId } from '@votingworks/types';
 import { MockPrintJob, PrintProps, Printer } from '../types.js';
-import { getMockConnectedPrinterStatus } from './fixtures.js';
+import { createMockJobId, getMockConnectedPrinterStatus } from './fixtures.js';
 
 /**
  * A mock of the UsbDrive interface. See createMockUsbDrive for details.
@@ -34,7 +34,7 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
     printJobHistory: [],
   };
 
-  async function mockPrint(props: PrintProps): Promise<void> {
+  async function mockPrint(props: PrintProps): Promise<PrintJobId> {
     if (!mockPrinterState.status.connected) {
       throw new Error('cannot print without printer connected');
     }
@@ -52,6 +52,8 @@ export function createMockPrinterHandler(): MemoryPrinterHandler {
       filename,
       options,
     });
+
+    return createMockJobId();
   }
 
   const printer: Printer = {

--- a/libs/printing/src/printer/print.test.ts
+++ b/libs/printing/src/printer/print.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { ok } from '@votingworks/basics';
 import { exec } from '../utils/exec.js';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure.js';
-import { print } from './print.js';
+import { cancelAllJobs, print } from './print.js';
 import { PrintSides } from './types.js';
 
 vi.mock('../utils/exec');
@@ -153,4 +153,15 @@ test('fails fast if the job id cannot be parsed from lp output', async () => {
   await expect(print({ data: Uint8Array.of(0xca, 0xfe) })).rejects.toThrow(
     'unable to parse job id from lp output: something unexpected'
   );
+});
+
+test('cancels all queued jobs', async () => {
+  vi.mocked(exec).mockResolvedValueOnce(ok({ stdout: '', stderr: '' }));
+
+  await cancelAllJobs();
+
+  expect(exec).toHaveBeenCalledWith('cancel', [
+    '-a',
+    DEFAULT_MANAGED_PRINTER_NAME,
+  ]);
 });

--- a/libs/printing/src/printer/print.ts
+++ b/libs/printing/src/printer/print.ts
@@ -50,3 +50,9 @@ export async function print({
   assert(jobIdMatch, `unable to parse job id from lp output: ${stdout}`);
   return safeParseInt(jobIdMatch[1]).unsafeUnwrap();
 }
+
+export async function cancelAllJobs(): Promise<void> {
+  const cancelArgs = ['-a', DEFAULT_MANAGED_PRINTER_NAME];
+  debug('cancelling all jobs: args=%o', cancelArgs);
+  (await exec('cancel', cancelArgs)).unsafeUnwrap();
+}

--- a/libs/printing/src/printer/print.ts
+++ b/libs/printing/src/printer/print.ts
@@ -1,17 +1,11 @@
 import { assert } from '@votingworks/basics';
-import { safeParseInt } from '@votingworks/types';
+import { PrintJobId, safeParseInt } from '@votingworks/types';
 import { rootDebug } from '../utils/debug.js';
 import { PrintProps, PrintSides } from './types.js';
 import { DEFAULT_MANAGED_PRINTER_NAME } from './configure.js';
 import { exec } from '../utils/exec.js';
 
 const debug = rootDebug.extend('status');
-
-/**
- * The id CUPS assigned to a submitted print job, unique per queue. Can be used
- * to query the job's status on the CUPS server.
- */
-export type PrintJobId = number;
 
 // `lp` reports the assigned job id on stdout, e.g. "request id is
 // VxPrinter-42 (1 file(s))". The sentence is localized but the

--- a/libs/printing/src/printer/printer.ts
+++ b/libs/printing/src/printer/printer.ts
@@ -108,8 +108,7 @@ export function detectPrinter(logger: BaseLogger): Printer {
             assertDefined(getPrinterConfig(printerDevice.uri))
           )
         : {};
-      // the job id is not yet consumed; CUPS-side job tracking will use it
-      await printData({ ...props, raw: { ...printerOptions, ...raw } });
+      return printData({ ...props, raw: { ...printerOptions, ...raw } });
     },
   };
 }

--- a/libs/printing/src/printer/status.test.ts
+++ b/libs/printing/src/printer/status.test.ts
@@ -253,7 +253,7 @@ test('throws error if ipptool output cannot be parsed', async () => {
     ],
     [
       mockIpptoolStdout({ 'printer-state': '(enum) = ' }),
-      'Unable to parse ipptool output line: printer-state (enum) =',
+      'Unexpected undefined value in line: printer-state (enum) =',
     ],
     [
       mockIpptoolStdout({ 'printer-state': '(badType) = idle' }),

--- a/libs/printing/src/printer/status.ts
+++ b/libs/printing/src/printer/status.ts
@@ -13,9 +13,23 @@ import { rootDebug } from '../utils/debug.js';
 
 const debug = rootDebug.extend('status');
 
-interface IppAttributes {
+export interface IppAttributes {
   [attribute: string]: string | string[] | number | number[];
 }
+
+/**
+ * A parsed `ipptool` response. `statusLine` is exposed raw rather than as a
+ * bare status code so callers can decide how strict to be: the printer status
+ * path treats anything but success as a fault, while job queries expect
+ * `client-error-not-found` for jobs that have aged out of CUPS's history.
+ */
+export interface IpptoolResponse {
+  statusLine: string;
+  attributes: IppAttributes;
+}
+
+export const IPPTOOL_SUCCESS_STATUS_LINE =
+  'status-code = successful-ok (successful-ok)';
 
 export const IPP_ATTRIBUTES_TO_QUERY = [
   'printer-state',
@@ -54,7 +68,10 @@ export const IPP_QUERY = `{
  *          printer-state (enum) = stopped
  *          printer-state-reasons (1setOf keyword) = media-empty-error,media-needed-error,media-empty-error
  */
-function parseIpptoolOutput(output: string): IppAttributes {
+export function parseIpptoolOutput(
+  output: string,
+  { allowFailureStatus }: { allowFailureStatus?: boolean } = {}
+): IpptoolResponse {
   const allLines = output.split('\n');
   assert(allLines.length > 0, 'ipptool output is empty');
 
@@ -65,10 +82,13 @@ function parseIpptoolOutput(output: string): IppAttributes {
   const statusLine = responseLines.shift();
   const characterSetLine = responseLines.shift();
   const languageLine = responseLines.shift();
-  assert(
-    statusLine === 'status-code = successful-ok (successful-ok)',
-    `Unsuccessful ipptool response: ${statusLine ?? '<empty>'}`
-  );
+  assert(statusLine !== undefined, 'Unsuccessful ipptool response: <empty>');
+  if (!allowFailureStatus) {
+    assert(
+      statusLine === IPPTOOL_SUCCESS_STATUS_LINE,
+      `Unsuccessful ipptool response: ${statusLine}`
+    );
+  }
   assert(
     characterSetLine === 'attributes-charset (charset) = utf-8',
     'Invalid character set line'
@@ -78,11 +98,21 @@ function parseIpptoolOutput(output: string): IppAttributes {
     'Invalid default language line'
   );
 
-  const lineRegex = /^(.+) \((.+)\) = (.+)$/;
+  // This regex must allow properties with no values. A query for job status
+  // will return `job-printer-state-message (textWithoutLanguage) =` when the job
+  // is a success.
+  const lineRegex = /^(.+) \((.+)\) =(?: (.*))?$/;
   const attributes = responseLines.reduce<IppAttributes>((attrs, line) => {
     const matches = lineRegex.exec(line);
     assert(matches, `Unable to parse ipptool output line: ${line}`);
     const [, attribute, type, value] = matches;
+    if (value === undefined) {
+      assert(
+        type === 'textWithoutLanguage' || type === 'nameWithoutLanguage',
+        `Unexpected undefined value in line: ${line}`
+      );
+      return { ...attrs, [attribute]: '' };
+    }
     switch (type) {
       case 'keyword':
       case 'enum':
@@ -107,7 +137,7 @@ function parseIpptoolOutput(output: string): IppAttributes {
         throw new Error(`Unsupported IPP attribute type: ${type}`);
     }
   }, {});
-  return attributes;
+  return { statusLine, attributes };
 }
 
 /**
@@ -144,7 +174,7 @@ async function getPrinterIppAttributes(
   debug('ipptool stdout:\n%s', stdout);
   debug('ipptool stderr:\n%s', stderr);
 
-  const attributes = parseIpptoolOutput(stdout);
+  const { attributes } = parseIpptoolOutput(stdout);
   debug('parsed ipptool attributes: %O', attributes);
   return attributes;
 }

--- a/libs/printing/src/printer/types.ts
+++ b/libs/printing/src/printer/types.ts
@@ -1,4 +1,8 @@
-import { HmpbBallotPaperSize, PrinterStatus } from '@votingworks/types';
+import {
+  HmpbBallotPaperSize,
+  PrinterStatus,
+  PrintJobId,
+} from '@votingworks/types';
 
 export enum PrintSides {
   /**
@@ -38,7 +42,7 @@ export type PrintProps = PrintOptions & {
     | AsyncIterable<Uint8Array>;
 };
 
-export type PrintFunction = (props: PrintProps) => Promise<void>;
+export type PrintFunction = (props: PrintProps) => Promise<PrintJobId>;
 
 export interface Printer {
   status: () => Promise<PrinterStatus>;

--- a/libs/types/src/ipp_printing.ts
+++ b/libs/types/src/ipp_printing.ts
@@ -107,3 +107,37 @@ export interface PrinterRichStatus {
   stateReasons: IppPrinterStateReason[];
   markerInfos: IppMarkerInfo[];
 }
+
+/**
+ * The id CUPS assigned to a submitted print job, unique per queue. Can be used
+ * to query the job's status on the CUPS server.
+ */
+export type PrintJobId = number;
+
+/**
+ * IPP `job-state` prop identifies the basic status of a print job.
+ * https://datatracker.ietf.org/doc/html/rfc2911#section-4.3.7
+ */
+export type IppJobState =
+  | 'pending'
+  | 'pending-held'
+  | 'processing'
+  | 'processing-stopped'
+  | 'canceled'
+  | 'aborted'
+  | 'completed';
+
+/**
+ * What a print job means to the application, derived from {@link IppJobState}.
+ * `sent-to-printer` means CUPS finished transferring the job to the printer.
+ * It does not mean the pages have physically printed.
+ */
+export type PrintJobOutcome = 'in-progress' | 'sent-to-printer' | 'failed';
+
+/**
+ * The status of a print job as tracked by `libs/printing`.
+ */
+export interface PrintJobStatus {
+  outcome: PrintJobOutcome;
+  reason?: string;
+}

--- a/specs/0008-print-job-tracking.md
+++ b/specs/0008-print-job-tracking.md
@@ -297,7 +297,10 @@ In `libs/printing`:
 
 In `VxMark` and `VxPrint`:
 
-1. TODO
+VxPrint uses `PrinterPrintRequest` for app-domain logs that have knowledge of
+ballot styles and number of ballots printed. Since `PrinterPrintRequest` will be
+moved to `libs/printing`, and to avoid redundancy, we'll add a `BallotPrinted`
+log event for use in VxPrint.
 
 ## Alternatives Considered
 


### PR DESCRIPTION
## Overview

Relates to https://github.com/votingworks/vxsuite/issues/9186. Extends `libs/printing` to support print status tracking behavior in VxMark/VxPrint

See the complete spec in https://github.com/votingworks/vxsuite/pull/9241

Sets up various parts of `libs/printing` to interact with job status and job management via CUPS and IPP.

* Adapts `parseIpptoolOutput` for our use by allowing empty values in response and not throwing on non-success statuses
* Adds IPP query file for getting job status (these must be files on disk)
* Adds method for querying CUPS for job status
* Adds method for clearing print job queue

## Demo Video or Screenshot

N/A; lib changes only

## Testing Plan

Added unit tests

## Checklist
All N/A

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
