### PR TITLE
refactor(basics): support arbitrary typed chunk sizes

### DIFF
--- a/libs/basics/src/iterators/async_iterator_plus.ts
+++ b/libs/basics/src/iterators/async_iterator_plus.ts
@@ -1,6 +1,12 @@
 import { assert } from '../assert';
 import { MaybePromise, Optional } from '../types';
-import { AsyncIteratorPlus, AsyncZipElements } from './types';
+import {
+  AsyncIteratorPlus,
+  AsyncZipElements,
+  Chunk,
+  ExactChunk,
+  Window,
+} from './types';
 
 /**
  * A wrapper around {@link AsyncIterable} that provides additional methods.
@@ -58,14 +64,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     );
   }
 
-  chunks(groupSize: 1): AsyncIteratorPlus<[T]>;
-  chunks(groupSize: 2): AsyncIteratorPlus<[T] | [T, T]>;
-  chunks(groupSize: 3): AsyncIteratorPlus<[T] | [T, T] | [T, T, T]>;
-  chunks(
-    groupSize: 4
-  ): AsyncIteratorPlus<[T] | [T, T] | [T, T, T] | [T, T, T, T]>;
-  chunks(groupSize: number): AsyncIteratorPlus<T[]>;
-  chunks(groupSize: number): AsyncIteratorPlus<T[]> {
+  chunks<N extends number>(groupSize: N): AsyncIteratorPlus<Chunk<N, T>> {
     assert(
       groupSize > 0 && Math.floor(groupSize) === groupSize,
       'groupSize must be an integer greater than 0'
@@ -74,8 +73,8 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     const iterator = iterable[Symbol.asyncIterator]();
     let group: T[] = [];
 
-    const result: AsyncIterableIterator<T[]> = {
-      [Symbol.asyncIterator](): AsyncIterableIterator<T[]> {
+    const result: AsyncIterableIterator<Chunk<N, T>> = {
+      [Symbol.asyncIterator](): AsyncIterableIterator<Chunk<N, T>> {
         return result;
       },
       async next() {
@@ -91,19 +90,16 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
         }
         const value = group;
         group = [];
-        return { value, done: false };
+        return { value: value as Chunk<N, T>, done: false };
       },
     };
 
     return new AsyncIteratorPlusImpl(result);
   }
 
-  chunksExact(chunkSize: 1): AsyncIteratorPlus<[T]>;
-  chunksExact(chunkSize: 2): AsyncIteratorPlus<[T, T]>;
-  chunksExact(chunkSize: 3): AsyncIteratorPlus<[T, T, T]>;
-  chunksExact(chunkSize: 4): AsyncIteratorPlus<[T, T, T, T]>;
-  chunksExact(chunkSize: number): AsyncIteratorPlus<T[]>;
-  chunksExact(chunkSize: number): AsyncIteratorPlus<T[]> {
+  chunksExact<N extends number>(
+    chunkSize: N
+  ): AsyncIteratorPlus<ExactChunk<N, T>> {
     assert(
       chunkSize > 0 && Math.floor(chunkSize) === chunkSize,
       'groupSize must be an integer greater than 0'
@@ -111,8 +107,8 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     const iterable = this.intoInner();
     const iterator = iterable[Symbol.asyncIterator]();
 
-    const result: AsyncIterableIterator<T[]> = {
-      [Symbol.asyncIterator](): AsyncIterableIterator<T[]> {
+    const result: AsyncIterableIterator<ExactChunk<N, T>> = {
+      [Symbol.asyncIterator](): AsyncIterableIterator<ExactChunk<N, T>> {
         return result;
       },
       async next() {
@@ -130,7 +126,7 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
         if (chunk.length !== chunkSize) {
           throw new Error('Chunk size is not a multiple of the iterator size');
         }
-        return { value: chunk, done: false };
+        return { value: chunk as ExactChunk<N, T>, done: false };
       },
     };
 
@@ -488,26 +484,19 @@ export class AsyncIteratorPlusImpl<T> implements AsyncIteratorPlus<T> {
     return this.join(separator);
   }
 
-  windows(groupSize: 0): never;
-  windows(groupSize: 1): AsyncIteratorPlus<[T]>;
-  windows(groupSize: 2): AsyncIteratorPlus<[T, T]>;
-  windows(groupSize: 3): AsyncIteratorPlus<[T, T, T]>;
-  windows(groupSize: 4): AsyncIteratorPlus<[T, T, T, T]>;
-  windows(groupSize: 5): AsyncIteratorPlus<[T, T, T, T, T]>;
-  windows(groupSize: number): AsyncIteratorPlus<T[]>;
-  windows(groupSize: number): AsyncIteratorPlus<T[]> {
+  windows<N extends number>(groupSize: N): AsyncIteratorPlus<Window<N, T>> {
     if (groupSize <= 0) {
       throw new Error('groupSize must be greater than 0');
     }
 
     const iterable = this.intoInner();
     return new AsyncIteratorPlusImpl(
-      (async function* gen(): AsyncIterableIterator<T[]> {
+      (async function* gen(): AsyncIterableIterator<Window<N, T>> {
         const window: T[] = [];
         for await (const value of iterable) {
           window.push(value);
           if (window.length === groupSize) {
-            yield window.slice();
+            yield window.slice() as Window<N, T>;
             window.shift();
           }
         }

--- a/libs/basics/src/iterators/iterator_plus.test.ts
+++ b/libs/basics/src/iterators/iterator_plus.test.ts
@@ -135,7 +135,7 @@ test('zip preserves arity of arbitrary length iterables', () => {
 });
 
 test('zip length mismatch', () => {
-  expect(() => iter([1]).zip([]).toArray()).toThrowError(
+  expect(() => iter([1]).zip([]).toArray()).toThrow(
     'not all iterables are the same length'
   );
 });
@@ -556,7 +556,7 @@ test('partition', () => {
 });
 
 test('windows', () => {
-  expect(() => iter([]).windows(0)).toThrowError();
+  expect(() => iter([]).windows(0)).toThrow();
   expect(iter([]).windows(2).toArray()).toEqual([]);
   expect(iter([1]).windows(2).toArray()).toEqual([]);
   expect(iter([1, 2]).windows(2).toArray()).toEqual([[1, 2]]);
@@ -614,9 +614,7 @@ test('reduce', () => {
 test('single ownership', () => {
   const it = iter([1, 2, 3]);
   expect(it.toArray()).toEqual([1, 2, 3]);
-  expect(() => it.toArray()).toThrowError(
-    'inner iterable has already been taken'
-  );
+  expect(() => it.toArray()).toThrow('inner iterable has already been taken');
 });
 
 test('cycle', () => {

--- a/libs/basics/src/iterators/iterator_plus.ts
+++ b/libs/basics/src/iterators/iterator_plus.ts
@@ -1,7 +1,14 @@
 import { assert } from '../assert';
 import { Optional } from '../types';
 import { AsyncIteratorPlusImpl } from './async_iterator_plus';
-import { AsyncIteratorPlus, IteratorPlus, ZipElements } from './types';
+import {
+  AsyncIteratorPlus,
+  IteratorPlus,
+  Chunk,
+  ExactChunk,
+  ZipElements,
+  Window,
+} from './types';
 
 /**
  * A wrapper around {@link Iterable} that provides additional methods.
@@ -70,12 +77,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     );
   }
 
-  chunks(groupSize: 1): IteratorPlus<[T]>;
-  chunks(groupSize: 2): IteratorPlus<[T] | [T, T]>;
-  chunks(groupSize: 3): IteratorPlus<[T] | [T, T] | [T, T, T]>;
-  chunks(groupSize: 4): IteratorPlus<[T] | [T, T] | [T, T, T] | [T, T, T, T]>;
-  chunks(groupSize: number): IteratorPlus<T[]>;
-  chunks(groupSize: number): IteratorPlus<T[]> {
+  chunks<N extends number>(groupSize: N): IteratorPlus<Chunk<N, T>> {
     assert(
       groupSize > 0 && Math.floor(groupSize) === groupSize,
       'groupSize must be an integer greater than 0'
@@ -83,8 +85,8 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     const iterable = this.intoInner();
     const iterator = iterable[Symbol.iterator]();
 
-    const result: IterableIterator<T[]> = {
-      [Symbol.iterator](): IterableIterator<T[]> {
+    const result: IterableIterator<Chunk<N, T>> = {
+      [Symbol.iterator](): IterableIterator<Chunk<N, T>> {
         return result;
       },
       next() {
@@ -99,19 +101,14 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
         if (group.length === 0) {
           return { value: undefined, done: true };
         }
-        return { value: group, done: false };
+        return { value: group as Chunk<N, T>, done: false };
       },
     };
 
     return new IteratorPlusImpl(result);
   }
 
-  chunksExact(chunkSize: 1): IteratorPlus<[T]>;
-  chunksExact(chunkSize: 2): IteratorPlus<[T, T]>;
-  chunksExact(chunkSize: 3): IteratorPlus<[T, T, T]>;
-  chunksExact(chunkSize: 4): IteratorPlus<[T, T, T, T]>;
-  chunksExact(chunkSize: number): IteratorPlus<T[]>;
-  chunksExact(chunkSize: number): IteratorPlus<T[]> {
+  chunksExact<N extends number>(chunkSize: N): IteratorPlus<ExactChunk<N, T>> {
     assert(
       chunkSize > 0 && Math.floor(chunkSize) === chunkSize,
       'groupSize must be an integer greater than 0'
@@ -119,8 +116,8 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     const iterable = this.intoInner();
     const iterator = iterable[Symbol.iterator]();
 
-    const result: IterableIterator<T[]> = {
-      [Symbol.iterator](): IterableIterator<T[]> {
+    const result: IterableIterator<ExactChunk<N, T>> = {
+      [Symbol.iterator](): IterableIterator<ExactChunk<N, T>> {
         return result;
       },
       next() {
@@ -138,7 +135,7 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
         if (chunk.length !== chunkSize) {
           throw new Error('Chunk size is not a multiple of the iterator size');
         }
-        return { value: chunk, done: false };
+        return { value: chunk as ExactChunk<N, T>, done: false };
       },
     };
 
@@ -474,26 +471,19 @@ export class IteratorPlusImpl<T> implements IteratorPlus<T>, AsyncIterable<T> {
     return this.join(separator);
   }
 
-  windows(groupSize: 0): never;
-  windows(groupSize: 1): IteratorPlus<[T]>;
-  windows(groupSize: 2): IteratorPlus<[T, T]>;
-  windows(groupSize: 3): IteratorPlus<[T, T, T]>;
-  windows(groupSize: 4): IteratorPlus<[T, T, T, T]>;
-  windows(groupSize: 5): IteratorPlus<[T, T, T, T, T]>;
-  windows(groupSize: number): IteratorPlus<T[]>;
-  windows(groupSize: number): IteratorPlus<T[]> {
+  windows<N extends number>(groupSize: N): IteratorPlus<Window<N, T>> {
     if (groupSize <= 0) {
       throw new Error('groupSize must be greater than 0');
     }
 
     const iterable = this.intoInner();
     return new IteratorPlusImpl(
-      (function* gen(): IterableIterator<T[]> {
+      (function* gen(): IterableIterator<Window<N, T>> {
         const window: T[] = [];
         for (const value of iterable) {
           window.push(value);
           if (window.length === groupSize) {
-            yield window.slice();
+            yield window.slice() as Window<N, T>;
             window.shift();
           }
         }

--- a/libs/basics/src/iterators/types.ts
+++ b/libs/basics/src/iterators/types.ts
@@ -25,6 +25,45 @@ export type AsyncZipElements<
 };
 
 /**
+ * Produces tuple types of an arbitrary number of elements.
+ */
+export type TupleOf<
+  N extends number,
+  T = undefined,
+  Acc extends T[] = [],
+> = Acc['length'] extends N ? Acc : TupleOf<N, T, [...Acc, T]>;
+
+/**
+ * Produces a union of tuple types up to an arbitrary number of elements.
+ */
+export type TupleUpTo<N extends number, T, Rest extends T[] = [T]> = N extends 0
+  ? []
+  : Rest | (Rest['length'] extends N ? never : TupleUpTo<N, T, [...Rest, T]>);
+
+/**
+ * `iter::chunks` return type based on chunk size.
+ */
+export type Chunk<N extends number, T> = number extends N
+  ? T[]
+  : TupleUpTo<N, T>;
+
+/**
+ * `iter::chunksExact` return type based on chunk size.
+ */
+export type ExactChunk<N extends number, T> = number extends N
+  ? T[]
+  : TupleOf<N, T>;
+
+/**
+ * `iter::windows` return type based on window size.
+ */
+export type Window<N extends number, T> = number extends N
+  ? T[]
+  : N extends 0
+  ? never
+  : TupleOf<N, T>;
+
+/**
  * An iterable with a number of convenience methods for chaining. Many methods are
  * lazy and return a new `IteratorPlus`, but some are eager and return a concrete
  * value.
@@ -47,109 +86,16 @@ export interface IteratorPlus<T> extends Iterable<T> {
   chain<U>(other: Iterable<U>): IteratorPlus<T | U>;
 
   /**
-   * Yields tuples of one element at a time.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(iter([1, 2, 3]).chunks(1).toArray()).toEqual([[1], [2], [3]]);
-   * ```
-   */
-  chunks(chunkSize: 1): IteratorPlus<[T]>;
-
-  /**
-   * Yields 2-element tuples, plus a 1-element tuple if there is a final
-   * element.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(iter([1, 2, 3]).chunks(2).toArray()).toEqual([[1, 2], [3]]);
-   * ```
-   */
-  chunks(chunkSize: 2): IteratorPlus<[T] | [T, T]>;
-
-  /**
-   * Yields 3-element tuples, plus a 1- or 2-element tuple if there are
-   * remaining elements.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(naturals().take(10).chunks(3).toArray()).toEqual([
-   *   [1, 2, 3],
-   *   [4, 5, 6],
-   *   [7, 8, 9],
-   *   [10],
-   * ]);
-   * ```
-   */
-  chunks(chunkSize: 3): IteratorPlus<[T] | [T, T] | [T, T, T]>;
-
-  /**
-   * Yields 4-element tuples, plus a 1-3-element tuple if there are remaining
-   * elements.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(naturals().take(10).chunks(4).toArray()).toEqual([
-   *   [1, 2, 3, 4],
-   *   [5, 6, 7, 8],
-   *   [9, 10],
-   * ]);
-   * ```
-   */
-  chunks(chunkSize: 4): IteratorPlus<[T] | [T, T] | [T, T, T] | [T, T, T, T]>;
-
-  /**
    * Yields arrays of {@link groupSize} elements, plus a smaller array if there
    * are remaining elements.
    */
