### PR TITLE
Tag image data as `RgbaImageData` or `GrayImageData`

### DIFF
--- a/apps/central-scan/backend/package.json
+++ b/apps/central-scan/backend/package.json
@@ -51,7 +51,6 @@
     "@votingworks/ui": "workspace:*",
     "@votingworks/usb-drive": "workspace:*",
     "@votingworks/utils": "workspace:*",
-    "canvas": "3.2.3",
     "debug": "4.3.4",
     "express": "4.18.2",
     "fs-extra": "11.1.1",

--- a/apps/central-scan/backend/src/importer.test.ts
+++ b/apps/central-scan/backend/src/importer.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@votingworks/fixtures';
 import { deferred } from '@votingworks/basics';
 import { mockBaseLogger, mockLogger } from '@votingworks/logging';
-import { createImageData } from 'canvas';
+import { createImageData } from '@votingworks/image-utils';
 import { anyPollingPlace } from '@votingworks/types';
 import { Importer } from './importer.js';
 import { createWorkspace, Workspace } from './util/workspace.js';

--- a/apps/central-scan/backend/src/importer.ts
+++ b/apps/central-scan/backend/src/importer.ts
@@ -14,6 +14,7 @@ import {
   pollingPlaceFromElection,
   pollingPlacePrecinctIds,
   SheetOf,
+  RgbaImageData,
 } from '@votingworks/types';
 import makeDebug from 'debug';
 import * as fsExtra from 'fs-extra';
@@ -21,7 +22,6 @@ import { join } from 'node:path';
 import { randomUUID as uuid } from 'node:crypto';
 import { interpretSheetAndSaveImages } from '@votingworks/ballot-interpreter';
 import { LogEventId, Logger } from '@votingworks/logging';
