### PR TITLE
hmpb: Stop waiting for a repaint on every setContent

### DIFF
--- a/libs/hmpb/src/renderer.tsx
+++ b/libs/hmpb/src/renderer.tsx
@@ -59,19 +59,11 @@ export function createDocument(pageHandle: PageHandle) {
 
           node.innerHTML = content;
 
-          // After we set the innerHTML, we need to wait for the DOM to finish
-          // updating with the new content.
-
-          // requestAnimationFrame will call the supplied callback before the
-          // next repaint, so we call it twice to wait for exactly one repaint
-          // to occur.
-          const repaintPromise = new Promise<void>((resolve) => {
-            requestAnimationFrame(() => {
-              requestAnimationFrame(() => {
-                resolve();
-              });
-            });
-          });
+          // Reading layout forces a synchronous reflow of the new content,
+          // which is all getBoundingClientRect and page.pdf need. Waiting for
+          // a repaint via requestAnimationFrame only added idle frames.
+          node.getBoundingClientRect();
+          const fontsPromise = document.fonts.ready;
           // We also wait for all images to load.
           const imagesLoadPromise = Promise.all(
             Array.from(node.querySelectorAll('img')).map((img) => {
@@ -85,7 +77,7 @@ export function createDocument(pageHandle: PageHandle) {
             })
           );
 
-          return Promise.all([repaintPromise, imagesLoadPromise]);
+          return Promise.all([fontsPromise, imagesLoadPromise]);
         },
         [selector, htmlContent]
       );


### PR DESCRIPTION
## Overview

`setContent` awaited two `requestAnimationFrame`s after every DOM write, a fixed 16–33 ms of idle per call in headless Chromium. Layout is forced synchronously by `getBoundingClientRect`, and `page.pdf` doesn't need a paint, so the wait only added idle frames. Fonts are still awaited via `document.fonts.ready`, images via their load events.

Both render passes go through `setContent` (layout measures through it; the PDF pass inserts the QR code and hash through it). Measured with `layOutBallotsAndCreateElectionDefinition` / `renderAllBallotPdfsAndCreateElectionDefinition` on a 24-ballot, 116-page, 4-language legal-size election, default pool (3 workers on a 3-vCPU dev VM):

| | Before | After |
|---|---|---|
| Layout pass | 5.6 s (49 ms/page) | 4.5 s (39 ms/page) |
| PDF pass | 3.8 s (33 ms/page) | 1.5 s (13 ms/page) |
| Layout + PDF | 9.5 s | 6.0 s |
| `pnpm generate-fixtures` (all 145 files, incl. build + rasterization) | 89 s | 65 s |

Extrapolated per page to a 6,400-ballot, 4-sheet election (51,200 pages) on the same 3-worker machine: PDF pass ~28 min → ~11 min; layout ~41 min → ~33 min.

## Testing Plan

- `pnpm generate-fixtures` before and after: 0 of 145 files differ (sha256).
- `CI=true pnpm test:run` in `libs/hmpb`: 26 files / 172 tests, coverage-check 0 uncovered.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