-  chunks(chunkSize: number): IteratorPlus<T[]>;
-
-  /**
-   * Yields tuples of one element at a time.
-   */
-  chunksExact(chunkSize: 1): IteratorPlus<[T]>;
-
-  /**
-   * Yields 2-element tuples, throwing an error if the iterator has an odd
-   * number of elements.
-   *
-   * @example
-   *
-   * ```ts
-   * const pairs = iter([1, 2, 3, 4]).chunksExact(2);
-   * assert.deepStrictEqual([...pairs], [[1, 2], [3, 4]]);
-   * ```
-   */
-  chunksExact(chunkSize: 2): IteratorPlus<[T, T]>;
-
-  /**
-   * Yields 3-element tuples, throwing an error if the iterator has a number of
-   * elements that is not a multiple of 3.
-   *
-   * @example
-   *
-   * ```ts
-   * const triples = iter([1, 2, 3, 4, 5, 6]).chunksExact(3);
-   * assert.deepStrictEqual([...triples], [[1, 2, 3], [4, 5, 6]]);
-   * ```
-   */
-  chunksExact(chunkSize: 3): IteratorPlus<[T, T, T]>;
-
-  /**
-   * Yields 4-element tuples, throwing an error if the iterator has a number of
-   * elements that is not a multiple of 4.
-   */
-  chunksExact(chunkSize: 4): IteratorPlus<[T, T, T, T]>;
+  chunks<N extends number>(chunkSize: N): IteratorPlus<Chunk<N, T>>;
 
   /**
    * Yields arrays of {@link groupSize} elements, throwing an error if the iterator has a number of
    * elements that is not a multiple of {@link groupSize}.
    */
