### PR TITLE
`libs/printing`: add print job monitor to track a single print job

### DIFF
--- a/libs/printing/src/printer/job_monitor.test.ts
+++ b/libs/printing/src/printer/job_monitor.test.ts
@@ -8,8 +8,8 @@ import {
   MAX_CONSECUTIVE_QUERY_FAILURES,
   TERMINAL_STATUS_RETENTION_MS,
   startPrintJobMonitor,
-} from './job_monitor';
-import { queryJobStatus } from './job_status';
+} from './job_monitor.js';
+import { queryJobStatus } from './job_status.js';
 
 vi.mock(import('./job_status.js'), async (importActual) => ({
   ...(await importActual()),

--- a/libs/printing/src/printer/job_monitor.test.ts
+++ b/libs/printing/src/printer/job_monitor.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { deferred, err, ok } from '@votingworks/basics';
+import { LogEventId, mockBaseLogger } from '@votingworks/logging';
+import { PrintJobId, PrintJobStatus } from '@votingworks/types';
+import {
+  JOB_POLL_INTERVAL_MS,
+  JOB_TIMEOUT_MS,
+  MAX_CONSECUTIVE_QUERY_FAILURES,
+  TERMINAL_STATUS_RETENTION_MS,
+  startPrintJobMonitor,
+} from './job_monitor';
+import { queryJobStatus } from './job_status';
+
+vi.mock(import('./job_status.js'), async (importActual) => ({
+  ...(await importActual()),
+  queryJobStatus: vi.fn(),
+}));
+
+const queryJobStatusMock = vi.mocked(queryJobStatus);
+
+const JOB_ID: PrintJobId = 42;
+
+let status: PrintJobStatus | undefined;
+let setStatus: (next: PrintJobStatus) => void;
+let clearStatus: () => void;
+let logger: ReturnType<typeof mockBaseLogger>;
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: false });
+  status = undefined;
+  setStatus = vi.fn((next: PrintJobStatus) => {
+    status = next;
+  });
+  clearStatus = vi.fn(() => {
+    status = undefined;
+  });
+  logger = mockBaseLogger({ fn: vi.fn });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function start() {
+  return startPrintJobMonitor({
+    jobId: JOB_ID,
+    setStatus,
+    clearStatus,
+    logger,
+  });
+}
+
+/**
+ * The async variant is required so the awaited query settles inside the tick.
+ */
+async function advancePolls(count = 1): Promise<void> {
+  await vi.advanceTimersByTimeAsync(JOB_POLL_INTERVAL_MS * count);
+}
+
+test('records the job as in progress before the first poll', () => {
+  start();
+  expect(status).toEqual({ outcome: 'in-progress' });
+  expect(queryJobStatusMock).not.toHaveBeenCalled();
+});
+
+test('stays in progress while CUPS reports the job in progress', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'in-progress' }));
+  start();
+
+  await advancePolls(3);
+
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(3);
+  expect(status).toEqual({ outcome: 'in-progress' });
+  expect(logger.log).not.toHaveBeenCalled();
+});
+
+test('finishes and stops polling when the job is sent to the printer', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  start();
+
+  await advancePolls();
+
+  expect(status).toEqual({ outcome: 'sent-to-printer' });
+  expect(logger.log).toHaveBeenCalledTimes(1);
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.PrinterPrintComplete,
+    'system',
+    {
+      message: 'CUPS finished sending the print job to the printer.',
+      disposition: 'success',
+      jobId: JOB_ID,
+    }
+  );
+
+  // polling stopped
+  await advancePolls(3);
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(1);
+});
+
+test('reports the diagnostic message when the job fails', async () => {
+  queryJobStatusMock.mockResolvedValue(
+    ok({ outcome: 'failed', reason: 'Unable to send data to printer.' })
+  );
+  start();
+
+  await advancePolls();
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: 'Unable to send data to printer.',
+  });
+  expect(logger.log).toHaveBeenLastCalledWith(
+    LogEventId.PrinterPrintComplete,
+    'system',
+    {
+      message: 'CUPS did not send the print job to the printer.',
+      disposition: 'failure',
+      jobId: JOB_ID,
+      reason: 'Unable to send data to printer.',
+    }
+  );
+});
+
+test('fails immediately when CUPS has no record of the job', async () => {
+  queryJobStatusMock.mockResolvedValue(
+    err({ type: 'unknown-job', message: 'CUPS did not return job 42' })
+  );
+  start();
+
+  await advancePolls();
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: `CUPS has no record of print job ${JOB_ID}.`,
+  });
+});
+
+test('retries a failed query and recovers', async () => {
+  queryJobStatusMock
+    .mockResolvedValueOnce(err({ type: 'query-failed', message: 'boom' }))
+    .mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  start();
+
+  await advancePolls();
+  expect(status).toEqual({ outcome: 'in-progress' });
+
+  await advancePolls();
+  expect(status).toEqual({ outcome: 'sent-to-printer' });
+});
+
+test('fails after consecutive query failures', async () => {
+  queryJobStatusMock.mockResolvedValue(
+    err({ type: 'query-failed', message: 'connection refused' })
+  );
+  start();
+
+  await advancePolls(MAX_CONSECUTIVE_QUERY_FAILURES - 1);
+  expect(status).toEqual({ outcome: 'in-progress' });
+
+  await advancePolls();
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: 'Unable to reach CUPS for print job status: connection refused',
+  });
+});
+
+test('resets the failure count after a successful query', async () => {
+  queryJobStatusMock
+    .mockResolvedValueOnce(err({ type: 'query-failed', message: 'boom' }))
+    .mockResolvedValueOnce(err({ type: 'query-failed', message: 'boom' }))
+    .mockResolvedValueOnce(ok({ outcome: 'in-progress' }))
+    .mockResolvedValue(err({ type: 'query-failed', message: 'boom' }));
+  start();
+
+  // two failures, then a success, then two more failures: never three in a row
+  await advancePolls(5);
+  expect(status).toEqual({ outcome: 'in-progress' });
+});
+
+test('treats an unparseable response as a failed query', async () => {
+  queryJobStatusMock.mockRejectedValue(new Error('Unable to parse ipptool'));
+  start();
+
+  await advancePolls(MAX_CONSECUTIVE_QUERY_FAILURES);
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason:
+      'Unable to reach CUPS for print job status: Unable to parse ipptool',
+  });
+});
+
+test('an unparseable response after the timeout is ignored', async () => {
+  const query = deferred<Awaited<ReturnType<typeof queryJobStatus>>>();
+  queryJobStatusMock.mockReturnValue(query.promise);
+  start();
+
+  await advancePolls();
+  await vi.advanceTimersByTimeAsync(JOB_TIMEOUT_MS);
+
+  query.reject(new Error('Unable to parse ipptool'));
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: `Print job did not reach a terminal state within ${JOB_TIMEOUT_MS}ms.`,
+  });
+  expect(logger.log).toHaveBeenCalledTimes(1);
+});
+
+test('fails the job if it never reaches a terminal state', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'in-progress' }));
+  start();
+
+  await vi.advanceTimersByTimeAsync(JOB_TIMEOUT_MS);
+
+  expect(status).toEqual({
+    outcome: 'failed',
+    reason: `Print job did not reach a terminal state within ${JOB_TIMEOUT_MS}ms.`,
+  });
+  expect(logger.log).toHaveBeenCalledTimes(1);
+});
+
+test('a query that resolves after the timeout does not overwrite the outcome', async () => {
+  const query = deferred<Awaited<ReturnType<typeof queryJobStatus>>>();
+  queryJobStatusMock.mockReturnValue(query.promise);
+  start();
+
+  // start a poll, then let the timeout fire while it is still in flight
+  await advancePolls();
+  await vi.advanceTimersByTimeAsync(JOB_TIMEOUT_MS);
+  expect(status?.outcome).toEqual('failed');
+
+  query.resolve(ok({ outcome: 'sent-to-printer' }));
+  await vi.advanceTimersByTimeAsync(0);
+
+  expect(status?.outcome).toEqual('failed');
+  expect(logger.log).toHaveBeenCalledTimes(1);
+});
+
+test('a query slower than the poll interval does not run concurrently', async () => {
+  const query = deferred<Awaited<ReturnType<typeof queryJobStatus>>>();
+  queryJobStatusMock.mockReturnValue(query.promise);
+  start();
+
+  await advancePolls(3);
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(1);
+
+  query.resolve(ok({ outcome: 'in-progress' }));
+  await vi.advanceTimersByTimeAsync(0);
+
+  await advancePolls();
+  expect(queryJobStatusMock).toHaveBeenCalledTimes(2);
+});
+
+test('forgets the job after the retention window', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  start();
+
+  await advancePolls();
+  expect(clearStatus).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(TERMINAL_STATUS_RETENTION_MS - 1);
+  expect(clearStatus).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(1);
+  expect(clearStatus).toHaveBeenCalled();
+});
+
+test('stop() halts polling without recording an outcome', async () => {
+  queryJobStatusMock.mockResolvedValue(ok({ outcome: 'sent-to-printer' }));
+  const monitor = start();
+
+  monitor.stop();
+  await advancePolls(3);
+
+  expect(queryJobStatusMock).not.toHaveBeenCalled();
+  expect(status).toEqual({ outcome: 'in-progress' });
+  expect(logger.log).not.toHaveBeenCalled();
+});

