### PR TITLE
VxAdmin: Stop parsing mark scores during tabulation

### DIFF
--- a/apps/admin/backend/src/store.ts
+++ b/apps/admin/backend/src/store.ts
@@ -2055,15 +2055,6 @@ export class Store implements BaseStore {
     return { ...votes, ...adjudicatedVotes };
   }
 
-  private parseMarkScores({
-    markScoresString,
-  }: {
-    markScoresString: string;
-  }): Tabulation.MarkScores {
-    const markScores = JSON.parse(markScoresString) as Tabulation.MarkScores;
-    return markScores;
-  }
-
   /**
    * Returns an iterator of cast vote records for tabulation purposes. Filters
    * the cast vote records by specified filters.
@@ -2097,8 +2088,7 @@ export class Store implements BaseStore {
           cvrs.card_type as cardType,
           cvrs.sheet_number as sheetNumber,
           cvrs.votes as votes,
-          cvrs.adjudicated_votes as adjudicatedVotes,
-          cvrs.mark_scores as markScores
+          cvrs.adjudicated_votes as adjudicatedVotes
         from cvrs
         inner join scanner_batches on cvrs.batch_id = scanner_batches.id
         inner join ballot_styles on
@@ -2114,7 +2104,6 @@ export class Store implements BaseStore {
         sheetNumber: number | null;
         votes: string;
         adjudicatedVotes: string | null;
-        markScores: string;
       }
     >) {
       const votes = this.applyAdjudicatedVotes({
@@ -2133,9 +2122,6 @@ export class Store implements BaseStore {
         precinctId: row.precinctId,
         card: this.convertSheetNumberToCard(row.cardType, row.sheetNumber),
         votes,
-        markScores: this.parseMarkScores({
-          markScoresString: row.markScores,
-        }),
       };
     }
   }


### PR DESCRIPTION
## Overview

`Store.getCastVoteRecords` is consumed only by tabulation, and no tabulation
code reads `markScores` (adjudication uses a separate query). Every CVR was
paying a 2–6 KB `JSON.parse` plus the SQLite overflow-page reads for a field
that was immediately dropped. This PR removes `mark_scores` from that SELECT
and from the yielded object. Output is identical.

Found while looking for "easy win" perf work of the same shape as the
thermal-printer and paper-handler conversion rewrites (#9303, #9306). Related
to the scale testing in #9063. A follow-up PR will address the per-write-in
query in write-in tabulation, which is the other large cost on this path.

### Benchmark

Real `Store` (in-memory SQLite) + `tabulateElectionResults`, NH test-ballot
fixture, 50k HMPB CVRs (2 KB mark scores each), 13.3k write-ins, grouped by
precinct × voting method, `includeWriteInAdjudicationResults`. Dev VM (arm64,
3 vCPU), baseline and branch built and run back to back; results hash
identical before/after.

| Path | Before | After |
|---|---|---|
| iterate `getCastVoteRecords` (all rows) | ~605 ms | ~290 ms |
| `tabulateCastVoteRecords` (unmemoized, grouped) | ~785 ms | ~465 ms |
| `tabulateElectionResults`, cache miss | 1721 ms | 1284 ms |
| `tabulateElectionResults`, cache hit | ~980 ms | ~830 ms |

The CVR pass is memoized by CVR data version, so the cache-miss row is what an
import, an adjudication, or a new filter/group combination pays. The remaining
cache-hit cost is the unmemoized write-in pass (follow-up PR).

## Demo Video or Screenshot

N/A (no UI change).

## Testing Plan

- Existing admin backend suite passes with coverage (`CI=true pnpm test:run`,
  coverage-check 0 uncovered).
- Before/after results hash from the benchmark above is identical.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