-  chunksExact(chunkSize: number): IteratorPlus<T[]>;
+  chunksExact<N extends number>(chunkSize: N): IteratorPlus<ExactChunk<N, T>>;
 
   /**
    * Counts the number of elements in `this`. Consumes the entire contained
@@ -614,72 +560,9 @@ export interface IteratorPlus<T> extends Iterable<T> {
   toString(separator?: string): string;
 
   /**
-   * Throws an error because `groupSize` must be greater than 0.
-   */
-  windows(groupSize: 0): never;
-
-  /**
-   * Yields elements from `this` as 1-element tuples.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(iter([1, 2, 3]).windows(1).toArray()).toEqual([[1], [2], [3]]);
-   * ```
-   */
-  windows(groupSize: 1): IteratorPlus<[T]>;
-
-  /**
-   * Yields tuples of two elements at a time.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(iter([1, 2, 3]).windows(2).toArray()).toEqual([[1, 2], [2, 3]]);
-   * ```
-   */
-  windows(groupSize: 2): IteratorPlus<[T, T]>;
-
-  /**
-   * Yields tuples of three elements at a time.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(iter([1, 2, 3]).windows(3).toArray()).toEqual([[1, 2, 3]]);
-   * expect(iter([1, 2, 3, 4]).windows(3).toArray()).toEqual([[1, 2, 3], [2, 3, 4]]);
-   * ```
-   */
-  windows(groupSize: 3): IteratorPlus<[T, T, T]>;
-
-  /**
-   * Yields tuples of four elements at a time.
-   *
-   * @example
-   *
-   * ```ts
-   * expect(iter([1, 2, 3]).windows(4).toArray()).toEqual([]);
-   * expect(
-   *   naturals()
-   *     .windows(4)
-   *     .take(2)
-   *     .toArray()
-   * ).toEqual([
-   *   [1, 2, 3, 4],
-   *   [2, 3, 4, 5]
-   * ]);
-   */
-  windows(groupSize: 4): IteratorPlus<[T, T, T, T]>;
-
-  /**
-   * Yields tuples of five elements at a time.
-   */
-  windows(groupSize: 5): IteratorPlus<[T, T, T, T, T]>;
-
-  /**
    * Yields tuples of elements at a time.
    */
