### PR TITLE
fix(auth): guard against a card swap

### DIFF
--- a/libs/auth/src/dipped_smart_card_auth.test.ts
+++ b/libs/auth/src/dipped_smart_card_auth.test.ts
@@ -435,6 +435,54 @@ test.each<{
   }
 );
 
+test('Card swapped during PIN entry restarts auth for the card actually present', async () => {
+  const auth = new DippedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({
+    status: 'ready',
+    cardDetails: { user: systemAdministratorUser },
+  });
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'checking_pin',
+    user: systemAdministratorUser,
+  });
+
+  mockCardStatus({
+    status: 'ready',
+    cardDetails: { user: electionManagerUser },
+  });
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'logged_out',
+    reason: 'machine_locked',
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthPinEntry,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'User canceled PIN entry.',
+    }
+  );
+
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+  });
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(defaultMachineState, { pin });
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'remove_card',
+    user: electionManagerUser,
+    sessionExpiresAt: expect.any(Date),
+  });
+});
+
 test('Card lockout', async () => {
   const auth = new DippedSmartCardAuth({
     card: mockCard,

--- a/libs/auth/src/dipped_smart_card_auth.ts
+++ b/libs/auth/src/dipped_smart_card_auth.ts
@@ -537,7 +537,14 @@ export class DippedSmartCardAuth implements DippedSmartCardAuthApi {
           }
 
           case 'checking_pin': {
-            if (action.cardStatus.status === 'no_card') {
+            if (
+              action.cardStatus.status === 'no_card' ||
+              (action.cardStatus.status === 'ready' &&
+                !deepEqual(
+                  action.cardStatus.cardDetails.user,
+                  currentAuthStatus.user
+                ))
+            ) {
               return { status: 'logged_out', reason: 'machine_locked' };
             }
             return currentAuthStatus;

--- a/libs/auth/src/inserted_smart_card_auth.test.ts
+++ b/libs/auth/src/inserted_smart_card_auth.test.ts
@@ -427,6 +427,87 @@ test('Login and logout using card without PIN', async () => {
   );
 });
 
+test('Card swapped during PIN entry restarts auth for the card actually present', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+
+  mockCardStatus({
+    status: 'ready',
+    cardDetails: { user: systemAdministratorUser },
+  });
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'checking_pin',
+    user: systemAdministratorUser,
+  });
+
+  mockCardStatus({
+    status: 'ready',
+    cardDetails: { user: electionManagerUser },
+  });
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthPinEntry,
+    'system_administrator',
+    {
+      disposition: LogDispositionStandardTypes.Failure,
+      message: 'User canceled PIN entry.',
+    }
+  );
+
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'checking_pin',
+    user: electionManagerUser,
+  });
+  mockCard.checkPin.expectCallWith(pin).resolves({ response: 'correct' });
+  await auth.checkPin(defaultMachineState, { pin });
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'logged_in',
+    user: electionManagerUser,
+    sessionExpiresAt: expect.any(Date),
+  });
+});
+
+test('Card swapped while logged in logs the original user out', async () => {
+  const auth = new InsertedSmartCardAuth({
+    card: mockCard,
+    config: defaultConfig,
+    logger: mockLogger,
+  });
+  await logInAsElectionManager(auth);
+
+  mockCardStatus({
+    status: 'ready',
+    cardDetails: { user: systemAdministratorUser },
+  });
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'logged_out',
+    reason: 'no_card',
+  });
+  expect(mockLogger.log).toHaveBeenCalledTimes(1);
+  expect(mockLogger.log).toHaveBeenNthCalledWith(
+    1,
+    LogEventId.AuthLogout,
+    'election_manager',
+    {
+      disposition: LogDispositionStandardTypes.Success,
+      message: 'User logged out.',
+      reason: 'no_card',
+    }
+  );
+  expect(await auth.getAuthStatus(defaultMachineState)).toEqual({
+    status: 'checking_pin',
+    user: systemAdministratorUser,
+  });
+});
+
 test('Card lockout', async () => {
   const auth = new InsertedSmartCardAuth({
     card: mockCard,

--- a/libs/auth/src/inserted_smart_card_auth.ts
+++ b/libs/auth/src/inserted_smart_card_auth.ts
@@ -462,6 +462,8 @@ export class InsertedSmartCardAuth implements InsertedSmartCardAuthApi {
                     throwIllegalValue(user, 'role');
                   }
                 }
+              } else if (!deepEqual(currentAuthStatus.user, user)) {
+                return { status: 'logged_out', reason: 'no_card' };
               }
               return currentAuthStatus;
             }


### PR DESCRIPTION
## Overview
_(Flagged by Claude Fable 5.1 when I asked it to look for bugs. The tests were Claude-written, the fixes mine.)_

If a card with a given role was inserted and then somehow replaced with a different one during the PIN check flow, we could be tricked into taking the role of the _first_ card while validating the PIN on the _second_. The frequency at which we check card status makes this exceedingly unlikely, but the mitigation was cheap and the correctness worth the minor complexity increase.


## Testing Plan
New automated tests. Ran locally with mock cards.