--- a/libs/printing/src/printer/job_monitor.ts
+++ b/libs/printing/src/printer/job_monitor.ts
@@ -1,0 +1,172 @@
+import { BaseLogger, LogEventId } from '@votingworks/logging';
+import { PrintJobId, PrintJobStatus } from '@votingworks/types';
+import { extractErrorMessage } from '@votingworks/basics';
+import { rootDebug } from '../utils/debug';
+import { queryJobStatus } from './job_status';
+
+const debug = rootDebug.extend('job-monitor');
+
+/**
+ * How often to ask CUPS about a job.
+ */
+export const JOB_POLL_INTERVAL_MS = 500;
+
+/**
+ * How long a job may go without reaching a terminal state before we give up on
+ * it. This is a failsafe in case a job hangs and CUPS never reports it failed.
+ *
+ * Note that because jobs reach a terminal state after CUPS transmits the job
+ * and its data to the printer, the timeout is not concerned with how long the
+ * actual job takes. 2 minutes is not always enough time to physically complete
+ * the print job, but should be plenty to transmit the job.
+ */
+export const JOB_TIMEOUT_MS = 2 * 60 * 1000;
+
+/**
+ * How long a job's terminal status stays readable after the job finishes, so a
+ * caller polling for the result still observes it before the entry is dropped.
+ */
+export const TERMINAL_STATUS_RETENTION_MS = 5 * 60 * 1000;
+
+/**
+ * How many consecutive failed queries mean CUPS is permanently, rather than
+ * momentarily, intermittently unavailable.
+ * See {@link getConnectedDeviceUris} for details about why CUPS may be
+ * momentarily unavailable.
+ */
+export const MAX_CONSECUTIVE_QUERY_FAILURES = 3;
+
+export interface PrintJobMonitorContext {
+  jobId: PrintJobId;
+  setStatus: (status: PrintJobStatus) => void;
+  clearStatus: () => void;
+  logger: BaseLogger;
+}
+
+/**
+ * Watches a single CUPS print job until it reaches a terminal outcome,
+ * reporting status through `setStatus` and logging the result.
+ *
+ * `setStatus` is called synchronously before polling begins, so a caller that
+ * reads status immediately after submitting a job sees `in-progress` rather
+ * than nothing. `clearStatus` is called once the retention window elapses.
+ */
+export function startPrintJobMonitor({
+  jobId,
+  setStatus,
+  clearStatus,
+  logger,
+}: PrintJobMonitorContext): { stop(): void } {
+  setStatus({ outcome: 'in-progress' });
+
+  let finished = false;
+  let isPolling = false;
+  let consecutiveQueryFailures = 0;
+  let pollTimer: NodeJS.Timeout;
+  let timeoutTimer: NodeJS.Timeout;
+
+  function stopTimers(): void {
+    finished = true;
+    clearInterval(pollTimer);
+    clearTimeout(timeoutTimer);
+  }
+
+  function finish(status: PrintJobStatus): void {
+    // @coverage-exclude: defensive. Every caller already checks `finished`.
+    if (finished) {
+      return;
+    }
+    stopTimers();
+
+    debug('job %d finished: %o', jobId, status);
+    setStatus(status);
+    logger.log(LogEventId.PrinterPrintComplete, 'system', {
+      message:
+        status.outcome === 'sent-to-printer'
+          ? 'CUPS finished sending the print job to the printer.'
+          : 'CUPS did not send the print job to the printer.',
+      disposition: status.outcome === 'sent-to-printer' ? 'success' : 'failure',
+      jobId,
+      reason: status.reason,
+    });
+
+    setTimeout(clearStatus, TERMINAL_STATUS_RETENTION_MS);
+  }
+
+  function onQueryFailure(message: string): void {
+    consecutiveQueryFailures += 1;
+    debug(
+      'job %d query failed (%d/%d): %s',
+      jobId,
+      consecutiveQueryFailures,
+      MAX_CONSECUTIVE_QUERY_FAILURES,
+      message
+    );
+    if (consecutiveQueryFailures >= MAX_CONSECUTIVE_QUERY_FAILURES) {
+      finish({
+        outcome: 'failed',
+        reason: `Unable to reach CUPS for print job status: ${message}`,
+      });
+    }
+  }
+
+  async function poll(): Promise<void> {
+    if (finished || isPolling) {
+      return;
+    }
+    isPolling = true;
+
+    try {
+      const result = await queryJobStatus(jobId);
+
+      // The timeout may have fired while the query was in flight, in which case
+      // the job already has a terminal status that must not be overwritten.
+      if (finished) {
+        return;
+      }
+
+      if (result.isErr()) {
+        const error = result.err();
+        if (error.type === 'unknown-job') {
+          finish({
+            outcome: 'failed',
+            reason: `CUPS has no record of print job ${jobId}.`,
+          });
+          return;
+        }
+        onQueryFailure(error.message);
+        return;
+      }
+
+      consecutiveQueryFailures = 0;
+      const status = result.ok();
+      if (status.outcome === 'in-progress') {
+        setStatus(status);
+        return;
+      }
+
+      finish(status);
+    } catch (error) {
+      if (!finished) {
+        onQueryFailure(extractErrorMessage(error));
+      }
+    } finally {
+      isPolling = false;
+    }
+  }
+
+  pollTimer = setInterval(() => {
+    void poll();
+  }, JOB_POLL_INTERVAL_MS);
+
+  timeoutTimer = setTimeout(() => {
+    finish({
+      outcome: 'failed',
+      reason: `Print job did not reach a terminal state within ${JOB_TIMEOUT_MS}ms.`,
+    });
+  }, JOB_TIMEOUT_MS);
+
+  return {
+    stop: stopTimers,
+  };
+}

--- a/libs/printing/src/printer/job_monitor.ts
+++ b/libs/printing/src/printer/job_monitor.ts
@@ -1,8 +1,8 @@
 import { BaseLogger, LogEventId } from '@votingworks/logging';
 import { PrintJobId, PrintJobStatus } from '@votingworks/types';
 import { extractErrorMessage } from '@votingworks/basics';
-import { rootDebug } from '../utils/debug';
-import { queryJobStatus } from './job_status';
+import { rootDebug } from '../utils/debug.js';
+import { queryJobStatus } from './job_status.js';
 
 const debug = rootDebug.extend('job-monitor');
 


### PR DESCRIPTION
## Overview

Relates to https://github.com/votingworks/vxsuite/issues/9186

See the complete spec in https://github.com/votingworks/vxsuite/pull/9241

Adds a monitor to monitor the status of a single print job. Builds on the query tooling added in https://github.com/votingworks/vxsuite/pull/9307.

## Demo Video or Screenshot

N/A; lib changes only

## Testing Plan

Added unit tests

## Checklist
All N/A

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