-  windows(groupSize: number): IteratorPlus<T[]>;
+  windows<N extends number>(groupSize: N): IteratorPlus<Window<N, T>>;
 
   /**
    * Yields tuples pairing each element of `this` with the corresponding element
@@ -746,13 +629,8 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   chain<U>(other: AsyncIterable<U>): AsyncIteratorPlus<T | U>;
 
   /**
-   * Yields tuples of one element at a time.
-   */
-  chunks(chunkSize: 1): AsyncIteratorPlus<[T]>;
-
-  /**
-   * Yields 2-element tuples, plus a 1-element tuple if there is a final
-   * element.
+   * Yields arrays of {@link chunkSize} elements, plus a smaller array if there
+   * are remaining elements.
    *
    * @example
    *
@@ -763,74 +641,15 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * }
    * ```
    */
-  chunks(chunkSize: 2): AsyncIteratorPlus<[T] | [T, T]>;
-
-  /**
-   * Yields 3-element tuples, plus a 1- or 2-element tuple if there are
-   * remaining elements.
-   */
-  chunks(chunkSize: 3): AsyncIteratorPlus<[T] | [T, T] | [T, T, T]>;
-
-  /**
-   * Yields 4-element tuples, plus a 1-3-element tuple if there are remaining
-   * elements.
-   */
-  chunks(
-    groupSize: 4
-  ): AsyncIteratorPlus<[T] | [T, T] | [T, T, T] | [T, T, T, T]>;
-
-  /**
-   * Yields arrays of {@link groupSize} elements, plus a smaller array if there
-   * are remaining elements.
-   */
-  chunks(chunkSize: number): AsyncIteratorPlus<T[]>;
-
-  /**
-   * Yields tuples of one element at a time.
-   */
-  chunksExact(chunkSize: 1): AsyncIteratorPlus<[T]>;
-
-  /**
-   * Yields 2-element tuples, throwing an error if the iterator has an odd
-   * number of elements.
-   *
-   * @example
-   *
-   * ```ts
-   * const linePairs = lines(process.stdin).chunksExact(2);
-   * for await (const [first, second] of linePairs) {
-   *   …
-   * }
-   * ```
-   */
-  chunksExact(chunkSize: 2): AsyncIteratorPlus<[T, T]>;
-
-  /**
-   * Yields 3-element tuples, throwing an error if the iterator has a number of
-   * elements that is not a multiple of 3.
-   *
-   * @example
-   *
-   * ```ts
-   * const lineTriples = lines(process.stdin).chunksExact(3);
-   * for await (const [first, second, third] of lineTriples) {
-   *   …
-   * }
-   * ```
-   */
-  chunksExact(chunkSize: 3): AsyncIteratorPlus<[T, T, T]>;
-
-  /**
-   * Yields 4-element tuples, throwing an error if the iterator has a number of
-   * elements that is not a multiple of 4.
-   */
-  chunksExact(chunkSize: 4): AsyncIteratorPlus<[T, T, T, T]>;
+  chunks<N extends number>(chunkSize: N): AsyncIteratorPlus<Chunk<N, T>>;
 
   /**
    * Yields arrays of {@link groupSize} elements, throwing an error if the iterator has a number of
    * elements that is not a multiple of {@link groupSize}.
    */
