### PR TITLE
VxDesign: MS SEMS conversion: Handle duplicate district labels

### DIFF
--- a/apps/design/backend/src/convert_ms_election.test.ts
+++ b/apps/design/backend/src/convert_ms_election.test.ts
@@ -95,3 +95,27 @@ test('convert election with precinct splits', async () => {
   await expectValidElection(election);
   expect(election).toMatchSnapshot();
 });
+
+test('convert election with districts that share a label', async () => {
+  const election = convertMsElection(
+    'election-id-5',
+    readFixture('ms-sems-election-general-10.csv').replaceAll(
+      /Election Commissioner [0-9]+/g,
+      'Election Commissioner'
+    ),
+    readFixture('ms-sems-election-candidates-general-10.csv')
+  );
+  await expectValidElection(election);
+
+  const districtNames = election.districts.map((district) => district.name);
+  expect(districtNames).toEqual([
+    'United States',
+    'US House Of Representatives',
+    'Supreme Court Justice',
+    'Election Commissioner (575000501)',
+    'Election Commissioner (575000503)',
+    'Election Commissioner (575000505)',
+    'School Board District 3',
+    'School Board District 4',
+  ]);
+});

--- a/apps/design/backend/src/convert_ms_election.ts
+++ b/apps/design/backend/src/convert_ms_election.ts
@@ -162,10 +162,22 @@ export function convertMsElection(
   );
 
   // Section 2 is one row per district: 2, PARENT_DISTRICT, DISTRICT_ID, DISTRICT_LABEL
-  const districts: District[] = sectionRows(2).map((row) => {
+  const districtRows = sectionRows(2).map((row) => {
     const [, , id, label] = row;
-    return { id: uniqueId(id), name: label };
+    return { id, label };
   });
+  const duplicateLabels = new Set(
+    groupBy(districtRows, ({ label }) => label)
+      .filter(([, rows]) => rows.length > 1)
+      .map(([label]) => label)
+  );
+  const districts: District[] = districtRows.map(({ id, label }) => ({
+    id: uniqueId(id),
+    // SEMS allows duplicate district labels, but VxDesign requires district
+    // names within an election to be unique, so qualify duplicates with
+    // district IDs
+    name: duplicateLabels.has(label) ? `${label} (${id})` : label,
+  }));
 
   // Section 3 is one row per polling location: 3, REGION_ID, LOCATION_ID, LOCATION_LABEL
   // Skip it


### PR DESCRIPTION
## Overview

Our MS SEMS conversion logic currently assumes that SEMS districts will have unique labels. But recent files are proving that assumption wrong.

```
2, -1, 100000203, "Circuit Court Judge"
2, -1, 775000034, "Circuit Court Judge"
```

VxDesign district names within an election must be unique, so when converting from SEMS district labels to VxDesign district names, this PR now adds the SEMS district ID in the case of duplicates to disambiguate and not break the VxDesign uniqueness constraint.

```
Circuit Court Judge (100000203)
Circuit Court Judge (775000034)
```

These district names don't appear on bubble ballots, just VxMark and reports. For VxMark and reports, I think that these augmented district names are reasonable.

## Testing Plan

- [x] Added an automated test
- [x] Tested manually with the files that surfaced this issue

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] ~I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.~
- [ ] ~I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.~