### PR TITLE
fix(admin): release the backup staging area lock even if its cleanup fails

### DIFF
--- a/apps/admin/backend/src/backup/staging_area.test.ts
+++ b/apps/admin/backend/src/backup/staging_area.test.ts
@@ -93,6 +93,23 @@ test('a lock that fails for any other reason is not reported as busy', async () 
   ).rejects.toThrow('ENOENT');
 });
 
+test('a staging area that cannot be cleaned up releases its lock', async () => {
+  const workspacePath = makeTemporaryDirectory();
+  const stagingArea = (
+    await BackupStagingArea.inWorkspace(workspacePath)
+  ).unsafeUnwrap();
+  const error: NodeJS.ErrnoException = new Error('input/output error');
+  error.code = 'EIO';
+  vi.mocked(rm).mockRejectedValueOnce(error);
+
+  await expect(stagingArea.cleanup()).rejects.toThrow('input/output error');
+
+  const lock = await tryLockFileExclusive(
+    BackupStagingArea.lockPathIn(workspacePath)
+  );
+  await lock.unsafeUnwrap().release();
+});
+
 test('a staging area that cannot be created releases its lock', async () => {
   const workspacePath = makeTemporaryDirectory();
   const error: NodeJS.ErrnoException = new Error('input/output error');

--- a/apps/admin/backend/src/backup/staging_area.ts
+++ b/apps/admin/backend/src/backup/staging_area.ts
@@ -215,9 +215,12 @@ export class BackupStagingArea {
    * to the staging area will be deleted.
    */
   async cleanup(): Promise<void> {
-    await rm(this.stagingAreaPath, { recursive: true, force: true });
-    this.preparedPaths.clear();
-    this.readyFiles.clear();
-    await this.lock.release();
+    try {
+      await rm(this.stagingAreaPath, { recursive: true, force: true });
+      this.preparedPaths.clear();
+      this.readyFiles.clear();
+    } finally {
+      await this.lock.release();
+    }
   }
 }


### PR DESCRIPTION
## Overview
`cleanup` removed the staging directory and only then released the lock, so a removal that failed skipped the release. The lock lives on an open descriptor and is held until the process exits, which would have refused every later backup until the machine restarted.

## Demo Video or Screenshot
n/a

## Testing Plan
New automated tests.