-  chunksExact(chunkSize: number): AsyncIteratorPlus<T[]>;
+  chunksExact<N extends number>(
+    chunkSize: N
+  ): AsyncIteratorPlus<ExactChunk<N, T>>;
 
   /**
    * Counts the number of elements in `this`. Consumes the entire contained iterable.
@@ -1287,23 +1106,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
   toString(separator?: string): Promise<string>;
 
   /**
-   * Throws an error because `groupSize` must be greater than 0.
-   */
-  windows(groupSize: 0): never;
-
-  /**
-   * Yields elements from `this` as 1-element tuples.
-   *
-   * @example
-   *
-   * ```ts
-   * const linesAsTuples = await lines(process.stdin).windows(1).toArray();
-   * ```
-   */
-  windows(groupSize: 1): AsyncIteratorPlus<[T]>;
-
-  /**
-   * Yields tuples of two elements at a time.
+   * Yields tuples of {@link groupSize} elements at a time.
    *
    * @example
    *
@@ -1322,27 +1125,7 @@ export interface AsyncIteratorPlus<T> extends AsyncIterable<T> {
    * }
    * ```
    */
-  windows(groupSize: 2): AsyncIteratorPlus<[T, T]>;
-
-  /**
-   * Yields tuples of three elements at a time.
-   */
-  windows(groupSize: 3): AsyncIteratorPlus<[T, T, T]>;
-
-  /**
-   * Yields tuples of four elements at a time.
-   */
-  windows(groupSize: 4): AsyncIteratorPlus<[T, T, T, T]>;
-
-  /**
-   * Yields tuples of five elements at a time.
-   */
-  windows(groupSize: 5): AsyncIteratorPlus<[T, T, T, T, T]>;
-
-  /**
-   * Yields tuples of elements at a time.
-   */
-  windows(groupSize: number): AsyncIteratorPlus<T[]>;
+  windows<N extends number>(groupSize: N): AsyncIteratorPlus<Window<N, T>>;
 
   /**
    * Yields tuples pairing each element of `this` with the corresponding element


### PR DESCRIPTION
## Overview
Instead of hardcoding overloads for specific chunk sizes, use type helpers to build tuple types of the correct sizes. I'd previously hardcoded the maximum tuple size at 4, but now it scales as far as TypeScript will allow the recursion. Loosely follows up on #9188.

## Demo Video or Screenshot
```ts
Chunk<3, string>      // => [string, string, string] | [string, string] | [string]
ExactChunk<3, string> // => [string, string, string]

Chunk<number, string>      // => string[]
ExactChunk<number, string> // => string[]
```

## Testing Plan
Existing tests.