-import { ImageData } from 'canvas';
 import { loadImageData } from '@votingworks/image-utils';
 import {
   BatchControl,
@@ -139,8 +139,8 @@ export class Importer {
 
   async importSheet(
     batchId: string,
-    frontInputImageData: ImageData,
-    backInputImageData: ImageData,
+    frontInputImageData: RgbaImageData,
+    backInputImageData: RgbaImageData,
     ballotAuditId?: string
   ): Promise<string> {
     let sheetId: string = uuid();
@@ -219,7 +219,7 @@ export class Importer {
   private async interpretSheet(
     electionDefinition: ElectionDefinition,
     sheetId: string,
-    [frontImageData, backImageData]: SheetOf<ImageData>
+    [frontImageData, backImageData]: SheetOf<RgbaImageData>
   ): Promise<SheetOf<PageInterpretationWithFiles>> {
     const { store } = this.workspace;
     const {

--- a/apps/mark-scan/backend/test/setup_custom_matchers.ts
+++ b/apps/mark-scan/backend/test/setup_custom_matchers.ts
@@ -1,11 +1,11 @@
 import { expect } from 'vitest';
 import {
-  ImageData,
   ToMatchImageOptions,
   ToMatchPdfSnapshotOptions,
   toMatchImage,
   buildToMatchPdfSnapshot,
 } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import { setGracefulCleanup } from 'tmp';
 
@@ -18,7 +18,7 @@ declare global {
     interface Matchers<R> {
       toMatchPdfSnapshot(options?: ToMatchPdfSnapshotOptions): Promise<R>;
       toMatchImage(
-        expected: ImageData,
+        expected: RgbaImageData,
         options?: ToMatchImageOptions
       ): Promise<R>;
     }

--- a/apps/scan/backend/src/app_export.test.ts
+++ b/apps/scan/backend/src/app_export.test.ts
@@ -31,7 +31,11 @@ import { decryptAes256 } from '@votingworks/auth';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { LogEventId } from '@votingworks/logging';
-import { scanBallot, withApp } from '../test/helpers/scanner_helpers.js';
+import {
+  scanBallot,
+  toGrayscaleSheet,
+  withApp,
+} from '../test/helpers/scanner_helpers.js';
 import {
   configureApp,
   pdfToImageSheet,
@@ -420,7 +424,7 @@ test('audit ballot IDs', async () => {
     );
   const ballotPdf = fs.readFileSync(ballotPaths[0]);
   await rendererPool.close();
-  const ballotImages = await pdfToImageSheet(ballotPdf);
+  const ballotImages = toGrayscaleSheet(await pdfToImageSheet(ballotPdf));
 
   await withApp(
     async ({

--- a/apps/scan/backend/src/app_polls_reports.test.ts
+++ b/apps/scan/backend/src/app_polls_reports.test.ts
@@ -36,6 +36,7 @@ import type { Store } from './store.js';
 import {
   POLLING_PLACE_ID_COMPETE_BMD,
   scanBallot,
+  toGrayscaleSheet,
   withApp,
 } from '../test/helpers/scanner_helpers.js';
 import { getScannerResults } from './util/results.js';
@@ -335,34 +336,38 @@ test('polls closed report shows correct sheet counts for multi-page BMD ballots'
       const ballotAuditId = 'test-multi-page-audit-id';
 
       // Render and scan page 1
-      const page1Images = await pdfToImageSheet(
-        await renderBmdBallotFixture({
-          electionDefinition,
-          ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
-          precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
-          votes: DEFAULT_FAMOUS_NAMES_VOTES,
-          pageNumber: 1,
-          totalPages: 2,
-          ballotAuditId,
-          contestIdsForPage: page1ContestIds,
-        })
+      const page1Images = toGrayscaleSheet(
+        await pdfToImageSheet(
+          await renderBmdBallotFixture({
+            electionDefinition,
+            ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
+            precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
+            votes: DEFAULT_FAMOUS_NAMES_VOTES,
+            pageNumber: 1,
+            totalPages: 2,
+            ballotAuditId,
+            contestIdsForPage: page1ContestIds,
+          })
+        )
       );
       await scanBallot(mockScanner, clock, apiClient, workspace.store, 0, {
         ballotImages: page1Images,
       });
 
       // Render and scan page 2
-      const page2Images = await pdfToImageSheet(
-        await renderBmdBallotFixture({
-          electionDefinition,
-          ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
-          precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
-          votes: DEFAULT_FAMOUS_NAMES_VOTES,
-          pageNumber: 2,
-          totalPages: 2,
-          ballotAuditId,
-          contestIdsForPage: page2ContestIds,
-        })
+      const page2Images = toGrayscaleSheet(
+        await pdfToImageSheet(
+          await renderBmdBallotFixture({
+            electionDefinition,
+            ballotStyleId: DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
+            precinctId: DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
+            votes: DEFAULT_FAMOUS_NAMES_VOTES,
+            pageNumber: 2,
+            totalPages: 2,
+            ballotAuditId,
+            contestIdsForPage: page2ContestIds,
+          })
+        )
       );
       await scanBallot(mockScanner, clock, apiClient, workspace.store, 1, {
         ballotImages: page2Images,

--- a/apps/scan/backend/src/app_scanning.test.ts
+++ b/apps/scan/backend/src/app_scanning.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import {
   POLLING_PLACE_ID_COMPLETE_HMPB,
   simulateScan,
+  toGrayscaleSheet,
   withApp,
 } from '../test/helpers/scanner_helpers.js';
 import { configureApp, waitForStatus } from '../test/helpers/shared_helpers.js';
@@ -35,27 +36,29 @@ beforeEach(() => {
 });
 
 test('scanBatch with streaked page', async () => {
-  const [frontImageData, backImageData] = asSheet(
-    await iter(
-      pdfToImages(
-        Uint8Array.from(await readFile(vxFamousNamesFixtures.markedBallotPath)),
-        { scale: 200 / 72 }
+  const [frontImageData, backImageData] = toGrayscaleSheet(
+    asSheet(
+      await iter(
+        pdfToImages(
+          Uint8Array.from(
+            await readFile(vxFamousNamesFixtures.markedBallotPath)
+          ),
+          { scale: 200 / 72 }
+        )
       )
+        .take(2)
+        .map(({ page }) => page)
+        .toArray()
     )
-      .map(({ page }) => page)
-      .toArray()
   );
 
   // add a vertical streak
   for (
-    let offset = 500;
+    let offset = 125;
     offset < frontImageData.data.length;
-    offset += frontImageData.width * 4
+    offset += frontImageData.width
   ) {
     frontImageData.data[offset] = 0;
-    frontImageData.data[offset + 1] = 0;
-    frontImageData.data[offset + 2] = 0;
-    frontImageData.data[offset + 3] = 255;
   }
 
   // try with vertical streak detection enabled

--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.test.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.test.ts
@@ -1,4 +1,5 @@
-import { createImageData } from 'canvas';
+import { createGrayImageData } from '@votingworks/image-utils';
+import { GrayImageData, SheetOf } from '@votingworks/types';
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 import {
   BooleanEnvironmentVariableName,
@@ -12,6 +13,10 @@ import {
 } from './print_and_scan_task.js';
 
 const mockFeatureFlagger = getFeatureFlagMock();
+
+function mockScanImages(): SheetOf<GrayImageData> {
+  return [createGrayImageData(1, 1), createGrayImageData(1, 1)];
+}
 
 vi.mock(import('@votingworks/utils'), async (importActual) => ({
   ...(await importActual()),
@@ -64,7 +69,7 @@ test.electrical(
 
     onScannerEvent({
       event: 'scanComplete',
-      images: [createImageData(1, 1), createImageData(1, 1)],
+      images: mockScanImages(),
     });
 
     // Wait long enough that we eject the paper.
@@ -135,7 +140,7 @@ test.electrical(
 
     onScannerEvent({
       event: 'scanComplete',
-      images: [createImageData(1, 1), createImageData(1, 1)],
+      images: mockScanImages(),
     });
 
     await vi.advanceTimersByTimeAsync(DELAY_AFTER_ACCEPT_MS);
@@ -168,7 +173,7 @@ test.electrical(
     // analysis try/catch path. The task should continue without crashing.
     onScannerEvent({
       event: 'scanComplete',
-      images: [createImageData(1, 1), createImageData(1, 1)],
+      images: mockScanImages(),
     });
 
     await vi.advanceTimersByTimeAsync(DELAY_AFTER_ACCEPT_MS);
@@ -208,7 +213,7 @@ test.electrical(
 
     onScannerEvent({
       event: 'scanComplete',
-      images: [createImageData(1, 1), createImageData(1, 1)],
+      images: mockScanImages(),
     });
 
     await vi.advanceTimersByTimeAsync(DELAY_AFTER_ACCEPT_MS);
@@ -239,7 +244,7 @@ test.electrical(
 
     onScannerEvent({
       event: 'scanComplete',
-      images: [createImageData(1, 1), createImageData(1, 1)],
+      images: mockScanImages(),
     });
 
     // Wait until the scanComplete handler is fully done before setting up the

--- a/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
+++ b/apps/scan/backend/src/electrical_testing/tasks/print_and_scan_task.ts
@@ -10,8 +10,8 @@ import {
 import { PAGE_DOTS_WIDTH } from '@votingworks/fujitsu-thermal-printer';
 import { LogEventId } from '@votingworks/logging';
 import { ScannerEvent } from '@votingworks/pdi-scanner';
-import { mapSheet, SheetOf } from '@votingworks/types';
-import { createCanvas, ImageData } from 'canvas';
+import { mapSheet, RgbaImageData, SheetOf } from '@votingworks/types';
+import { createCanvas } from 'canvas';
 import { DateTime } from 'luxon';
 import { mkdir, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -33,7 +33,7 @@ export const PRINT_INTERVAL_SECONDS = 5 * 60;
 export const DELAY_AFTER_ACCEPT_MS = 2_500;
 export const DELAY_AFTER_SCANNER_ERROR_MS = 5_000;
 
-function createPrinterTestImage(): ImageData {
+function createPrinterTestImage(): RgbaImageData {
   const canvas = createCanvas(PAGE_DOTS_WIDTH, 50);
   const ctx = canvas.getContext('2d');
 
@@ -44,7 +44,7 @@ function createPrinterTestImage(): ImageData {
   ctx.font = '20px Arial';
   ctx.fillText('Testing printer', 25, 25);
 
-  return ctx.getImageData(0, 0, canvas.width, canvas.height);
+  return ctx.getImageData(0, 0, canvas.width, canvas.height) as RgbaImageData;
 }
 
 export async function runPrintAndScanTask({

--- a/apps/scan/backend/src/interpret.test.ts
+++ b/apps/scan/backend/src/interpret.test.ts
@@ -6,7 +6,7 @@ import {
   renderBmdBallotFixture,
 } from '@votingworks/bmd-ballot-fixtures';
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
-import { ImageData, pdfToImages } from '@votingworks/image-utils';
+import { pdfToImages } from '@votingworks/image-utils';
 import {
   AdjudicationReason,
   DEFAULT_MARK_THRESHOLDS,
@@ -15,6 +15,7 @@ import {
   InterpretedHmpbPage,
   SheetOf,
   asSheet,
+  RgbaImageData,
 } from '@votingworks/types';
 import { assert } from 'node:console';
 import * as fs from 'node:fs/promises';
@@ -29,10 +30,10 @@ if (process.env.CI) {
 const { electionDefinition } = vxFamousNamesFixtures;
 
 let ballotImages: {
-  overvoteBallot: SheetOf<ImageData>;
-  normalBallot: SheetOf<ImageData>;
-  normalBmdBallot: SheetOf<ImageData>;
-  undervoteBmdBallot: SheetOf<ImageData>;
+  overvoteBallot: SheetOf<RgbaImageData>;
+  normalBallot: SheetOf<RgbaImageData>;
+  normalBmdBallot: SheetOf<RgbaImageData>;
+  undervoteBmdBallot: SheetOf<RgbaImageData>;
 };
 let ballotImagesPath!: string;
 

--- a/apps/scan/backend/src/interpret.ts
+++ b/apps/scan/backend/src/interpret.ts
@@ -6,11 +6,11 @@ import {
 import { ok, Result } from '@votingworks/basics';
 import {
   mapSheet,
+  ImageData,
   SheetInterpretationWithPages,
   SheetOf,
 } from '@votingworks/types';
 import { time } from '@votingworks/utils';
-import { ImageData } from 'canvas';
 import { rootDebug } from './util/debug.js';
 
 export async function interpret(

--- a/apps/scan/backend/src/scanner.ts
+++ b/apps/scan/backend/src/scanner.ts
@@ -27,6 +27,7 @@ import {
   pollingPlacePrecinctIds,
   pollingPlaceFromElection,
   Election,
+  GrayImageData,
 } from '@votingworks/types';
 import { UsbDrive } from '@votingworks/usb-drive';
 import { time, Timer } from '@votingworks/utils';
@@ -170,18 +171,14 @@ export function cleanLogData(key: string, value: unknown): unknown {
   if (value === undefined) {
     return 'undefined';
   }
+  // @coverage-exclude: should be unreachable due to `createImageData`'s
+  // `toJSON` override, but kept here just in case something sneaks through
   if (value instanceof ImageData) {
     return {
       width: value.width,
       height: value.height,
       data: value.data.length,
     };
-  }
-  // Grayscale scan images from the scanner client are plain objects, not
-  // `ImageData` instances, so catch their pixel buffers directly rather than
-  // serializing millions of bytes as JSON numbers.
-  if (value instanceof Uint8ClampedArray) {
-    return `[${value.length} bytes]`;
   }
   if (value instanceof Error) {
     return { ...value, message: value.message, stack: value.stack };
@@ -211,7 +208,7 @@ let scanAndInterpretTimer: Timer | undefined;
 
 async function interpretSheet(
   workspace: Workspace,
-  scanImages: SheetOf<ImageData>
+  scanImages: SheetOf<GrayImageData>
 ): Promise<InterpretationResult> {
   const sheetId = uuid();
   const { store } = workspace;
@@ -276,7 +273,7 @@ function anyFrontSensorCovered(status: ScannerStatus): boolean {
   );
 }
 
-async function runScannerDiagnostic(scanImages: SheetOf<ImageData>) {
+async function runScannerDiagnostic(scanImages: SheetOf<GrayImageData>) {
   const [frontPassed, backPassed] = await mapSheet(scanImages, (image) =>
     runBlankPaperDiagnosticFromImage(image)
   );
@@ -286,7 +283,7 @@ async function runScannerDiagnostic(scanImages: SheetOf<ImageData>) {
 export const RESET_COOLDOWN_MS = 30_000;
 
 interface Context {
-  scanImages?: SheetOf<ImageData>;
+  scanImages?: SheetOf<GrayImageData>;
   interpretation?: InterpretationResult;
   error?: ScannerError | PrecinctScannerError | Error;
   rootListenerRef?: ActorRef<Event>;

--- a/apps/scan/backend/src/util/write_in_report.test.ts
+++ b/apps/scan/backend/src/util/write_in_report.test.ts
@@ -11,7 +11,9 @@ import {
   BallotPageLayout,
   BallotStyleId,
   BallotType,
+  ImageData,
   PageInterpretationWithFiles,
+  RgbaImageData,
   SheetOf,
   TEST_JURISDICTION,
   VotesDict,
@@ -401,8 +403,13 @@ function addHmpbSheet(
 }
 
 test('extracts HMPB write-ins as image entries', async () => {
+  const mockImage: ImageData = {
+    width: 850,
+    height: 1100,
+    data: new Uint8ClampedArray(0),
+  };
   vi.mocked(loadImageData).mockResolvedValueOnce(
-    ok({ width: 850, height: 1100, data: new Uint8ClampedArray(0) })
+    ok(mockImage as RgbaImageData)
   );
 
   const store = createStore();

--- a/apps/scan/backend/test/helpers/scanner_helpers.ts
+++ b/apps/scan/backend/test/helpers/scanner_helpers.ts
@@ -21,7 +21,10 @@ import {
 } from '@votingworks/fujitsu-thermal-printer';
 import * as grout from '@votingworks/grout';
 import { vxFamousNamesFixtures } from '@votingworks/hmpb';
-import { ImageData, RGBA_CHANNEL_COUNT } from '@votingworks/image-utils';
+import {
+  createGrayImageData,
+  RGBA_CHANNEL_COUNT,
+} from '@votingworks/image-utils';
 import { Logger, mockBaseLogger } from '@votingworks/logging';
 import {
   Listener,
@@ -31,7 +34,12 @@ import {
   ScannerStatus,
   mockScannerStatus,
 } from '@votingworks/pdi-scanner';
-import { mapSheet, SheetOf } from '@votingworks/types';
+import {
+  GrayImageData,
+  mapSheet,
+  RgbaImageData,
+  SheetOf,
+} from '@votingworks/types';
 import { MockUsbDrive, createMockUsbDrive } from '@votingworks/usb-drive';
 import { Application } from 'express';
 import { readFile } from 'node:fs/promises';
@@ -114,7 +122,7 @@ export function createMockPdiScannerClient(): MockPdiScannerClient {
 export async function simulateScan(
   apiClient: grout.Client<Api>,
   mockScanner: MockPdiScannerClient,
-  images: SheetOf<ImageData>,
+  images: SheetOf<GrayImageData>,
   ballotsCounted = 0
 ): Promise<void> {
   mockScanner.emitEvent({ event: 'scanStart' });
@@ -228,15 +236,21 @@ export const POLLING_PLACE_ID_COMPETE_BMD =
  * the real PDI scanner client emits. See `libs/pdi-scanner/src/ts/scanner_client.ts`.
  * Assumes the RGBA image was actually expanded from a grayscale image originally.
  */
-function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
+function toGrayscaleImageData({
+  width,
+  height,
+  data,
+}: RgbaImageData): GrayImageData {
   const pixels = new Uint8ClampedArray(width * height);
   for (let i = 0; i < pixels.length; i += 1) {
     pixels[i] = data[i * RGBA_CHANNEL_COUNT];
   }
-  return { width, height, data: pixels };
+  return createGrayImageData(pixels, width, height);
 }
 
-function toGrayscaleSheet(sheet: SheetOf<ImageData>): SheetOf<ImageData> {
+export function toGrayscaleSheet(
+  sheet: SheetOf<RgbaImageData>
+): SheetOf<GrayImageData> {
   return mapSheet(sheet, toGrayscaleImageData);
 }
 
@@ -274,7 +288,12 @@ export const ballotImages = {
           Math.round((canvas.width - page.width) / 2),
           Math.round((canvas.height - page.height) / 2)
         );
-        return ctx.getImageData(0, 0, canvas.width, canvas.height);
+        return ctx.getImageData(
+          0,
+          0,
+          canvas.width,
+          canvas.height
+        ) as RgbaImageData;
       })
     );
   },
@@ -309,7 +328,7 @@ export const ballotImages = {
       await sampleBallotImages.blankPage.asImageData(),
       await sampleBallotImages.blankPage.asImageData(),
     ]),
-} satisfies Record<string, () => Promise<SheetOf<ImageData>>>;
+} satisfies Record<string, () => Promise<SheetOf<GrayImageData>>>;
 
 export async function scanBallot(
   mockScanner: MockPdiScannerClient,
@@ -319,7 +338,7 @@ export async function scanBallot(
   initialBallotsCounted: number,
   options: {
     waitForContinuousExportToUsbDrive?: boolean;
-    ballotImages?: SheetOf<ImageData>;
+    ballotImages?: SheetOf<GrayImageData>;
   } = {}
 ): Promise<void> {
   clock.increment(delays.DELAY_SCANNING_ENABLED_POLLING_INTERVAL);

--- a/apps/scan/backend/test/helpers/shared_helpers.ts
+++ b/apps/scan/backend/test/helpers/shared_helpers.ts
@@ -23,10 +23,11 @@ import {
   asSheet,
   constructElectionKey,
   pollingPlaceFromElection,
+  RgbaImageData,
 } from '@votingworks/types';
 import { MockUsbDrive } from '@votingworks/usb-drive';
 import { mockLogger, LogSource, MockLogger } from '@votingworks/logging';
-import { pdfToImages, ImageData } from '@votingworks/image-utils';
+import { pdfToImages } from '@votingworks/image-utils';
 
 import { Api } from '../../src/app.js';
 import {
@@ -175,7 +176,7 @@ export function createPrecinctScannerStateMachineMock(): Mocked<PrecinctScannerS
 export async function pdfToImageSheet(
   pdf: Uint8Array,
   { scale = 200 / 72 }: { scale?: number } = {}
-): Promise<SheetOf<ImageData>> {
+): Promise<SheetOf<RgbaImageData>> {
   return asSheet(
     await iter(pdfToImages(pdf, { scale }))
       .map(({ page }) => page)

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.test.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from 'vitest';
 import { join } from 'node:path';
-import { ImageData } from 'canvas';
-import { loadImageData, RGBA_CHANNEL_COUNT } from '@votingworks/image-utils';
+import { GrayImageData, RgbaImageData } from '@votingworks/types';
+import {
+  createGrayImageData,
+  loadImageData,
+  RGBA_CHANNEL_COUNT,
+} from '@votingworks/image-utils';
 import {
   runBlankPaperDiagnostic,
   runBlankPaperDiagnosticFromImage,
@@ -21,12 +25,16 @@ const streakedImagePath = join(
  * that scanner clients emit. Assumes the RGBA image was actually expanded from
  * a grayscale image originally.
  */
-function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
+function toGrayscaleImageData({
+  width,
+  height,
+  data,
+}: RgbaImageData): GrayImageData {
   const pixels = new Uint8ClampedArray(width * height);
   for (let i = 0; i < pixels.length; i += 1) {
     pixels[i] = data[i * RGBA_CHANNEL_COUNT] as number;
   }
-  return { width, height, data: pixels };
+  return createGrayImageData(pixels, width, height);
 }
 
 test('runBlankPaperDiagnostic can pass', async () => {

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/diagnostic.ts
@@ -1,4 +1,4 @@
-import { ImageData } from 'canvas';
+import { ImageData } from '@votingworks/types';
 import { napi } from './napi.js';
 
 /**

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/index.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/index.ts
@@ -1,4 +1,4 @@
-import { ImageData } from 'canvas';
+import { ImageData } from '@votingworks/types';
 import { napi } from './napi.js';
 import { TimingMarks } from './types.js';
 

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/interpret.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/interpret.ts
@@ -1,8 +1,8 @@
 import { assert, err, ok } from '@votingworks/basics';
 import { sliceBallotHashForEncoding } from '@votingworks/ballot-encoder';
-import { ImageData } from 'canvas';
 import {
   ElectionDefinition,
+  ImageData,
   SheetOf,
   DEFAULT_MAX_CUMULATIVE_STREAK_WIDTH,
   DEFAULT_RETRY_STREAK_WIDTH_THRESHOLD,

--- a/libs/ballot-interpreter/src/bubble-ballot-ts/scoring_report.ts
+++ b/libs/ballot-interpreter/src/bubble-ballot-ts/scoring_report.ts
@@ -2,15 +2,12 @@
 import { assert, unique } from '@votingworks/basics';
 import {
   ElectionDefinition,
+  RgbaImageData,
   SheetOf,
   safeParseElectionDefinition,
 } from '@votingworks/types';
 import { mkdir, readFile, readdir } from 'node:fs/promises';
-import {
-  ImageData,
-  loadImageData,
-  writeImageData,
-} from '@votingworks/image-utils';
+import { loadImageData, writeImageData } from '@votingworks/image-utils';
 import { basename, join } from 'node:path';
 import { CanvasRenderingContext2D, createCanvas } from 'canvas';
 import { fileSync } from 'tmp';
@@ -92,9 +89,9 @@ function fillTextWithBackground({
 
 function annotateBallotImageScores(
   scoreType: 'marks' | 'write-ins',
-  ballotImage: ImageData,
+  ballotImage: RgbaImageData,
   interpretation: InterpretedBallotPage
-): ImageData {
+): RgbaImageData {
   const canvas = createCanvas(ballotImage.width, ballotImage.height);
   const context = canvas.getContext('2d');
   context.imageSmoothingEnabled = false;
@@ -164,7 +161,12 @@ function annotateBallotImageScores(
     }
   }
 
-  return context.getImageData(0, 0, canvas.width, canvas.height);
+  return context.getImageData(
+    0,
+    0,
+    canvas.width,
+    canvas.height
+  ) as RgbaImageData;
 }
 
 async function generateScoringReport(

--- a/libs/ballot-interpreter/src/interpret.ts
+++ b/libs/ballot-interpreter/src/interpret.ts
@@ -39,6 +39,8 @@ import {
   VotesDict,
   WriteInAreaStatus,
   WriteInId,
+  ImageData,
+  RgbaImageData,
 } from '@votingworks/types';
 import {
   allContestOptions,
@@ -46,7 +48,6 @@ import {
   electionHasBallotPositions,
   time,
 } from '@votingworks/utils';
-import { ImageData } from 'canvas';
 import makeDebug from 'debug';
 import { join } from 'node:path';
 import {
@@ -600,7 +601,7 @@ async function interpretHmpb(
  * already RGBA, or converts from grayscale if needed. The summary ballot
  * interpreter assumes RGBA layout for pixel operations (crop, rotate, etc.).
  */
-function ensureRgba(image: ImageData): ImageData {
+function ensureRgba(image: ImageData): RgbaImageData {
   if (isRgba(image)) return image;
   // @coverage-defer
   return fromGrayScale(image.data, image.width, image.height);

--- a/libs/ballot-interpreter/src/interpret_blank_sheet.test.ts
+++ b/libs/ballot-interpreter/src/interpret_blank_sheet.test.ts
@@ -2,8 +2,11 @@ import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   sampleBallotImages,
 } from '@votingworks/fixtures';
-import { DEFAULT_MARK_THRESHOLDS, SheetOf } from '@votingworks/types';
-import { ImageData } from 'canvas';
+import {
+  DEFAULT_MARK_THRESHOLDS,
+  SheetOf,
+  RgbaImageData,
+} from '@votingworks/types';
 import { beforeEach, expect, test, vi } from 'vitest';
 import { interpretSheet } from './interpret.js';
 import { normalizeBallotMode } from './validation.js';
@@ -15,7 +18,7 @@ beforeEach(() => {
 });
 
 test('blank sheet of paper', async () => {
-  const sheet: SheetOf<ImageData> = [
+  const sheet: SheetOf<RgbaImageData> = [
     await sampleBallotImages.blankPage.asImageData(),
     await sampleBallotImages.blankPage.asImageData(),
   ];

--- a/libs/ballot-interpreter/src/interpret_summary_ballots.test.ts
+++ b/libs/ballot-interpreter/src/interpret_summary_ballots.test.ts
@@ -30,9 +30,10 @@ import {
   getBallotStyle,
   getContests,
   mapSheet,
+  RgbaImageData,
   vote,
 } from '@votingworks/types';
-import { createCanvas, ImageData } from 'canvas';
+import { createCanvas } from 'canvas';
 import { assert } from 'node:console';
 import { assertDefined, throwIllegalValue } from '@votingworks/basics';
 import { loadImageMetadata, toImageBuffer } from '@votingworks/image-utils';
@@ -58,7 +59,7 @@ describe('adjudication reporting', () => {
 
   async function renderBmdSummaryBallotPage(
     votes: VotesDict
-  ): Promise<ImageData> {
+  ): Promise<RgbaImageData> {
     const validBmdSheet = asSheet(
       await pdfToPageImages(
         await renderBmdBallotFixture({
@@ -344,9 +345,9 @@ describe('VX BMD interpretation', () => {
   const ballotStyleId: BallotStyleId = DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID;
   const precinctId: PrecinctId = DEFAULT_FAMOUS_NAMES_PRECINCT_ID;
 
-  let bmdSummaryBallotPage: ImageData;
-  let bmdBlankPage: ImageData;
-  let validBmdSheet: SheetOf<ImageData>;
+  let bmdSummaryBallotPage: RgbaImageData;
+  let bmdBlankPage: RgbaImageData;
+  let validBmdSheet: SheetOf<RgbaImageData>;
 
   beforeAll(async () => {
     validBmdSheet = asSheet(
@@ -459,7 +460,12 @@ describe('VX BMD interpretation', () => {
         context.fillStyle = 'black';
         context.fillRect(0, 0, canvas.width, canvas.height);
         context.putImageData(imageData, 25, 250);
-        return context.getImageData(0, 0, canvas.width, canvas.height);
+        return context.getImageData(
+          0,
+          0,
+          canvas.width,
+          canvas.height
+        ) as RgbaImageData;
       }
     );
 
@@ -594,7 +600,7 @@ describe('VX BMD interpretation', () => {
         0,
         canvas.width,
         canvas.height
-      );
+      ) as RgbaImageData;
 
       switch (rotation) {
         case 'inverted': {

--- a/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
+++ b/libs/ballot-interpreter/src/interpret_vx_bubble_ballot.test.ts
@@ -28,7 +28,7 @@ import {
   PageInterpretation,
   InterpretedHmpbPage,
   SheetOf,
-  ImageData,
+  RgbaImageData,
   BaseBallotProps,
   ElectionDefinition,
   getBallotStyle,
@@ -234,7 +234,12 @@ describe('HMPB - VX Famous Names', () => {
     context.fillStyle = 'black';
     // Make a giant vertical streak that will trigger the cumulative streak threshold
     context.fillRect(canvas.width / 2, 0, 6, canvas.height);
-    const streakImage = context.getImageData(0, 0, canvas.width, canvas.height);
+    const streakImage = context.getImageData(
+      0,
+      0,
+      canvas.width,
+      canvas.height
+    ) as RgbaImageData;
 
     const [frontResult, backResult] = await interpretSheet(
       {
@@ -257,7 +262,7 @@ describe('HMPB - VX Famous Names', () => {
 });
 
 function snapshotWriteInCrops(
-  sheetImages: SheetOf<ImageData>,
+  sheetImages: SheetOf<RgbaImageData>,
   sheetInterpretations: SheetOf<InterpretedHmpbPage>
 ) {
   for (const [pageImage, interpretation] of iter(sheetImages).zip(
@@ -300,7 +305,7 @@ function snapshotWriteInCrops(
 }
 
 function snapshotCandidateOptionCrops(
-  sheetImages: SheetOf<ImageData>,
+  sheetImages: SheetOf<RgbaImageData>,
   sheetInterpretations: SheetOf<InterpretedHmpbPage>
 ) {
   for (const [pageImage, interpretation] of iter(sheetImages).zip(
@@ -343,7 +348,7 @@ function snapshotCandidateOptionCrops(
 }
 
 function snapshotBallotMeasureCrops(
-  sheetImages: SheetOf<ImageData>,
+  sheetImages: SheetOf<RgbaImageData>,
   sheetInterpretations: SheetOf<InterpretedHmpbPage>
 ) {
   for (const [pageImage, interpretation] of iter(sheetImages).zip(

--- a/libs/ballot-interpreter/src/save_images.test.ts
+++ b/libs/ballot-interpreter/src/save_images.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
-import { createImageData, ImageData } from '@votingworks/image-utils';
-import { SheetOf } from '@votingworks/types';
+import { createImageData } from '@votingworks/image-utils';
+import { RgbaImageData, SheetOf } from '@votingworks/types';
 import { join } from 'node:path';
 import { tmpDir } from '../test/helpers/tmp.js';
 import { saveSheetImages } from './save_images.js';
@@ -8,7 +8,7 @@ import { saveSheetImages } from './save_images.js';
 test('saveSheetImages', async () => {
   const sheetId = 'sheetId';
   const ballotImagesPath = tmpDir();
-  const images: SheetOf<ImageData> = [
+  const images: SheetOf<RgbaImageData> = [
     createImageData(1, 1),
     createImageData(1, 1),
   ];

--- a/libs/ballot-interpreter/src/save_images.ts
+++ b/libs/ballot-interpreter/src/save_images.ts
@@ -1,5 +1,4 @@
-import { ImageData } from '@votingworks/image-utils';
-import { mapSheet, SheetOf } from '@votingworks/types';
+import { ImageData, mapSheet, SheetOf } from '@votingworks/types';
 import { time } from '@votingworks/utils';
 import makeDebug from 'debug';
 import { join } from 'node:path';

--- a/libs/ballot-interpreter/src/summary-ballot/image_utils.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/image_utils.ts
@@ -6,7 +6,7 @@
 
 import { Optional } from '@votingworks/basics';
 import { RGBA_CHANNEL_COUNT } from '@votingworks/image-utils';
-import { ImageData } from '@votingworks/types';
+import { RgbaImageData } from '@votingworks/types';
 
 export interface Inset {
   top: number;
@@ -35,7 +35,7 @@ export const CROP_BORDERS_THRESHOLD_RATIO: number = 0.1;
  * given threshold.
  */
 export function findScannedDocumentInset(
-  image: ImageData,
+  image: RgbaImageData,
   threshold: number
 ): Optional<Inset> {
   const { width, height } = image;

--- a/libs/ballot-interpreter/src/summary-ballot/interpret.test.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/interpret.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, expect, test } from 'vitest';
+import { createCanvas } from 'canvas';
 import { sliceBallotHashForEncoding } from '@votingworks/ballot-encoder';
 import { assert, err } from '@votingworks/basics';
 import {
@@ -6,23 +7,22 @@ import {
   electionGridLayoutNewHampshireTestBallotFixtures,
   sampleBallotImages,
 } from '@votingworks/fixtures';
-import { SheetOf, asSheet, vote } from '@votingworks/types';
+import { RgbaImageData, SheetOf, asSheet, vote } from '@votingworks/types';
 import {
   renderBmdBallotFixture,
   DEFAULT_FAMOUS_NAMES_BALLOT_STYLE_ID,
   DEFAULT_FAMOUS_NAMES_PRECINCT_ID,
   DEFAULT_FAMOUS_NAMES_VOTES,
 } from '@votingworks/bmd-ballot-fixtures';
-import { ImageData, createCanvas } from 'canvas';
+import { createImageData } from '@votingworks/image-utils';
 import { InterpretResult, interpret } from './interpret.js';
 import { pdfToPageImages } from '../../test/helpers/interpretation.js';
 
-let famousNamesBmdBallot: SheetOf<ImageData>;
-let famousNamesBmdBallotUpsideDown: SheetOf<ImageData>;
+let famousNamesBmdBallot: SheetOf<RgbaImageData>;
+let famousNamesBmdBallotUpsideDown: SheetOf<RgbaImageData>;
 
-function copyImageData(imageData: ImageData): ImageData {
-  // Create a new canvas element
-  const newImageData = new ImageData(imageData.width, imageData.height);
+function copyImageData(imageData: RgbaImageData): RgbaImageData {
+  const newImageData = createImageData(imageData.width, imageData.height);
   newImageData.data.set(imageData.data.slice());
   return newImageData;
 }
@@ -186,7 +186,7 @@ test('happy path: back, front upside down', async () => {
 });
 
 test('votes not found', async () => {
-  const card: SheetOf<ImageData> = [
+  const card: SheetOf<RgbaImageData> = [
     await sampleBallotImages.blankPage.asImageData(),
     await sampleBallotImages.blankPage.asImageData(),
   ];
@@ -204,7 +204,7 @@ test('votes not found', async () => {
 
 test('multiple QR codes', async () => {
   const [page1] = famousNamesBmdBallot;
-  const card: SheetOf<ImageData> = [page1, page1];
+  const card: SheetOf<RgbaImageData> = [page1, page1];
   const result = await interpret(
     electionFamousNames2021Fixtures.readElectionDefinition(),
     card

--- a/libs/ballot-interpreter/src/summary-ballot/interpret.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/interpret.ts
@@ -1,4 +1,3 @@
-import { ImageData } from 'canvas';
 import { Result, err, ok } from '@votingworks/basics';
 import {
   SummaryBallotPageMetadata,
@@ -6,6 +5,7 @@ import {
   SheetOf,
   VotesDict,
   mapSheet,
+  RgbaImageData,
 } from '@votingworks/types';
 import {
   BALLOT_HASH_ENCODING_LENGTH,
@@ -25,8 +25,8 @@ import { otsu } from './otsu.js';
 export interface Interpretation {
   metadata: SummaryBallotPageMetadata;
   votes: VotesDict;
-  summaryBallotImage: ImageData;
-  blankPageImage: ImageData;
+  summaryBallotImage: RgbaImageData;
+  blankPageImage: RgbaImageData;
 }
 
 export type InterpretError =
@@ -51,7 +51,7 @@ export type InterpretResult = Result<Interpretation, InterpretError>;
  */
 export async function interpret(
   electionDefinition: ElectionDefinition,
-  card: SheetOf<ImageData>
+  card: SheetOf<RgbaImageData>
 ): Promise<InterpretResult> {
   const croppedCard = mapSheet(card, (imageData) => {
     const threshold = otsu(imageData.data);

--- a/libs/ballot-interpreter/src/summary-ballot/utils/luminosity.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/luminosity.ts
@@ -1,6 +1,5 @@
-import { ImageData } from 'canvas';
 import { assertDefined } from '@votingworks/basics';
-import { Rect } from '@votingworks/types';
+import { ImageData, Rect } from '@votingworks/types';
 import makeDebug from 'debug';
 
 const debug = makeDebug('ballot-interpreter:bmd:luminosity');

--- a/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/qrcode.ts
@@ -1,8 +1,8 @@
 import { ScanOptions, scanGrayscale } from 'zedbar';
 import { decode as quircDecode, QRCode } from 'node-quirc';
 import { isVxBallot } from '@votingworks/ballot-encoder';
-import { ImageData, RGBA_CHANNEL_COUNT, crop } from '@votingworks/image-utils';
-import { Rect, Size } from '@votingworks/types';
+import { RGBA_CHANNEL_COUNT, crop } from '@votingworks/image-utils';
+import { Rect, RgbaImageData, Size } from '@votingworks/types';
 import { Buffer } from 'node:buffer';
 import makeDebug from 'debug';
 import { Optional, Result, err, ok, assertDefined } from '@votingworks/basics';
@@ -115,14 +115,14 @@ export function* getSearchAreas(
  * Detects QR codes in a ballot image.
  */
 export async function detect(
-  imageData: ImageData
+  imageData: RgbaImageData
 ): Promise<Optional<DetectedQrCode>> {
   debug('detect: checking %dˣ%d image', imageData.width, imageData.height);
 
   const detectors = [
     {
       name: 'zedbar',
-      detect: ({ data, width, height }: ImageData): Buffer[] => {
+      detect: ({ data, width, height }: RgbaImageData): Buffer[] => {
         const grayscale = rgbaToGrayscale(data, width, height);
         const options = new ScanOptions();
         options.symbologies = ['QR-Code'];
@@ -138,8 +138,10 @@ export async function detect(
     },
     {
       name: 'quirc',
-      detect: async (croppedImage: ImageData): Promise<Buffer[]> => {
-        const results = await quircDecode(croppedImage as globalThis.ImageData);
+      detect: async (croppedImage: RgbaImageData): Promise<Buffer[]> => {
+        const results = await quircDecode(
+          croppedImage as unknown as globalThis.ImageData
+        );
         return results
           .filter((result): result is QRCode => !('err' in result))
           .map((result) => result.data);
@@ -207,7 +209,7 @@ export type DetectQrCodeError = { type: 'blank-page' } | { type: 'no-qr-code' };
 export type QrCodePageResult = Result<DetectedQrCode, DetectQrCodeError>;
 
 export async function detectInBallot(
-  imageData: ImageData
+  imageData: RgbaImageData
 ): Promise<QrCodePageResult> {
   let foundDarkRegion = false;
   let darkestRegionStats: Stats | undefined;

--- a/libs/ballot-interpreter/src/summary-ballot/utils/rotate.test.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/rotate.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest';
 import { assert } from '@votingworks/basics';
 import { sampleBallotImages } from '@votingworks/fixtures';
-import { ImageData } from 'canvas';
+import { createImageData } from '@votingworks/image-utils';
 import { rotateImageData180 } from './rotate.js';
 
 test('can rotate real life ImageData as expected', async () => {
@@ -24,14 +24,14 @@ test('can rotate real life ImageData as expected', async () => {
 });
 
 test('can rotate simple ImageData as expected', () => {
-  const sampleImageData = new ImageData(2, 2);
+  const sampleImageData = createImageData(2, 2);
   // Make the first pixel red
   sampleImageData.data[0] = 255;
   sampleImageData.data[1] = 0;
   sampleImageData.data[2] = 0;
   sampleImageData.data[3] = 255;
 
-  const expectedRotatedImageData = new ImageData(2, 2);
+  const expectedRotatedImageData = createImageData(2, 2);
   // After a 180 degree rotation the first pixel should be the bottom right pixel
   // which corresponds to the data indexes beginning at 3*4 = 12
   expectedRotatedImageData.data[12] = 255;

--- a/libs/ballot-interpreter/src/summary-ballot/utils/rotate.ts
+++ b/libs/ballot-interpreter/src/summary-ballot/utils/rotate.ts
@@ -1,8 +1,8 @@
-import { ImageData } from 'canvas';
+import { RgbaImageData } from '@votingworks/types';
 /**
  * Rotate an image 180 degrees in place.
  */
-export function rotateImageData180(imageData: ImageData): void {
+export function rotateImageData180(imageData: RgbaImageData): void {
   const { data } = imageData;
   const channels = 4;
 

--- a/libs/ballot-interpreter/test/helpers/interpretation.ts
+++ b/libs/ballot-interpreter/test/helpers/interpretation.ts
@@ -5,10 +5,11 @@ import {
   unique,
 } from '@votingworks/basics';
 import { voteToOptionId } from '@votingworks/hmpb';
-import { ImageData, pdfToImages } from '@votingworks/image-utils';
+import { pdfToImages } from '@votingworks/image-utils';
 import {
   ContestId,
   GridPosition,
+  RgbaImageData,
   UnmarkedWriteIn,
   Vote,
   VotesDict,
@@ -17,7 +18,7 @@ import { readFileSync } from 'node:fs';
 
 export function pdfToPageImages(
   pdf: Uint8Array | string
-): AsyncIteratorPlus<ImageData> {
+): AsyncIteratorPlus<RgbaImageData> {
   const pdfData =
     typeof pdf === 'string' ? Uint8Array.from(readFileSync(pdf)) : pdf;
   return iter(pdfToImages(pdfData, { scale: 200 / 72 })).map(

--- a/libs/custom-paper-handler/src/driver/driver.ts
+++ b/libs/custom-paper-handler/src/driver/driver.ts
@@ -18,12 +18,12 @@ import {
   oneOf,
 } from '@votingworks/message-coder';
 import {
+  createGrayImageData,
   createImageData,
   crop,
-  ImageData,
   writeImageData,
 } from '@votingworks/image-utils';
-import { Rect } from '@votingworks/types';
+import { GrayImageData, Rect } from '@votingworks/types';
 import { Mutex } from '@votingworks/utils';
 import {
   assertNumberIsInRangeInclusive,
@@ -540,7 +540,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
     return this.syncScannerConfig();
   }
 
-  async scan(): Promise<ImageData> {
+  async scan(): Promise<GrayImageData> {
     const result = await this.genericLock.withLock(async () => {
       await this.transferOutGeneric(ScanCommand, undefined);
       debug('STARTING SCAN');
@@ -611,7 +611,7 @@ export class PaperHandlerDriver implements PaperHandlerDriverInterface {
       );
     }
     const imageBuf = Buffer.concat(result.imageData);
-    return createImageData(
+    return createGrayImageData(
       Uint8ClampedArray.from(imageBuf),
       result.width,
       imageBuf.byteLength / result.width

--- a/libs/custom-paper-handler/src/driver/driver_interface.ts
+++ b/libs/custom-paper-handler/src/driver/driver_interface.ts
@@ -1,6 +1,6 @@
 import { Coder, CoderError, Uint16, Uint8 } from '@votingworks/message-coder';
 import { Result } from '@votingworks/basics';
-import { ImageData } from '@votingworks/image-utils';
+import { ImageData } from '@votingworks/types';
 import {
   PrintingDensity,
   PrintingSpeed,

--- a/libs/custom-paper-handler/src/driver/mock_driver.test.ts
+++ b/libs/custom-paper-handler/src/driver/mock_driver.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { ImageData, writeImageData } from '@votingworks/image-utils';
+import { createImageData, writeImageData } from '@votingworks/image-utils';
 
 import { PaperHandlerStatus } from './coders.js';
 import {
@@ -143,9 +143,10 @@ test('presentPaper()', async () => {
 describe('print and scan', () => {
   const mockDriver = new MockPaperHandlerDriver();
 
-  const mockPageContents = new ImageData(
+  const mockPageContents = createImageData(
     new Uint8ClampedArray([1, 2, 3, 4]),
-    2
+    1,
+    1
   );
 
   test('scan only', async () => {

--- a/libs/custom-paper-handler/src/driver/mock_driver.ts
+++ b/libs/custom-paper-handler/src/driver/mock_driver.ts
@@ -3,9 +3,9 @@ import { CoderError } from '@votingworks/message-coder';
 import makeDebug from 'debug';
 import {
   BLANK_PAGE_IMAGE_DATA,
-  ImageData,
   writeImageData,
 } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 import {
   PaperHandlerStatus,
   PrinterStatusRealTimeExchangeResponse,
@@ -80,7 +80,7 @@ export type MockPaperHandlerStatus = keyof typeof MOCK_STATUSES_DEFINITIONS;
 export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
   private statusRef: PaperHandlerStatus = defaultPaperHandlerStatus();
   private mockStatus: MockPaperHandlerStatus = 'noPaper';
-  private mockPaperContents?: ImageData;
+  private mockPaperContents?: RgbaImageData;
   private coverOpen = false;
 
   constructor() {
@@ -207,7 +207,7 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
     return Promise.resolve(true);
   }
 
-  scan(): Promise<ImageData> {
+  scan(): Promise<RgbaImageData> {
     // @coverage-defer
     return Promise.resolve(this.mockPaperContents || BLANK_PAGE_IMAGE_DATA);
   }
@@ -346,7 +346,7 @@ export class MockPaperHandlerDriver implements PaperHandlerDriverInterface {
     };
   }
 
-  setMockPaperContents(contents?: ImageData): void {
+  setMockPaperContents(contents?: RgbaImageData): void {
     this.mockPaperContents = contents;
   }
 

--- a/libs/custom-paper-handler/src/printing.ts
+++ b/libs/custom-paper-handler/src/printing.ts
@@ -1,7 +1,7 @@
 // @coverage-defer-file
 import { assert, iter } from '@votingworks/basics';
 import { BITS_PER_BYTE } from '@votingworks/message-coder';
-import { ImageData } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 import { BitArray, bitArrayToByte, Uint8Max } from './bits.js';
 import { PaperHandlerBitmap } from './driver/coders.js';
 
@@ -46,14 +46,16 @@ function rgbToBinary(r: number, g: number, b: number): boolean {
   return rgbToGrayscale(r, g, b) < GRAYSCALE_WHITE_THRESHOLD;
 }
 
-export function imageDataToBinaryBitmap(imageData: ImageData): BinaryBitmap {
+export function imageDataToBinaryBitmap(
+  imageData: RgbaImageData
+): BinaryBitmap {
   const data: boolean[] = [];
 
   let r = 0;
   let g = 0;
   let b = 0;
   imageData.data.forEach((element, index) => {
-    // ImageData.data is in RGBA format. Map RBG values to grayscale.
+    // RgbaImageData.data is in RGBA format. Map RBG values to grayscale.
     // eslint-disable-next-line default-case
     switch (index % 4) {
       case 0:

--- a/libs/dev-dock/backend/src/dev_dock_api.ts
+++ b/libs/dev-dock/backend/src/dev_dock_api.ts
@@ -21,6 +21,7 @@ import {
   asSheet,
   DEFAULT_SYSTEM_SETTINGS,
   ElectionPackageFileName,
+  GrayImageData,
   PrinterConfig,
   PrinterStatus,
   safeParseElectionDefinition,
@@ -60,9 +61,9 @@ import { getMockFilePrinterHandler } from '@votingworks/printing';
 import { writeFile } from 'node:fs/promises';
 import { MockScanner, MockSheetStatus } from '@votingworks/pdi-scanner';
 import {
+  createGrayImageData,
   createImageData,
   getPdfPageCount,
-  ImageData,
   loadImageMetadata,
   pdfToImages,
   writeImageData,
@@ -345,7 +346,7 @@ export interface PdiScannerStatus {
 }
 
 interface PdiScannerSheetQueueState {
-  sheetIterator: AsyncIterator<SheetOf<ImageData>>;
+  sheetIterator: AsyncIterator<SheetOf<GrayImageData>>;
   totalSheets: number;
   sheetsInserted: number;
   timeoutId: ReturnType<typeof setTimeout>;
@@ -627,11 +628,16 @@ function buildApi(
       const pdfData = Uint8Array.from(fs.readFileSync(input.path));
       const pageCount = await getPdfPageCount(Uint8Array.from(pdfData));
       const totalSheets = Math.ceil(pageCount / 2);
-      const sheetIterator = iter(pdfToImages(pdfData, { scale: 200 / 72 }))
+      const sheetIterator = iter(
+        pdfToImages(pdfData, { scale: 200 / 72, color: 'gray' })
+      )
         .map(({ page }) => page)
         .chunks(2)
         .map(([front, back]) =>
-          asSheet([front, back ?? createImageData(front.width, front.height)])
+          asSheet([
+            front,
+            back ?? createGrayImageData(front.width, front.height),
+          ])
         )
         [Symbol.asyncIterator]();
 

--- a/libs/fixtures/src/builders.ts
+++ b/libs/fixtures/src/builders.ts
@@ -3,8 +3,8 @@ import {
   Election,
   ElectionDefinition,
   ElectionPackage,
-  ImageData,
   LATEST_METADATA,
+  RgbaImageData,
   safeParseElection,
   safeParseElectionDefinition,
   SystemSettings,
@@ -71,9 +71,9 @@ export interface ElectionFixture extends FileFixture {
  */
 export interface ImageFixture extends FileFixture {
   /**
-   * Returns the image as an ImageData object.
+   * Returns the image as an RgbaImageData object.
    */
-  asImageData(): Promise<ImageData>;
+  asImageData(): Promise<RgbaImageData>;
 }
 
 /**
@@ -187,12 +187,12 @@ export function image(path: string): ImageFixture {
   const inner = file(path);
   return {
     ...inner,
-    async asImageData(): Promise<ImageData> {
+    async asImageData(): Promise<RgbaImageData> {
       const img = await loadImage(realPath);
       const canvas = createCanvas(img.width, img.height);
       const context = canvas.getContext('2d');
       context.drawImage(img, 0, 0);
-      return context.getImageData(0, 0, img.width, img.height);
+      return context.getImageData(0, 0, img.width, img.height) as RgbaImageData;
     },
   };
 }

--- a/libs/fujitsu-thermal-printer/src/mocks/file_printer.ts
+++ b/libs/fujitsu-thermal-printer/src/mocks/file_printer.ts
@@ -1,5 +1,6 @@
 import { Optional, assert, err, iter, ok, sleep } from '@votingworks/basics';
-import { ImageData, writeImageData } from '@votingworks/image-utils';
+import { writeImageData } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 import { LogEventId, Logger } from '@votingworks/logging';
 import { Buffer } from 'node:buffer';
 import {
@@ -168,7 +169,7 @@ export class MockFileFujitsuPrinter implements FujitsuThermalPrinterInterface {
   }
 
   // @coverage-defer
-  async printImageData(imageData: ImageData): Promise<PrintResult> {
+  async printImageData(imageData: RgbaImageData): Promise<PrintResult> {
     return this.mockPrintJob((filename) =>
       writeImageData(`${filename}.png`, imageData)
     );

--- a/libs/fujitsu-thermal-printer/src/mocks/memory_printer.ts
+++ b/libs/fujitsu-thermal-printer/src/mocks/memory_printer.ts
@@ -1,5 +1,6 @@
 import { err, ok } from '@votingworks/basics';
-import { ImageData, writeImageData } from '@votingworks/image-utils';
+import { writeImageData } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 import { rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpName } from 'tmp-promise';
@@ -56,7 +57,7 @@ export function createMockFujitsuPrinterHandler(): MemoryFujitsuPrinterHandler {
 
   // @coverage-defer
   async function mockPrintImageData(
-    imageData: ImageData
+    imageData: RgbaImageData
   ): Promise<PrintResult> {
     if (mockPrinterState.status.state !== 'idle') {
       return err(mockPrinterState.status);

--- a/libs/fujitsu-thermal-printer/src/printer.ts
+++ b/libs/fujitsu-thermal-printer/src/printer.ts
@@ -5,8 +5,8 @@ import {
   ok,
   Result,
 } from '@votingworks/basics';
-import { ImageData } from '@votingworks/image-utils';
 import { LogEventId, Logger } from '@votingworks/logging';
+import { RgbaImageData } from '@votingworks/types';
 import {
   BooleanEnvironmentVariableName,
   isFeatureFlagEnabled,
@@ -153,7 +153,7 @@ export class FujitsuThermalPrinter implements FujitsuThermalPrinterInterface {
   }
 
   // @coverage-defer
-  async printImageData(imageData: ImageData): Promise<PrintResult> {
+  async printImageData(imageData: RgbaImageData): Promise<PrintResult> {
     assert(this.driver);
     await this.logger.logAsCurrentRole(LogEventId.PrinterPrintRequest, {
       message: 'Initiating print',

--- a/libs/fujitsu-thermal-printer/src/printing.test.ts
+++ b/libs/fujitsu-thermal-printer/src/printing.test.ts
@@ -3,7 +3,8 @@ import { expect, Mocked, test, vi } from 'vitest';
 import { Device, findByIds, WebUSBDevice } from 'usb';
 import { LogEventId, mockLogger } from '@votingworks/logging';
 import { readFileSync } from 'node:fs';
-import { createImageData, ImageData } from '@votingworks/image-utils';
+import { createImageData } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 import { assertDefined, iter, ok } from '@votingworks/basics';
 import {
   BYTES_PER_BIT_IMAGE_ROW,
@@ -46,7 +47,7 @@ function imageDataWithRowMarkers(width: number, height: number) {
   return createImageData(data, width, height);
 }
 
-function pixelAt(imageData: ImageData, x: number, y: number) {
+function pixelAt(imageData: RgbaImageData, x: number, y: number) {
   const offset = (y * imageData.width + x) * BYTES_PER_PIXEL;
   return [
     imageData.data[offset],
@@ -117,17 +118,22 @@ test('chunkImageData requires page-width image data', () => {
   ).toThrow();
 });
 
-function whiteImage(width: number, height: number): ImageData {
+function whiteImage(width: number, height: number): RgbaImageData {
   const imageData = createImageData(width, height);
   imageData.data.fill(255);
   return imageData;
 }
 
-function paintGray(imageData: ImageData, x: number, y: number, gray: number) {
+function paintGray(
+  imageData: RgbaImageData,
+  x: number,
+  y: number,
+  gray: number
+) {
   imageData.data.set([gray, gray, gray, 255], (y * imageData.width + x) * 4);
 }
 
-function paintBlack(imageData: ImageData, x: number, y: number) {
+function paintBlack(imageData: RgbaImageData, x: number, y: number) {
   paintGray(imageData, x, y, 0);
 }
 

--- a/libs/fujitsu-thermal-printer/src/printing.ts
+++ b/libs/fujitsu-thermal-printer/src/printing.ts
@@ -1,9 +1,10 @@
 import { IteratorPlus, Result, assert, iter, ok } from '@votingworks/basics';
 import {
   createImageData,
-  ImageData,
   pdfToImages,
+  rgbToGrayscale,
 } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 import { BITS_PER_BYTE } from '@votingworks/message-coder';
 import { readFileSync } from 'node:fs';
 import {
@@ -38,7 +39,9 @@ const PRINTING_DPI = 200;
  * Trims a page rendered at 8.5" wide (i.e. 1700px) to the printer's printable
  * width, centering the printable area.
  */
-export function trimImageDataToPageWidth(imageData: ImageData): ImageData {
+export function trimImageDataToPageWidth(
+  imageData: RgbaImageData
+): RgbaImageData {
   assert(imageData.width === LETTER_WIDTH_INCHES * PRINTING_DPI);
   debug('trimming image data to page width');
 
@@ -63,7 +66,9 @@ export function trimImageDataToPageWidth(imageData: ImageData): ImageData {
 /**
  * Splits page-width image data into chunks the driver can accept.
  */
-export function* chunkImageData(imageData: ImageData): Generator<ImageData> {
+export function* chunkImageData(
+  imageData: RgbaImageData
+): Generator<RgbaImageData> {
   assert(imageData.width === PAGE_DOTS_WIDTH);
 
   const bytesPerRow = PAGE_DOTS_WIDTH * IMAGE_DATA_BYTES_PER_PIXEL;
@@ -89,19 +94,6 @@ export function* chunkImageData(imageData: ImageData): Generator<ImageData> {
 }
 
 /**
- * Converts 8-bit sRGB color values to an 8-bit grayscale value without gamma
- * correction.
- *
- * @param r Red color value from 0 - 255
- * @param g Green color value from 0 - 255
- * @param b Blue color value from 0 - 255
- * @returns Grayscale color value from 0 - 255
- */
-export function rgbToGrayscale(r: number, g: number, b: number): number {
-  return 0.299 * r + 0.587 * g + 0.114 * b;
-}
-
-/**
  * Below this value, we consider the grayscale to be black. Otherwise, white.
  */
 const GRAYSCALE_WHITE_THRESHOLD = 230;
@@ -111,7 +103,7 @@ const GRAYSCALE_WHITE_THRESHOLD = 230;
  * 1 = black.
  */
 export function imageDataToBitImage(
-  imageData: ImageData
+  imageData: RgbaImageData
 ): UncompressedBitImage {
   assert(
     imageData.width === PAGE_DOTS_WIDTH,
@@ -285,7 +277,7 @@ export async function printPageBitImage(
  */
 async function printImageDataInternal(
   driver: FujitsuThermalPrinterDriverInterface,
-  imageData: ImageData
+  imageData: RgbaImageData
 ): Promise<Result<void, RawPrinterStatus>> {
   return await printPageBitImage(
     driver,
@@ -300,7 +292,7 @@ async function printImageDataInternal(
  */
 export async function printImageData(
   driver: FujitsuThermalPrinterDriverInterface,
-  imageData: ImageData
+  imageData: RgbaImageData
 ): Promise<Result<void, RawPrinterStatus>> {
   assert(
     imageData.width === PAGE_DOTS_WIDTH,

--- a/libs/fujitsu-thermal-printer/src/types.ts
+++ b/libs/fujitsu-thermal-printer/src/types.ts
@@ -1,5 +1,5 @@
 import { Result } from '@votingworks/basics';
-import { type ImageData } from '@votingworks/image-utils';
+import { type RgbaImageData } from '@votingworks/types';
 
 export type ErrorType =
   | 'hardware'
@@ -31,5 +31,5 @@ export type PrintResult = Result<void, PrinterStatus>;
 export interface FujitsuThermalPrinterInterface {
   getStatus(): Promise<PrinterStatus>;
   printPdf(data: Uint8Array): Promise<PrintResult>;
-  printImageData(imageData: ImageData): Promise<PrintResult>;
+  printImageData(imageData: RgbaImageData): Promise<PrintResult>;
 }

--- a/libs/hmpb/src/ballot_fixtures.ts
+++ b/libs/hmpb/src/ballot_fixtures.ts
@@ -28,10 +28,11 @@ import {
   LanguageCode,
   LATEST_SOFTWARE_VERSION,
   VotesDict,
+  RgbaImageData,
 } from '@votingworks/types';
 import { join } from 'node:path';
 import makeDebug from 'debug';
-import { ImageData, pdfToImages } from '@votingworks/image-utils';
+import { pdfToImages } from '@votingworks/image-utils';
 import { createTestVotes, markBallotDocument } from './mark_ballot.js';
 import {
   allBaseBallotProps,
@@ -244,10 +245,10 @@ export const vxFamousNamesFixtures = lazyFixtures(() => {
         };
       });
 
-      let blankBallotPageImages: Optional<ImageData[]>;
-      let markedBallotPageImages: Optional<ImageData[]>;
-      let blankOfficialBallotPageImages: Optional<ImageData[]>;
-      let markedOfficialBallotPageImages: Optional<ImageData[]>;
+      let blankBallotPageImages: Optional<RgbaImageData[]>;
+      let markedBallotPageImages: Optional<RgbaImageData[]>;
+      let blankOfficialBallotPageImages: Optional<RgbaImageData[]>;
+      let markedOfficialBallotPageImages: Optional<RgbaImageData[]>;
       // @coverage-defer
       if (generatePageImages) {
         [

--- a/libs/hmpb/test/setupTests.ts
+++ b/libs/hmpb/test/setupTests.ts
@@ -4,11 +4,8 @@ import {
   clearTemporaryRootDir,
   setupTemporaryRootDir,
 } from '@votingworks/fixtures';
-import {
-  ImageData,
-  toMatchImage,
-  ToMatchImageOptions,
-} from '@votingworks/image-utils';
+import { toMatchImage, ToMatchImageOptions } from '@votingworks/image-utils';
+import { RgbaImageData } from '@votingworks/types';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -16,7 +13,7 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R> {
       toMatchImage(
-        expected: ImageData,
+        expected: RgbaImageData,
         options?: ToMatchImageOptions
       ): Promise<void>;
     }

--- a/libs/image-utils/src/crop.test.ts
+++ b/libs/image-utils/src/crop.test.ts
@@ -1,19 +1,18 @@
 import { expect, test } from 'vitest';
-import { Rect } from '@votingworks/types';
-import { createImageData, ImageData } from 'canvas';
+import { Rect, RgbaImageData } from '@votingworks/types';
 import fc from 'fast-check';
 import { arbitraryImageData, arbitraryRect } from '../test/arbitraries';
 import { crop } from './crop';
+import { createImageData, RGBA_CHANNEL_COUNT } from './image_data';
 import { int } from './types';
-import { RGBA_CHANNEL_COUNT } from './index';
 
 /**
  * A slow-but-accurate implementation of `crop` to compare against.
  */
 function cropReferenceImplementation(
-  { data: src, width: srcWidth }: ImageData,
+  { data: src, width: srcWidth }: RgbaImageData,
   bounds: Rect
-): ImageData {
+): RgbaImageData {
   const dst = new Uint8ClampedArray(
     bounds.width * bounds.height * RGBA_CHANNEL_COUNT
   );

--- a/libs/image-utils/src/crop.ts
+++ b/libs/image-utils/src/crop.ts
@@ -1,23 +1,19 @@
-import { assert } from '@votingworks/basics';
-import { Rect } from '@votingworks/types';
-import { createImageData, ImageData } from 'canvas';
-import { RGBA_CHANNEL_COUNT, isRgba } from './image_data';
+import { Rect, RgbaImageData } from '@votingworks/types';
+import { createImageData, RGBA_CHANNEL_COUNT } from './image_data';
 
 /**
  * Returns a new image cropped to the specified bounds.
  */
-export function crop(imageData: ImageData, bounds: Rect): ImageData {
+export function crop(imageData: RgbaImageData, bounds: Rect): RgbaImageData {
   const { data: src, width: srcWidth } = imageData;
-  assert(isRgba(imageData), 'Image must be RGBA');
-  const dst = new Uint8ClampedArray(
-    bounds.width * bounds.height * RGBA_CHANNEL_COUNT
-  );
   const {
     x: srcOffsetX,
     y: srcOffsetY,
     width: dstWidth,
     height: dstHeight,
   } = bounds;
+  const dstImageData = createImageData(dstWidth, dstHeight);
+  const dst = dstImageData.data;
 
   for (let y = 0; y < dstHeight; y += 1) {
     const srcOffset = (srcOffsetY + y) * srcWidth + srcOffsetX;
@@ -31,5 +27,5 @@ export function crop(imageData: ImageData, bounds: Rect): ImageData {
     );
   }
 
-  return createImageData(dst, dstWidth, dstHeight);
+  return dstImageData;
 }

--- a/libs/image-utils/src/image_data.test.ts
+++ b/libs/image-utils/src/image_data.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 import { Buffer } from 'node:buffer';
-import { ImageData, createImageData } from 'canvas';
+import { ImageData } from 'canvas';
 import fc from 'fast-check';
 import { writeFile } from 'node:fs/promises';
 import { makeTemporaryFile } from '@votingworks/fixtures';
@@ -9,6 +9,8 @@ import { err, ok, MaybePromise } from '@votingworks/basics';
 import { arbitraryImageData } from '../test/arbitraries';
 import {
   RGBA_CHANNEL_COUNT,
+  createGrayImageData,
+  createImageData,
   encodeImageData,
   ensureImageData,
   fromGrayScale,
@@ -16,11 +18,45 @@ import {
   isRgba,
   loadImageData,
   loadImageMetadata,
+  rgbToGrayscale,
   toDataUrl,
+  toGrayScale,
   toImageBuffer,
   writeImageData,
 } from './image_data';
 
+test('createGrayImageData with dimensions', () => {
+  const image = createGrayImageData(3, 2);
+  expect(image).toBeInstanceOf(ImageData);
+  expect({ width: image.width, height: image.height }).toEqual({
+    width: 3,
+    height: 2,
+  });
+  expect([...image.data]).toEqual([0, 0, 0, 0, 0, 0]);
+});
+
+test('createGrayImageData with pixels', () => {
+  const pixels = Uint8ClampedArray.of(1, 2, 3, 4, 5, 6);
+  const image = createGrayImageData(pixels, 3, 2);
+  expect(image).toBeInstanceOf(ImageData);
+  expect({ width: image.width, height: image.height }).toEqual({
+    width: 3,
+    height: 2,
+  });
+  // the pixels are wrapped, not copied
+  pixels[0] = 9;
+  expect(image.data[0]).toEqual(9);
+});
+
+test.each([
+  ['createImageData', createImageData(3, 2)],
+  ['createGrayImageData', createGrayImageData(3, 2)],
+] as const)('%s serializes compactly', (_name, image) => {
+  expect(JSON.stringify(image)).toEqual('"[ImageData 3x2]"');
+
+  // the compact `toJSON` is non-enumerable, so equality checks ignore it
+  expect(Object.keys(image)).not.toContain('toJSON');
+});
 test('channels', () => {
   const rgbaImage = createImageData(1, 1);
   expect(getImageChannelCount(rgbaImage)).toEqual(RGBA_CHANNEL_COUNT);
@@ -88,6 +124,82 @@ test('fromGrayScale', () => {
       }
     )
   );
+});
+
+test('toGrayScale', () => {
+  expect(() => toGrayScale(Buffer.alloc(RGBA_CHANNEL_COUNT), 0, 1)).toThrow(
+    'Invalid width'
+  );
+  expect(() => toGrayScale(Buffer.alloc(RGBA_CHANNEL_COUNT), 1, 0)).toThrow(
+    'Invalid height'
+  );
+  expect(() => toGrayScale(Buffer.alloc(RGBA_CHANNEL_COUNT), 1, 2)).toThrow(
+    'Invalid pixel count'
+  );
+
+  // accepts a Buffer
+  expect(
+    getImageChannelCount(toGrayScale(Buffer.of(1, 2, 3, 0xff), 1, 1))
+  ).toEqual(1);
+
+  // accepts a Uint8ClampedArray
+  expect(
+    getImageChannelCount(toGrayScale(Uint8ClampedArray.of(1, 2, 3, 0xff), 1, 1))
+  ).toEqual(1);
+
+  // accepts a number[]
+  expect(getImageChannelCount(toGrayScale([1, 2, 3, 0xff], 1, 1))).toEqual(1);
+
+  // ignores the alpha channel
+  expect(toGrayScale([9, 9, 9, 0x00], 1, 1).data).toEqual(
+    toGrayScale([9, 9, 9, 0xff], 1, 1).data
+  );
+
+  fc.assert(
+    fc.property(
+      fc
+        .tuple(fc.integer({ min: 1, max: 10 }), fc.integer({ min: 1, max: 10 }))
+        .chain(([width, height]) =>
+          fc.tuple(
+            fc.array(fc.integer({ min: 0, max: 0xff }), {
+              minLength: width * height * RGBA_CHANNEL_COUNT,
+              maxLength: width * height * RGBA_CHANNEL_COUNT,
+            }),
+            fc.constant(width),
+            fc.constant(height)
+          )
+        ),
+      ([pixels, width, height]) => {
+        const imageData = toGrayScale(pixels, width, height);
+        expect({
+          width: imageData.width,
+          height: imageData.height,
+          dataLength: imageData.data.length,
+        }).toEqual({ width, height, dataLength: width * height });
+
+        for (let i = 0; i < width * height; i += 1) {
+          const offset = i * RGBA_CHANNEL_COUNT;
+          expect(imageData.data[i]).toEqual(
+            Uint8ClampedArray.of(
+              rgbToGrayscale(
+                pixels[offset] as number,
+                pixels[offset + 1] as number,
+                pixels[offset + 2] as number
+              )
+            )[0]
+          );
+        }
+      }
+    )
+  );
+});
+
+test('rgbToGrayscale', () => {
+  expect(rgbToGrayscale(0, 0, 0)).toEqual(0);
+  expect(rgbToGrayscale(0xff, 0xff, 0xff)).toEqual(0xff);
+  expect(rgbToGrayscale(0xff, 0, 0)).toBeCloseTo(0.299 * 0xff);
+  expect(rgbToGrayscale(0, 0xff, 0)).toBeCloseTo(0.587 * 0xff);
+  expect(rgbToGrayscale(0, 0, 0xff)).toBeCloseTo(0.114 * 0xff);
 });
 
 test('loadImage/writeImageData', async () => {

--- a/libs/image-utils/src/image_data.ts
+++ b/libs/image-utils/src/image_data.ts
@@ -5,17 +5,10 @@ import {
   ok,
   Result,
 } from '@votingworks/basics';
+import { GrayImageData, RgbaImageData } from '@votingworks/types';
 import { time } from '@votingworks/utils';
 import { Buffer } from 'node:buffer';
-import {
-  loadImage as canvasLoadImage,
-  createCanvas,
-  createImageData,
-  Image,
-  ImageData,
-  JpegConfig,
-  PngConfig,
-} from 'canvas';
+import * as canvas from 'canvas';
 import makeDebug from 'debug';
 import { open, writeFile } from 'node:fs/promises';
 
@@ -30,28 +23,144 @@ const debug = makeDebug('image-utils');
 export const RGBA_CHANNEL_COUNT = 4;
 
 /**
+ * Summarize pixel buffers rather than serializing them.
+ */
+function withCompactJson<T extends canvas.ImageData>(image: T): T {
+  return Object.defineProperty(image, 'toJSON', {
+    value: () => `[ImageData ${image.width}x${image.height}]`,
+  });
+}
+
+/**
+ * Allocates RGBA pixel data of the given dimensions.
+ */
+export function createImageData(width: number, height: number): RgbaImageData;
+
+/**
+ * Wraps existing RGBA pixel data of the givevn dimensions.
+ */
+export function createImageData(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number
+): RgbaImageData;
+
+/**
+ * Creates RGBA (four bytes per pixel) image data.
+ */
+export function createImageData(
+  widthOrData: number | Uint8ClampedArray,
+  heightOrWidth: number,
+  undefinedOrHeight?: number
+): RgbaImageData {
+  if (
+    typeof widthOrData === 'number' &&
+    typeof undefinedOrHeight === 'undefined'
+  ) {
+    const width = widthOrData;
+    const height = heightOrWidth;
+    return withCompactJson(
+      canvas.createImageData(width, height)
+    ) as RgbaImageData;
+  }
+
+  if (
+    typeof widthOrData === 'object' &&
+    typeof undefinedOrHeight === 'number'
+  ) {
+    const data = widthOrData;
+    const width = heightOrWidth;
+    const height = undefinedOrHeight;
+    assert(data.length === width * height * RGBA_CHANNEL_COUNT);
+    return withCompactJson(
+      canvas.createImageData(data, width, height)
+    ) as RgbaImageData;
+  }
+
+  // @coverage-exclude
+  throw new Error('unexpected arguments');
+}
+
+/**
+ * Allocates grayscale pixel data of the given dimensions.
+ */
+export function createGrayImageData(
+  width: number,
+  height: number
+): GrayImageData;
+
+/**
+ * Wraps existing grayscale pixel data of the given dimensions.
+ */
+export function createGrayImageData(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number
+): GrayImageData;
+
+/**
+ * Creates grayscale image data.
+ */
+export function createGrayImageData(
+  widthOrData: number | Uint8ClampedArray,
+  heightOrWidth: number,
+  undefinedOrHeight?: number
+): GrayImageData {
+  if (
+    typeof widthOrData === 'number' &&
+    typeof undefinedOrHeight === 'undefined'
+  ) {
+    const width = widthOrData;
+    const height = heightOrWidth;
+    return withCompactJson(
+      canvas.createImageData(
+        new Uint8ClampedArray(width * height),
+        width,
+        height
+      )
+    ) as GrayImageData;
+  }
+
+  if (
+    typeof widthOrData === 'object' &&
+    typeof undefinedOrHeight === 'number'
+  ) {
+    const data = widthOrData;
+    const width = heightOrWidth;
+    const height = undefinedOrHeight;
+    assert(data.length === width * height);
+    return withCompactJson(
+      canvas.createImageData(data, width, height)
+    ) as GrayImageData;
+  }
+
+  // @coverage-exclude
+  throw new Error('unexpected arguments');
+}
+
+/**
  * Ensures the image data is an instance of ImageData.
  */
-export function ensureImageData(imageData: ImageData): ImageData {
-  if (imageData instanceof ImageData) {
+export function ensureImageData(imageData: canvas.ImageData): canvas.ImageData {
+  if (imageData instanceof canvas.ImageData) {
     return imageData;
   }
 
   const { data, width, height } = imageData;
-  return createImageData(data, width, height);
+  return canvas.createImageData(data, width, height);
 }
 
 /**
  * Determines the number of channels in an image.
  */
-export function getImageChannelCount(image: ImageData): int {
+export function getImageChannelCount(image: canvas.ImageData): int {
   return assertInteger(image.data.length / image.width / image.height);
 }
 
 /**
  * Determines whether the image is RGBA.
  */
-export function isRgba(image: ImageData): boolean {
+export function isRgba(image: canvas.ImageData): image is RgbaImageData {
   return getImageChannelCount(image) === RGBA_CHANNEL_COUNT;
 }
 
@@ -60,10 +169,12 @@ export function isRgba(image: ImageData): boolean {
  */
 export async function loadImageData(
   pathOrData: string | Buffer
-): Promise<Result<ImageData, { type: 'invalid-image-file'; message: string }>> {
-  let image: Image;
+): Promise<
+  Result<RgbaImageData, { type: 'invalid-image-file'; message: string }>
+> {
+  let image: canvas.Image;
   try {
-    image = await canvasLoadImage(pathOrData);
+    image = await canvas.loadImage(pathOrData);
   } catch (error) {
     // canvasLoadImage will fail on a corrupted image or a file that isn't an image
     return err({
@@ -71,10 +182,15 @@ export async function loadImageData(
       message: extractErrorMessage(error),
     });
   }
-  const canvas = createCanvas(image.width, image.height);
-  const context = canvas.getContext('2d');
-  context.drawImage(image, 0, 0);
-  const imageData = context.getImageData(0, 0, image.width, image.height);
+  const cvs = canvas.createCanvas(image.width, image.height);
+  const ctx = cvs.getContext('2d');
+  ctx.drawImage(image, 0, 0);
+  const imageData = ctx.getImageData(
+    0,
+    0,
+    image.width,
+    image.height
+  ) as RgbaImageData;
   return ok(imageData);
 }
 
@@ -239,7 +355,7 @@ export function fromGrayScale(
   pixels: ArrayLike<u8>,
   width: usize,
   height: usize
-): ImageData {
+): RgbaImageData {
   assert(width > 0 && Number.isInteger(width), 'Invalid width');
   assert(height > 0 && Number.isInteger(height), 'Invalid height');
   assert(pixels.length === width * height, 'Invalid pixel count');
@@ -265,30 +381,70 @@ export function fromGrayScale(
   return createImageData(imageDataBuffer, width, height);
 }
 
-function createCanvasWithImageData(imageData: ImageData) {
+/**
+ * Converts 8-bit sRGB color values to an 8-bit grayscale value.
+ */
+export function rgbToGrayscale(r: number, g: number, b: number): number {
+  return 0.299 * r + 0.587 * g + 0.114 * b;
+}
+
+/**
+ * Converts RGBA pixel data to a grayscale image. Ignores the alpha channel.
+ */
+export function toGrayScale(
+  pixels: ArrayLike<u8>,
+  width: usize,
+  height: usize
+): GrayImageData {
+  assert(width > 0 && Number.isInteger(width), 'Invalid width');
+  assert(height > 0 && Number.isInteger(height), 'Invalid height');
+  assert(
+    pixels.length === width * height * RGBA_CHANNEL_COUNT,
+    'Invalid pixel count'
+  );
+
+  const imageData = createGrayImageData(width, height);
+  const dstData = imageData.data;
+
+  for (
+    let srcOffset = 0, dstOffset = 0;
+    srcOffset < pixels.length;
+    srcOffset += RGBA_CHANNEL_COUNT, dstOffset += 1
+  ) {
+    dstData[dstOffset] = rgbToGrayscale(
+      pixels[srcOffset] as number,
+      pixels[srcOffset + 1] as number,
+      pixels[srcOffset + 2] as number
+    );
+  }
+
+  return imageData;
+}
+
+function createCanvasWithImageData(imageData: canvas.ImageData) {
   assert(
     isRgba(imageData),
     `Expected RGBA image data, got ${getImageChannelCount(
       imageData
     )} channel(s)`
   );
-  const canvas = createCanvas(imageData.width, imageData.height);
-  const context = canvas.getContext('2d');
-  context.putImageData(ensureImageData(imageData), 0, 0);
-  return canvas;
+  const cvs = canvas.createCanvas(imageData.width, imageData.height);
+  const ctx = cvs.getContext('2d');
+  ctx.putImageData(ensureImageData(imageData), 0, 0);
+  return cvs;
 }
 
 /**
  * Creates a data URL from image data.
  */
 export function toDataUrl(
-  image: ImageData,
+  image: canvas.ImageData,
   mimeType: 'image/png' | 'image/jpeg'
 ): string {
-  const canvas = createCanvasWithImageData(image);
+  const cvs = createCanvasWithImageData(image);
   return mimeType === 'image/jpeg'
-    ? canvas.toDataURL(mimeType)
-    : canvas.toDataURL(mimeType);
+    ? cvs.toDataURL(mimeType)
+    : cvs.toDataURL(mimeType);
 }
 
 /**
@@ -296,16 +452,16 @@ export function toDataUrl(
  */
 export async function writeImageData(
   path: string,
-  imageData: ImageData
+  imageData: canvas.ImageData
 ): Promise<void> {
   const timer = time(
     debug,
     `writeImageData: ${path} (${imageData.width}×${imageData.height})`
   );
-  const canvas = createCanvasWithImageData(imageData);
+  const cvs = createCanvasWithImageData(imageData);
   const encoded = /\.png$/i.test(path)
-    ? canvas.toBuffer('image/png')
-    : canvas.toBuffer('image/jpeg');
+    ? cvs.toBuffer('image/png')
+    : cvs.toBuffer('image/jpeg');
   await writeFile(path, encoded);
   timer.end();
 }
@@ -317,9 +473,9 @@ export async function writeImageData(
  * tasks in parallel, such as encoding the image data.
  */
 export async function encodeImageData(
-  imageData: ImageData,
+  imageData: canvas.ImageData,
   mimeType: 'image/png',
-  pngConfig?: PngConfig
+  pngConfig?: canvas.PngConfig
 ): Promise<Buffer>;
 
 /**
@@ -329,9 +485,9 @@ export async function encodeImageData(
  * tasks in parallel, such as encoding the image data.
  */
 export async function encodeImageData(
-  imageData: ImageData,
+  imageData: canvas.ImageData,
   mimeType: 'image/jpeg',
-  pngConfig?: JpegConfig
+  pngConfig?: canvas.JpegConfig
 ): Promise<Buffer>;
 
 /**
@@ -341,26 +497,26 @@ export async function encodeImageData(
  * tasks in parallel, such as encoding the image data.
  */
 export async function encodeImageData(
-  imageData: ImageData,
+  imageData: canvas.ImageData,
   mimeType: 'image/png' | 'image/jpeg',
-  config?: PngConfig | JpegConfig
+  config?: canvas.PngConfig | canvas.JpegConfig
 ): Promise<Buffer> {
   const timer = time(debug, `writeImageDataToBuffer: ${mimeType}`);
-  const canvas = createCanvasWithImageData(imageData);
+  const cvs = createCanvasWithImageData(imageData);
   const encoded = await new Promise<Buffer>((resolve, reject) => {
     if (mimeType === 'image/png') {
-      canvas.toBuffer(
+      cvs.toBuffer(
         // @coverage-exclude
         (error, buffer) => (error ? reject(error) : resolve(buffer)),
         mimeType,
-        config as PngConfig
+        config as canvas.PngConfig
       );
     } else {
-      canvas.toBuffer(
+      cvs.toBuffer(
         // @coverage-exclude
         (error, buffer) => (error ? reject(error) : resolve(buffer)),
         mimeType,
-        config as JpegConfig
+        config as canvas.JpegConfig
       );
     }
   });
@@ -372,12 +528,12 @@ export async function encodeImageData(
  * Converts an ImageData to an image Buffer.
  */
 export function toImageBuffer(
-  imageData: ImageData,
+  imageData: canvas.ImageData,
   mimeType: 'image/png' | 'image/jpeg' = 'image/png'
 ): Buffer {
-  const canvas = createCanvasWithImageData(imageData);
+  const cvs = createCanvasWithImageData(imageData);
   // Help TS match the union type branches to overloaded function signatures
   return mimeType === 'image/png'
-    ? canvas.toBuffer(mimeType)
-    : canvas.toBuffer(mimeType);
+    ? cvs.toBuffer(mimeType)
+    : cvs.toBuffer(mimeType);
 }

--- a/libs/image-utils/src/index.ts
+++ b/libs/image-utils/src/index.ts
@@ -6,4 +6,4 @@ export * from './jest_pdf_snapshot';
 export * from './overlay';
 export * from './test_utils';
 export * from './types';
-export { createImageData, ImageData } from 'canvas';
+export { ImageData } from 'canvas';

--- a/libs/image-utils/src/jest_match_image.test.ts
+++ b/libs/image-utils/src/jest_match_image.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 import { sampleBallotImages } from '@votingworks/fixtures';
-import { createImageData } from 'canvas';
 import { basename } from 'node:path';
+import { createImageData } from './image_data';
 import { crop } from './crop';
 
 test('matching images', async () => {

--- a/libs/image-utils/src/jest_match_image.ts
+++ b/libs/image-utils/src/jest_match_image.ts
@@ -1,10 +1,10 @@
-import { ImageData } from 'canvas';
 import { assert } from '@votingworks/basics';
+import { RgbaImageData } from '@votingworks/types';
 import { format } from '@votingworks/utils';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import pixelmatch from 'pixelmatch';
-import { writeImageData } from './image_data';
+import { createImageData, writeImageData } from './image_data';
 
 /**
  * Options for the `toMatchImage` custom Jest matcher.
@@ -30,7 +30,12 @@ export interface ToMatchImageOptions {
  *
  * @see https://en.wikipedia.org/wiki/Bit_blit
  */
-function bitblt(src: ImageData, dst: ImageData, dx: number, dy: number): void {
+function bitblt(
+  src: RgbaImageData,
+  dst: RgbaImageData,
+  dx: number,
+  dy: number
+): void {
   const channels = 4;
   const srcData = src.data;
   const dstData = dst.data;
@@ -56,18 +61,18 @@ function bitblt(src: ImageData, dst: ImageData, dx: number, dy: number): void {
 }
 
 /**
- * Custom matcher to compare two `ImageData` instances.
+ * Custom matcher to compare two `RgbaImageData` instances.
  */
 export async function toMatchImage(
-  received: ImageData,
-  expected: ImageData,
+  received: RgbaImageData,
+  expected: RgbaImageData,
   options: ToMatchImageOptions = {}
 ): Promise<jest.CustomMatcherResult> {
   assert(
     options.failureThreshold === undefined ||
       (options.failureThreshold >= 0 && options.failureThreshold <= 1)
   );
-  const diffImg = new ImageData(received.width, received.height);
+  const diffImg = createImageData(received.width, received.height);
   const diff = pixelmatch(
     received.data,
     expected.data,
@@ -98,7 +103,7 @@ export async function toMatchImage(
     };
   }
 
-  const compositeImg = new ImageData(3 * received.width, received.height);
+  const compositeImg = createImageData(3 * received.width, received.height);
 
   bitblt(received, compositeImg, 0, 0);
   bitblt(diffImg, compositeImg, received.width, 0);

--- a/libs/image-utils/src/overlay.ts
+++ b/libs/image-utils/src/overlay.ts
@@ -1,12 +1,16 @@
 // @coverage-exclude-file: tested externally at point of usage
-import { createCanvas, ImageData } from 'canvas';
+import { createCanvas } from 'canvas';
+import { RgbaImageData } from '@votingworks/types';
 
 /**
  * Creates a new image consisting of {@link overlay} drawn on top of
  * {@link base}. Assumes the overlay image already has the necessary
  * transparency where needed.
  */
-export function overlayImages(base: ImageData, overlay: ImageData): ImageData {
+export function overlayImages(
+  base: RgbaImageData,
+  overlay: RgbaImageData
+): RgbaImageData {
   const overlayCanvas = createCanvas(base.width, base.height);
   const overlayCtx = overlayCanvas.getContext('2d');
   overlayCtx.putImageData(overlay, 0, 0);
@@ -17,5 +21,5 @@ export function overlayImages(base: ImageData, overlay: ImageData): ImageData {
   baseCtx.putImageData(base, 0, 0);
   baseCtx.drawImage(overlayCanvas, 0, 0);
 
-  return baseCtx.getImageData(0, 0, base.width, base.height);
+  return baseCtx.getImageData(0, 0, base.width, base.height) as RgbaImageData;
 }

--- a/libs/image-utils/src/pdf_to_images.test.ts
+++ b/libs/image-utils/src/pdf_to_images.test.ts
@@ -4,6 +4,8 @@ import { Size } from '@votingworks/types';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { expect, test } from 'vitest';
+import { ImageData } from 'canvas';
+import { isRgba } from './image_data';
 import {
   PdfPage,
   getPdfPageCount,
@@ -18,7 +20,7 @@ async function readMsBallotPdf(): Promise<Uint8Array> {
 }
 
 function assertHasPageCountAndSize(
-  pages: PdfPage[],
+  pages: ReadonlyArray<PdfPage<ImageData>>,
   { pageCount, size }: { pageCount: number; size: Size }
 ): void {
   expect(pages).toHaveLength(pageCount);
@@ -87,4 +89,20 @@ test('parsePdf', async () => {
 test('getPdfPageCount', async () => {
   const pageCount = await getPdfPageCount(await readMsBallotPdf());
   expect(pageCount).toEqual(6);
+});
+
+test('can generate grayscale images', async () => {
+  const pages = await iter(
+    pdfToImages(await readMsBallotPdf(), { color: 'gray' })
+  ).toArray();
+
+  assertHasPageCountAndSize(pages, {
+    pageCount: 6,
+    size: { width: 612, height: 792 },
+  });
+
+  for (const { page } of pages) {
+    expect(isRgba(page)).toEqual(false);
+    expect(page.data).toHaveLength(page.width * page.height);
+  }
 });

--- a/libs/image-utils/src/pdf_to_images.ts
+++ b/libs/image-utils/src/pdf_to_images.ts
@@ -1,12 +1,14 @@
 import { createCanvas } from '@napi-rs/canvas';
 import { Buffer } from 'node:buffer';
-import { CanvasGradient, CanvasPattern, ImageData } from 'canvas';
+import { CanvasGradient, CanvasPattern } from 'canvas';
 import type { PDFDocumentProxy } from 'pdfjs-dist';
+import { GrayImageData, RgbaImageData } from '@votingworks/types';
+import { createImageData, toGrayScale } from './image_data';
 
 /**
  * A page of a PDF document.
  */
-export interface PdfPage {
+export interface PdfPage<ImageData = RgbaImageData> {
   readonly pageNumber: number;
   readonly pageCount: number;
   readonly page: ImageData;
@@ -15,6 +17,7 @@ export interface PdfPage {
 /** Options for {@link pdfToImages}. */
 export interface PdfToImagesOptions {
   background?: string | CanvasGradient | CanvasPattern;
+  color?: 'rgba' | 'gray';
 
   /** @default 1 */
   scale?: number;
@@ -24,17 +27,42 @@ export interface PdfToImagesOptions {
  * Renders PDF pages as images. This function consumes the data source, leaving
  * the caller with an empty `Uint8Array` when this function resolves. Be sure to
  * clone the data if you need it afterward.
- *
- * Rendering uses `@napi-rs/canvas` rather than `canvas` because that's the
- * canvas implementation pdfjs supports in Node.js — rendering to a
- * node-canvas context silently produces blank pages. The resulting pixels are
- * returned as node-canvas `ImageData` to match the rest of this library.
+ */
+export function pdfToImages(
+  pdfBytes: Uint8Array,
+  opts: PdfToImagesOptions & { color: 'rgba' }
+): AsyncIterable<PdfPage<RgbaImageData>>;
+
+/**
+ * Renders PDF pages as images. This function consumes the data source, leaving
+ * the caller with an empty `Uint8Array` when this function resolves. Be sure to
+ * clone the data if you need it afterward.
+ */
+export function pdfToImages(
+  pdfBytes: Uint8Array,
+  opts: PdfToImagesOptions & { color: 'gray' }
+): AsyncIterable<PdfPage<GrayImageData>>;
+
+/**
+ * Renders PDF pages as images. This function consumes the data source, leaving
+ * the caller with an empty `Uint8Array` when this function resolves. Be sure to
+ * clone the data if you need it afterward.
+ */
+export function pdfToImages(
+  pdfBytes: Uint8Array,
+  opts?: PdfToImagesOptions
+): AsyncIterable<PdfPage>;
+
+/**
+ * Renders PDF pages as images. This function consumes the data source, leaving
+ * the caller with an empty `Uint8Array` when this function resolves. Be sure to
+ * clone the data if you need it afterward.
  */
 export async function* pdfToImages(
   pdfBytes: Uint8Array,
   opts: PdfToImagesOptions = {}
-): AsyncIterable<PdfPage> {
-  const { background, scale = 1 } = opts;
+): AsyncIterable<PdfPage<RgbaImageData | GrayImageData>> {
+  const { background, color, scale = 1 } = opts;
   const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
   const canvas = createCanvas(0, 0);
   const context = canvas.getContext('2d');
@@ -78,7 +106,10 @@ export async function* pdfToImages(
     yield {
       pageCount: pdf.numPages,
       pageNumber: i,
-      page: new ImageData(data, width, height),
+      page:
+        color === 'gray'
+          ? toGrayScale(data, width, height)
+          : createImageData(data, width, height),
     };
   }
 }

--- a/libs/image-utils/src/test_utils.ts
+++ b/libs/image-utils/src/test_utils.ts
@@ -1,9 +1,9 @@
-import { ImageData } from 'canvas';
+import { createImageData } from './image_data';
 
 /**
  * ImageData for a 1x1 image for use in tests that mock a blank page.
  */
-export const BLANK_PAGE_IMAGE_DATA = new ImageData(
+export const BLANK_PAGE_IMAGE_DATA = createImageData(
   new Uint8ClampedArray([0, 0, 0, 255]),
   1,
   1

--- a/libs/image-utils/test/arbitraries.ts
+++ b/libs/image-utils/test/arbitraries.ts
@@ -1,8 +1,7 @@
 import { assert } from '@votingworks/basics';
-import { Rect } from '@votingworks/types';
-import { createImageData, ImageData } from 'canvas';
+import { Rect, RgbaImageData } from '@votingworks/types';
 import fc from 'fast-check';
-import { int, RGBA_CHANNEL_COUNT } from '../src/index';
+import { createImageData, int, RGBA_CHANNEL_COUNT } from '../src/index';
 import { assertInteger } from '../src/numeric';
 
 /**
@@ -15,13 +14,13 @@ export interface ArbitraryImageDataOptions {
 }
 
 /**
- * Builds an arbitrary `ImageData` object based on the given parameters.
+ * Builds an arbitrary `RgbaImageData` object based on the given parameters.
  */
 export function arbitraryImageData({
   width: arbitraryWidth = fc.integer({ min: 1, max: 20 }),
   height: arbitraryHeight = fc.integer({ min: 1, max: 20 }),
   pixels: arbitraryPixels = fc.integer({ min: 0, max: 255 }),
-}: ArbitraryImageDataOptions = {}): fc.Arbitrary<ImageData> {
+}: ArbitraryImageDataOptions = {}): fc.Arbitrary<RgbaImageData> {
   return fc
     .record({
       width:

--- a/libs/image-utils/test/setupTests.ts
+++ b/libs/image-utils/test/setupTests.ts
@@ -2,7 +2,7 @@ import {
   clearTemporaryRootDir,
   setupTemporaryRootDir,
 } from '@votingworks/fixtures';
-import { ImageData } from 'canvas';
+import { RgbaImageData } from '@votingworks/types';
 import { afterAll, beforeAll, expect } from 'vitest';
 import { toMatchImage, ToMatchImageOptions } from '../src';
 
@@ -12,7 +12,7 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Matchers<R> {
       toMatchImage(
-        expected: ImageData,
+        expected: RgbaImageData,
         options?: ToMatchImageOptions
       ): Promise<CustomMatcherResult>;
     }

--- a/libs/integration-test-utils/src/ballots.ts
+++ b/libs/integration-test-utils/src/ballots.ts
@@ -19,9 +19,9 @@ import {
   getContests,
   LATEST_SOFTWARE_VERSION,
   straightPartyNotYetImplemented,
+  RgbaImageData,
 } from '@votingworks/types';
 import {
-  ImageData,
   createImageData,
   pdfToImages,
   writeImageData,
@@ -104,7 +104,8 @@ export function withOvervote(
   const current = votes[contest.id] as CandidateContest['candidates'];
   const currentIds = new Set(current.map((c) => c.id));
   const extra = contest.candidates.find((c) => !currentIds.has(c.id));
-  if (!extra) throw new Error(`No extra candidate to overvote in ${contest.id}`);
+  if (!extra)
+    throw new Error(`No extra candidate to overvote in ${contest.id}`);
   return { ...votes, [contest.id]: [...current, extra] };
 }
 
@@ -219,7 +220,7 @@ export async function renderMarkedBallot(
  * a folded-over ("dog-eared") corner that obscures the timing marks there.
  * Equal-length legs give a natural 45° fold line. */
 function drawFoldedCorner(
-  image: ImageData,
+  image: RgbaImageData,
   corner: 'top-left' | 'top-right'
 ): void {
   const { width, data } = image;
@@ -249,7 +250,7 @@ export async function renderFoldedCornerSheet(
   const pdfBytes = new Uint8Array(readFileSync(ballotPdfPath));
   // Rasterize at roughly the scanner's 200 DPI. Only the front and back are
   // needed, so stop after two pages.
-  const pageImages: ImageData[] = [];
+  const pageImages: RgbaImageData[] = [];
   for await (const { page } of pdfToImages(pdfBytes, { scale: 200 / 72 })) {
     pageImages.push(page);
     if (pageImages.length === 2) break;

--- a/libs/integration-test-utils/src/cast_vote_records.ts
+++ b/libs/integration-test-utils/src/cast_vote_records.ts
@@ -10,7 +10,7 @@ import {
 } from '@votingworks/backend';
 import { interpretSheetAndSaveImages } from '@votingworks/ballot-interpreter';
 import { type MarginalMark } from '@votingworks/hmpb';
-import { pdfToImages, type ImageData } from '@votingworks/image-utils';
+import { pdfToImages } from '@votingworks/image-utils';
 import {
   AdjudicationReason,
   anyPollingPlace,
@@ -31,6 +31,7 @@ import {
   SheetOf,
   unsafeParse,
   VotesDict,
+  RgbaImageData,
 } from '@votingworks/types';
 import { createHash, randomUUID } from 'node:crypto';
 import { Buffer } from 'node:buffer';
@@ -99,7 +100,7 @@ async function renderInterpretAndWriteCvr({
   castVoteRecordDirectory: string;
 }): Promise<CVR.CVR> {
   const pdfBytes = new Uint8Array(await fs.readFile(pdfPath));
-  const pageImages: ImageData[] = [];
+  const pageImages: RgbaImageData[] = [];
   for await (const { page } of pdfToImages(pdfBytes, { scale: 200 / 72 })) {
     pageImages.push(page);
     if (pageImages.length === 2) break;
@@ -111,7 +112,7 @@ async function renderInterpretAndWriteCvr({
     pageImages.length === 2,
     `expected a 2-page (single-sheet) ballot, got ${pageImages.length} page(s)`
   );
-  const sheet: SheetOf<ImageData> = [
+  const sheet: SheetOf<RgbaImageData> = [
     assertDefined(pageImages[0]),
     assertDefined(pageImages[1]),
   ];

--- a/libs/pdi-scanner/src/ts/mock_file_scanner.ts
+++ b/libs/pdi-scanner/src/ts/mock_file_scanner.ts
@@ -1,10 +1,6 @@
 import { iter } from '@votingworks/basics';
-import {
-  ImageData,
-  RGBA_CHANNEL_COUNT,
-  pdfToImages,
-} from '@votingworks/image-utils';
-import { asSheet, SheetOf } from '@votingworks/types';
+import { createGrayImageData, pdfToImages } from '@votingworks/image-utils';
+import { asSheet, GrayImageData, SheetOf } from '@votingworks/types';
 import {
   existsSync,
   mkdirSync,
@@ -30,48 +26,12 @@ const MOCK_STATE_DIR = join(
 );
 const COMMAND_FILE = join(MOCK_STATE_DIR, 'command.json');
 
-/**
- * Reshapes RGBA image data into the grayscale (one byte per pixel) image data
- * the real scanner client emits (see `scanner_client.ts`), so that mock scans
- * exercise the same downstream image handling as real hardware.
- */
-function toGrayscaleImageData({ width, height, data }: ImageData): ImageData {
-  const pixels = new Uint8ClampedArray(width * height);
-  for (let i = 0; i < pixels.length; i += 1) {
-    pixels[i] = data[i * RGBA_CHANNEL_COUNT] as number;
-  }
-  return grayscaleImageData(width, height, pixels);
-}
-
-function blankGrayscalePage(width: number, height: number): ImageData {
-  return grayscaleImageData(
+function blankGrayscalePage(width: number, height: number): GrayImageData {
+  return createGrayImageData(
+    new Uint8ClampedArray(width * height).fill(0xff),
     width,
-    height,
-    new Uint8ClampedArray(width * height).fill(0xff)
+    height
   );
-}
-
-interface LoggableImageData extends ImageData {
-  toJSON(): string;
-}
-
-function grayscaleImageData(
-  width: number,
-  height: number,
-  data: Uint8ClampedArray
-): ImageData {
-  const image: LoggableImageData = {
-    width,
-    height,
-    data,
-
-    // Define `toJSON` such that `JSON.stringify` does not try to serialize
-    // all the bytes in `data` as an array of numbers, matching the real
-    // scanner client (see `scanner_client.ts`).
-    // eslint-disable-next-line vx/gts-identifiers
-    toJSON: () => `[ImageData ${width}x${height}]`,
-  };
-  return image;
 }
 
 type Command =
@@ -166,14 +126,13 @@ export function createMockFilePdiScanner(): MockScanner {
           }, 50);
         });
         for await (const sheet of iter(
-          pdfToImages(pdfData, { scale: 200 / 72 })
+          pdfToImages(pdfData, { scale: 200 / 72, color: 'gray' })
         )
-          .map(({ page }: { page: ImageData }) => toGrayscaleImageData(page))
           .chunks(2)
-          .map((pages: [ImageData] | [ImageData, ImageData]) => {
-            const front = pages[0];
+          .map((pages) => {
+            const front = pages[0].page;
             const back =
-              pages[1] ?? blankGrayscalePage(front.width, front.height);
+              pages[1]?.page ?? blankGrayscalePage(front.width, front.height);
             return asSheet([front, back]);
           })) {
           inner.insertSheet(sheet);
@@ -194,7 +153,7 @@ export function createMockFilePdiScanner(): MockScanner {
     get client() {
       return inner.client;
     },
-    insertSheet(images: SheetOf<ImageData>): void {
+    insertSheet(images: SheetOf<GrayImageData>): void {
       inner.insertSheet(images);
     },
     removeSheet(): void {

--- a/libs/pdi-scanner/src/ts/mock_scanner.test.ts
+++ b/libs/pdi-scanner/src/ts/mock_scanner.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test } from 'vitest';
 import { err, ok } from '@votingworks/basics';
-import { createImageData } from '@votingworks/image-utils';
+import { createGrayImageData } from '@votingworks/image-utils';
 import { asSheet } from '@votingworks/types';
 import { backendWaitFor, mockFunction } from '@votingworks/test-utils';
 import {
@@ -10,8 +10,8 @@ import {
 } from './mock_scanner.js';
 
 const mockSheetImageDatas = asSheet([
-  createImageData(Uint8ClampedArray.from([0, 1, 0, 1]), 2, 2),
-  createImageData(Uint8ClampedArray.from([1, 0, 1, 0]), 2, 2),
+  createGrayImageData(Uint8ClampedArray.from([0, 1, 0, 1]), 2, 2),
+  createGrayImageData(Uint8ClampedArray.from([1, 0, 1, 0]), 2, 2),
 ]);
 
 async function insertAndScanSheet(mockScanner: MockScanner) {

--- a/libs/pdi-scanner/src/ts/mock_scanner.ts
+++ b/libs/pdi-scanner/src/ts/mock_scanner.ts
@@ -5,7 +5,7 @@ import {
   Assigner,
   PropertyAssigner,
 } from 'xstate';
-import { SheetOf, ImageData } from '@votingworks/types';
+import { SheetOf, GrayImageData } from '@votingworks/types';
 import { assertDefined, err, ok, sleep } from '@votingworks/basics';
 import makeDebug from 'debug';
 import {
@@ -101,7 +101,7 @@ export const mockScannerStatus = {
 } satisfies Record<string, ScannerStatus>;
 
 interface MachineContext {
-  scanImages?: SheetOf<ImageData>;
+  scanImages?: SheetOf<GrayImageData>;
 }
 
 type MachineEvent =
@@ -110,7 +110,7 @@ type MachineEvent =
   | { type: 'ENABLE_SCANNING' }
   | { type: 'DISABLE_SCANNING' }
   | { type: 'EJECT_DOCUMENT'; motion: EjectMotion }
-  | { type: 'INSERT_SHEET'; images: SheetOf<ImageData> }
+  | { type: 'INSERT_SHEET'; images: SheetOf<GrayImageData> }
   | { type: 'REMOVE_SHEET' };
 
 function assign(
@@ -137,7 +137,7 @@ export type MockSheetStatus =
  */
 export interface MockScanner {
   client: ScannerClient;
-  insertSheet(images: SheetOf<ImageData>): void;
+  insertSheet(images: SheetOf<GrayImageData>): void;
   removeSheet(): void;
   getSheetStatus(): MockSheetStatus;
   cleanup(): Promise<void>;
@@ -431,7 +431,7 @@ export function createMockPdiScanner(
   return {
     client,
 
-    insertSheet(images: SheetOf<ImageData>) {
+    insertSheet(images: SheetOf<GrayImageData>) {
       mockScanner.send({ type: 'INSERT_SHEET', images });
     },
 

--- a/libs/pdi-scanner/src/ts/scanner_client.ts
+++ b/libs/pdi-scanner/src/ts/scanner_client.ts
@@ -9,9 +9,9 @@ import {
   ok,
   throwIllegalValue,
 } from '@votingworks/basics';
-import { ImageData } from '@votingworks/image-utils';
 import { Buffer } from 'node:buffer';
-import { SheetOf } from '@votingworks/types';
+import { GrayImageData, SheetOf } from '@votingworks/types';
+import { createGrayImageData } from '@votingworks/image-utils';
 import makeDebug from 'debug';
 
 const debug = makeDebug('pdi-scanner');
@@ -130,7 +130,7 @@ export type ScannerEvent =
   | { event: 'scanStart' }
   | {
       event: 'scanComplete';
-      images: SheetOf<ImageData>;
+      images: SheetOf<GrayImageData>;
     }
   | { event: 'coverOpen' }
   | { event: 'coverClosed' }
@@ -254,7 +254,7 @@ function isResponse(message: PdictlMessage): message is PdictlResponse {
  * scanned page images. The image data is a zero-copy view over the payload's
  * memory.
  */
-function parseScanCompletePayload(payload: Buffer): SheetOf<ImageData> {
+function parseScanCompletePayload(payload: Buffer): SheetOf<GrayImageData> {
   let offset = 0;
   function readImage() {
     const width = payload.readUInt32LE(offset);
@@ -266,18 +266,9 @@ function parseScanCompletePayload(payload: Buffer): SheetOf<ImageData> {
       byteLength
     );
     offset += IMAGE_DIMENSIONS_LENGTH + byteLength;
-    return {
-      width,
-      height,
-      data,
-
-      // Define `toJSON` such that `JSON.stringify` does not try to
-      // serialize all the bytes in `data` as an array of numbers.
-      // eslint-disable-next-line vx/gts-identifiers
-      toJSON: () => `[ImageData ${width}x${height}]`,
-    };
+    return createGrayImageData(data, width, height);
   }
-  const images: SheetOf<ImageData> = [readImage(), readImage()];
+  const images: SheetOf<GrayImageData> = [readImage(), readImage()];
   assert(
     offset === payload.length,
     `scanComplete payload length mismatch: expected ${offset}, got ${payload.length}`

--- a/libs/types/src/image.ts
+++ b/libs/types/src/image.ts
@@ -10,3 +10,11 @@ export const ImageDataSchema: z.ZodSchema<ImageData> = z.object({
   height: z.number().nonnegative(),
   data: z.instanceof(Uint8ClampedArray),
 });
+
+export const RgbaImageData = ImageDataSchema.brand('RgbaImageData');
+
+export interface RgbaImageData extends z.infer<typeof RgbaImageData> {}
+
+export const GrayImageData = ImageDataSchema.brand('GrayImageData');
+
+export interface GrayImageData extends z.infer<typeof GrayImageData> {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,9 +567,6 @@ importers:
       '@votingworks/utils':
         specifier: workspace:*
         version: link:../../../libs/utils
-      canvas:
-        specifier: 3.2.3
-        version: 3.2.3
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@5.5.0)


### PR DESCRIPTION
## Overview
We use `ImageData` to contain both RGBA data and grayscale data. This causes problems when passing one where the other is expected, but the type system was not helping us out to keep the two straight. This introduces two branded aliases for `ImageData`—`RgbaImageData` and `GrayImageData`—that are mutually-unassignable so we get type errors when we get it wrong.

This PR then replaces most `ImageData` uses with the branded types. I added `createImageData` and `createGrayImageData` to wrap `canvas.createImageData`, adding a `toJSON` method that prevents serializing pixel data. Notably, this mostly doesn't change anything to what it _should_ be but only annotates what it currently _is_, with the exceptions being in tests and the dev dock. I plan to change some RGBA images that should be grayscale to actually be grayscale in follow-up commits.

## Testing Plan
`tsc` and automated tests.