### PR TITLE
VxCentralScan: Refactors and cleanup unlocked by state machine refactor

### DIFF
--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -51,12 +51,6 @@ create table sheets (
   front_interpretation_json text not null,
   back_interpretation_json text not null,
 
-  -- Did this sheet require adjudication? This value should never be updated.
-  requires_adjudication integer,
-
-  -- When adjudication is finished, this value is updated to now.
-  finished_adjudication_at text,
-
   created_at text default current_timestamp not null,
   deleted_at text,
 

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -172,7 +172,7 @@ test('unconfigure', async () => {
     await apiClient.setTestMode({ testMode: false });
 
     const batchId = store.addBatch();
-    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.addSheet(uuid(), batchId, sheet);
     store.finishBatch({ batchId });
     expect(store.getBallotsCounted()).toEqual(1);
 
@@ -211,7 +211,7 @@ test('unconfigure w/ ignoreBackupRequirement', async () => {
     await apiClient.setTestMode({ testMode: false });
 
     const batchId = store.addBatch();
-    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.addSheet(uuid(), batchId, sheet);
     store.finishBatch({ batchId });
     expect(store.getBallotsCounted()).toEqual(1);
 
@@ -235,7 +235,7 @@ test('retrySendBatchToAdmin clears a batch send failure', async () => {
     store.setPollingPlaceId(anyPollingPlace(electionDefinition.election).id);
 
     const batchId = store.addBatch();
-    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.addSheet(uuid(), batchId, sheet);
     store.finishBatch({ batchId });
     store.setBatchSendToAdminError(batchId, 'sending failed');
     expect(store.getBatch(batchId).sendToAdminError).toEqual('sending failed');
@@ -261,7 +261,7 @@ test('resendBatchToAdmin queues a sent batch to be sent again', async () => {
     store.setPollingPlaceId(anyPollingPlace(electionDefinition.election).id);
 
     const batchId = store.addBatch();
-    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.addSheet(uuid(), batchId, sheet);
     store.finishBatch({ batchId });
     store.setBatchSentToAdmin(batchId);
     expect(store.getNextBatchToSendToAdmin()).toBeUndefined();
@@ -292,7 +292,7 @@ test('clearing scanning data', async () => {
     await apiClient.setTestMode({ testMode: false });
 
     const batchId = store.addBatch();
-    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.addSheet(uuid(), batchId, sheet);
     store.finishBatch({ batchId });
     expect(store.getBallotsCounted()).toEqual(1);
 
@@ -361,7 +361,7 @@ test('getting / setting test mode', async () => {
     expect(await apiClient.getTestMode()).toEqual(false);
 
     const batchId = store.addBatch();
-    store.addSheet(electionDefinition.election, uuid(), batchId, sheet);
+    store.addSheet(uuid(), batchId, sheet);
     store.finishBatch({ batchId });
     expect(store.getBallotsCounted()).toEqual(1);
 
@@ -638,7 +638,7 @@ test('getSheetForReview returns interpretation and image data for uninterpretabl
 
     const batchId = workspace.store.addBatch();
     const sheetId = uuid();
-    workspace.store.addSheet(electionDefinition.election, sheetId, batchId, [
+    workspace.store.addSheet(sheetId, batchId, [
       { imagePath: frontImagePath, interpretation: { type: 'BlankPage' } },
       { imagePath: backImagePath, interpretation: { type: 'BlankPage' } },
     ]);
@@ -720,7 +720,7 @@ test('getSheetForReview returns interpretation, image data, and layouts for inte
     const backPage = buildHmpbPage(2);
 
     const sheetId = uuid();
-    workspace.store.addSheet(electionDefinition.election, sheetId, batchId, [
+    workspace.store.addSheet(sheetId, batchId, [
       { imagePath: frontImagePath, interpretation: frontPage },
       { imagePath: backImagePath, interpretation: backPage },
     ]);

--- a/apps/central-scan/backend/src/app.grout.test.ts
+++ b/apps/central-scan/backend/src/app.grout.test.ts
@@ -624,13 +624,7 @@ test('configure with invalid file', async () => {
   });
 });
 
-test('get next sheet returns null when no adjudication sheet', async () => {
-  await withApp(async ({ apiClient }) => {
-    expect(await apiClient.getNextReviewSheet()).toBeNull();
-  });
-});
-
-test('getNextReviewSheet returns interpretation and image data for uninterpretable sheets', async () => {
+test('getSheetForReview returns interpretation and image data for uninterpretable sheets', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
 
@@ -643,20 +637,20 @@ test('getNextReviewSheet returns interpretation and image data for uninterpretab
     store.setPollingPlaceId(anyPollingPlace(electionDefinition.election).id);
 
     const batchId = workspace.store.addBatch();
-    workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
+    const sheetId = uuid();
+    workspace.store.addSheet(electionDefinition.election, sheetId, batchId, [
       { imagePath: frontImagePath, interpretation: { type: 'BlankPage' } },
       { imagePath: backImagePath, interpretation: { type: 'BlankPage' } },
     ]);
     workspace.store.finishBatch({ batchId });
 
-    const result = await apiClient.getNextReviewSheet();
-    expect(result).toBeDefined();
-    expect(result!.sheetInterpretation).toEqual({
+    const result = await apiClient.getSheetForReview({ sheetId });
+    expect(result.sheetInterpretation).toEqual({
       type: 'InvalidSheet',
       reason: { type: 'unknown' },
     });
 
-    const [frontImage, backImage] = result!.images;
+    const [frontImage, backImage] = result.images;
     for (const image of [frontImage, backImage]) {
       expect(image).toMatchObject({
         imageUrl: expect.stringMatching(/^data:image\//),
@@ -673,7 +667,7 @@ test('getNextReviewSheet returns interpretation and image data for uninterpretab
   });
 });
 
-test('getNextReviewSheet returns interpretation, image data, and layouts for interpretable sheets', async () => {
+test('getSheetForReview returns interpretation, image data, and layouts for interpretable sheets', async () => {
   const electionDefinition =
     electionGridLayoutNewHampshireTestBallotFixtures.readElectionDefinition();
 
@@ -725,18 +719,19 @@ test('getNextReviewSheet returns interpretation, image data, and layouts for int
     const frontPage = buildHmpbPage(1, [overvoteReason]);
     const backPage = buildHmpbPage(2);
 
-    workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
+    const sheetId = uuid();
+    workspace.store.addSheet(electionDefinition.election, sheetId, batchId, [
       { imagePath: frontImagePath, interpretation: frontPage },
       { imagePath: backImagePath, interpretation: backPage },
     ]);
     workspace.store.finishBatch({ batchId });
 
-    const result = await apiClient.getNextReviewSheet();
-    expect(result!.sheetInterpretation).toEqual({
+    const result = await apiClient.getSheetForReview({ sheetId });
+    expect(result.sheetInterpretation).toEqual({
       type: 'NeedsReviewSheet',
       reasons: [overvoteReason],
     });
-    const [frontImage, backImage] = result!.images;
+    const [frontImage, backImage] = result.images;
     expect(frontImage.layout).toEqual(frontPage.layout);
     expect(backImage.layout).toEqual(backPage.layout);
   });

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -27,6 +27,16 @@ import { ScannedSheetInfo } from './fujitsu_scanner.js';
 
 const jurisdiction = TEST_JURISDICTION;
 
+const ANY_BALLOT_IMAGE = {
+  imageUrl: expect.stringMatching(/^data:image\//),
+  ballotBounds: {
+    x: 0,
+    y: 0,
+    width: expect.any(Number),
+    height: expect.any(Number),
+  },
+} as const;
+
 vi.setConfig({ testTimeout: 20000 });
 
 const featureFlagMock = getFeatureFlagMock();
@@ -113,7 +123,16 @@ test('continueScanning after invalid ballot', async () => {
       .end();
 
     await apiClient.scanBatch();
-    await waitForStatus(apiClient, { state: 'needsReview' });
+    const { sheetId } = await waitForStatus(apiClient, {
+      state: 'needsReview',
+    });
+    expect(await apiClient.getSheetForReview({ sheetId })).toEqual({
+      sheetInterpretation: {
+        type: 'InvalidSheet',
+        reason: { type: 'unreadable' },
+      },
+      images: [ANY_BALLOT_IMAGE, ANY_BALLOT_IMAGE],
+    });
     {
       const status = await apiClient.getStatus();
       expect(status.canUnconfigure).toEqual(true);
@@ -200,14 +219,19 @@ test('scanBatch with streaked page', async () => {
     scanner.withNextScannerSession().sheet(scannedBallot).end();
 
     await apiClient.scanBatch();
-    await waitForStatus(apiClient, { state: 'needsReview' });
-
-    const nextAdjudicationSheet = workspace.store.getNextAdjudicationSheet();
+    const { sheetId } = await waitForStatus(apiClient, {
+      state: 'needsReview',
+    });
+    expect(
+      (await apiClient.getSheetForReview({ sheetId })).sheetInterpretation
+    ).toEqual({
+      type: 'InvalidSheet',
+      reason: { type: 'vertical_streaks_detected' },
+    });
 
     // adjudication should be needed because of the vertical streak
-    expect(nextAdjudicationSheet?.pages[0]).toMatchObject<
-      Partial<PageInterpretation>
-    >({
+    const [frontPage] = workspace.store.getSheetInterpretation(sheetId);
+    expect(frontPage).toMatchObject<Partial<PageInterpretation>>({
       type: 'UnreadablePage',
       reason: 'verticalStreaksDetected',
     });
@@ -235,7 +259,7 @@ test('scanBatch with streaked page', async () => {
     await waitForStatus(apiClient, { state: 'idle' });
 
     // no adjudication should be needed
-    expect(workspace.store.getNextAdjudicationSheet()).toBeUndefined();
+    expect(workspace.store.getBallotsCounted()).toEqual(1);
   });
 });
 
@@ -273,11 +297,28 @@ test('accepting a sheet that needs review keeps it and continues scanning', asyn
     scanner.withNextScannerSession().sheet({ frontPath, backPath }).end();
 
     await apiClient.scanBatch();
-    await waitForStatus(apiClient, { state: 'needsReview' });
-    expect(workspace.store.getNextAdjudicationSheet()?.pages[0]).toMatchObject({
-      adjudicationInfo: expect.objectContaining({
-        enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
-      }),
+    const { sheetId } = await waitForStatus(apiClient, {
+      state: 'needsReview',
+    });
+    expect(await apiClient.getSheetForReview({ sheetId })).toEqual({
+      sheetInterpretation: {
+        type: 'NeedsReviewSheet',
+        reasons: [{ type: AdjudicationReason.BlankBallot }],
+      },
+      images: [
+        {
+          ...ANY_BALLOT_IMAGE,
+          layout: expect.objectContaining({
+            metadata: expect.objectContaining({ pageNumber: 1 }),
+          }),
+        },
+        {
+          ...ANY_BALLOT_IMAGE,
+          layout: expect.objectContaining({
+            metadata: expect.objectContaining({ pageNumber: 2 }),
+          }),
+        },
+      ],
     });
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ScannerEvent,
@@ -287,6 +328,16 @@ test('accepting a sheet that needs review keeps it and continues scanning', asyn
           /^Event: done\.invoke\..*interpretingSheet/
         ),
         eventObject: expect.stringContaining('"reasons":["BlankBallot"]'),
+      }),
+      expect.any(Function)
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      LogEventId.ScannerStateChanged,
+      'system',
+      expect.objectContaining({
+        changedFields: expect.stringContaining(
+          `"sheetIdToReview":"${sheetId}"`
+        ),
       }),
       expect.any(Function)
     );
@@ -326,10 +377,18 @@ test('rejects ballots whose precinct is not in the selected polling place', asyn
     scanner.withNextScannerSession().sheet(scannedBallot).end();
 
     await apiClient.scanBatch();
-    await waitForStatus(apiClient, { state: 'needsReview' });
+    const { sheetId } = await waitForStatus(apiClient, {
+      state: 'needsReview',
+    });
+    expect(
+      (await apiClient.getSheetForReview({ sheetId })).sheetInterpretation
+    ).toEqual({
+      type: 'InvalidSheet',
+      reason: { type: 'invalid_precinct' },
+    });
 
-    const nextAdjudicationSheet = workspace.store.getNextAdjudicationSheet();
-    expect(nextAdjudicationSheet?.pages[0]).toMatchObject({
+    const [frontPage] = workspace.store.getSheetInterpretation(sheetId);
+    expect(frontPage).toMatchObject({
       type: 'InvalidPrecinctPage',
       metadata: expect.objectContaining({ precinctId: '23' }),
     });

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -96,7 +96,7 @@ test('scanBatch with multiple sheets', async () => {
   });
 });
 
-test('continueScanning after invalid ballot', async () => {
+test('rejectSheet after invalid ballot', async () => {
   const electionDefinition =
     electionFamousNames2021Fixtures.readElectionDefinition();
   const bmdFixture = await generateBmdBallotFixture();
@@ -147,7 +147,7 @@ test('continueScanning after invalid ballot', async () => {
         pollingPlaceId: 'central-scanning',
       });
     }
-    await apiClient.continueScanning({ forceAccept: false });
+    await apiClient.rejectSheet();
     await waitForStatus(apiClient, { state: 'idle' });
     {
       const status = await apiClient.getStatus();
@@ -342,7 +342,7 @@ test('accepting a sheet that needs review keeps it and continues scanning', asyn
       expect.any(Function)
     );
 
-    await apiClient.continueScanning({ forceAccept: true });
+    await apiClient.acceptSheet();
     await waitForStatus(apiClient, { state: 'idle' });
 
     const status = await apiClient.getStatus();

--- a/apps/central-scan/backend/src/app.scanning.test.ts
+++ b/apps/central-scan/backend/src/app.scanning.test.ts
@@ -72,7 +72,6 @@ test('scanBatch with multiple sheets', async () => {
     await waitForStatus(apiClient, { state: 'idle' });
 
     const status = await apiClient.getStatus();
-    expect(status.adjudicationsRemaining).toEqual(0);
     expect(status.canUnconfigure).toEqual(true);
     expect(status.batches.length).toEqual(1);
     expect(status.batches[0]).toEqual<BatchInfo>({
@@ -117,7 +116,6 @@ test('continueScanning after invalid ballot', async () => {
     await waitForStatus(apiClient, { state: 'needsReview' });
     {
       const status = await apiClient.getStatus();
-      expect(status.adjudicationsRemaining).toEqual(1);
       expect(status.canUnconfigure).toEqual(true);
       expect(status.batches.length).toEqual(1);
       expect(status.batches[0]).toEqual<BatchInfo>({
@@ -134,7 +132,6 @@ test('continueScanning after invalid ballot', async () => {
     await waitForStatus(apiClient, { state: 'idle' });
     {
       const status = await apiClient.getStatus();
-      expect(status.adjudicationsRemaining).toEqual(0);
       expect(status.canUnconfigure).toEqual(true);
       expect(status.batches.length).toEqual(1);
       expect(status.batches[0]).toEqual<BatchInfo>({
@@ -282,7 +279,6 @@ test('accepting a sheet that needs review keeps it and continues scanning', asyn
         enabledReasonInfos: [{ type: AdjudicationReason.BlankBallot }],
       }),
     });
-    expect((await apiClient.getStatus()).adjudicationsRemaining).toEqual(1);
     expect(logger.log).toHaveBeenCalledWith(
       LogEventId.ScannerEvent,
       'system',
@@ -299,7 +295,6 @@ test('accepting a sheet that needs review keeps it and continues scanning', asyn
     await waitForStatus(apiClient, { state: 'idle' });
 
     const status = await apiClient.getStatus();
-    expect(status.adjudicationsRemaining).toEqual(0);
     expect(status.batches).toEqual([
       expect.objectContaining({ count: 1, endedAt: expect.any(String) }),
     ]);

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -283,29 +283,24 @@ function buildApi({
       machine.startBatch();
     },
 
-    async getNextReviewSheet(): Promise<{
+    async getSheetForReview(input: { sheetId: string }): Promise<{
       sheetInterpretation: SheetInterpretation;
       images: SheetOf<BallotImage>;
-    } | null> {
-      const sheet = store.getNextAdjudicationSheet();
-
-      if (!sheet) {
-        return null;
-      }
-
+    }> {
       const { election } = assertDefined(
         store.getElectionRecord()
       ).electionDefinition;
+      const pageInterpretations = store.getSheetInterpretation(input.sheetId);
       const sheetInterpretation = combinePageInterpretationsForSheet(
-        sheet.pages,
+        pageInterpretations,
         election
       );
 
       const images = await mapSheet(
-        sheet.pages,
+        pageInterpretations,
         async (interpretation, side): Promise<BallotImage> => {
           const imagePath = assertDefined(
-            store.getBallotImagePath(sheet.id, side)
+            store.getBallotImagePath(input.sheetId, side)
           );
           const imageBuffer = await readFile(imagePath);
           const metadata = (

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -274,7 +274,6 @@ function buildApi({
     getStatus(): ScanStatus {
       return {
         ...machine.status(),
-        adjudicationsRemaining: store.adjudicationsRemaining(),
         batches: store.getBatches(),
         canUnconfigure: store.getCanUnconfigure(),
       };

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -328,12 +328,12 @@ function buildApi({
       };
     },
 
-    continueScanning(input: { forceAccept: boolean }): void {
-      if (input.forceAccept) {
-        machine.acceptSheet();
-      } else {
-        machine.rejectSheet();
-      }
+    acceptSheet(): void {
+      machine.acceptSheet();
+    },
+
+    rejectSheet(): void {
+      machine.rejectSheet();
     },
 
     async unconfigure(

--- a/apps/central-scan/backend/src/app.ts
+++ b/apps/central-scan/backend/src/app.ts
@@ -274,7 +274,6 @@ function buildApi({
     getStatus(): ScanStatus {
       return {
         ...machine.status(),
-        isScannerAttached: scanner.isAttached(),
         adjudicationsRemaining: store.adjudicationsRemaining(),
         batches: store.getBatches(),
         canUnconfigure: store.getCanUnconfigure(),

--- a/apps/central-scan/backend/src/cvr_sync.test.ts
+++ b/apps/central-scan/backend/src/cvr_sync.test.ts
@@ -157,12 +157,7 @@ function addFinishedBatch(store: Store, sheetCount = 1): string {
       copyPage(sheet[0], 0),
       copyPage(sheet[1], 1),
     ];
-    store.addSheet(
-      vxFamousNamesFixtures.electionDefinition.election,
-      uuid(),
-      batchId,
-      sheetCopy
-    );
+    store.addSheet(uuid(), batchId, sheetCopy);
   }
   store.finishBatch({ batchId });
   return batchId;

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -213,7 +213,6 @@ test('ballots printed with invalid scale are rejected', async () => {
       const status = await apiClient.getStatus();
       expect(status.batches.length).toEqual(1);
       expect(status.batches[0].count).toEqual(1);
-      expect(status.adjudicationsRemaining).toEqual(1);
 
       // Reject the ballot
       await apiClient.continueScanning({ forceAccept: false });

--- a/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
+++ b/apps/central-scan/backend/src/end_to_end_hmpb.test.ts
@@ -215,7 +215,7 @@ test('ballots printed with invalid scale are rejected', async () => {
       expect(status.batches[0].count).toEqual(1);
 
       // Reject the ballot
-      await apiClient.continueScanning({ forceAccept: false });
+      await apiClient.rejectSheet();
     }
 
     {

--- a/apps/central-scan/backend/src/scanner.ts
+++ b/apps/central-scan/backend/src/scanner.ts
@@ -278,12 +278,11 @@ function buildMachine({
     ) {
       pages = [pages[1], pages[0]];
     }
-    store.addSheet(election, sheetId, batchId, pages, sheet.ballotAuditId);
-
-    const interpretations = mapSheet(
-      pages,
-      ({ interpretation }) => interpretation
+    const sheetInterpretation = combinePageInterpretationsForSheet(
+      mapSheet(pages, ({ interpretation }) => interpretation),
+      election
     );
+    store.addSheet(sheetId, batchId, pages, sheet.ballotAuditId);
 
     debug(
       'imported sheet %o for batch %s in %dms',
@@ -291,13 +290,7 @@ function buildMachine({
       batchId,
       Date.now() - start
     );
-    return {
-      sheetId,
-      interpretation: combinePageInterpretationsForSheet(
-        interpretations,
-        election
-      ),
-    };
+    return { sheetId, interpretation: sheetInterpretation };
   }
 
   async function finishBatch({
@@ -456,11 +449,7 @@ function buildMachine({
 
       sheetNeedsReview: {
         on: {
-          ACCEPT_SHEET: {
-            target: 'scanningSheet',
-            actions: (context) =>
-              store.adjudicateSheet(assertDefined(context.sheetIdToReview)),
-          },
+          ACCEPT_SHEET: 'scanningSheet',
           REJECT_SHEET: {
             target: 'scanningSheet',
             actions: (context) =>

--- a/apps/central-scan/backend/src/scanner.ts
+++ b/apps/central-scan/backend/src/scanner.ts
@@ -594,7 +594,7 @@ export function createBatchScannerStateMachine({
   return {
     status(): BatchScannerMachineStatus {
       const { state } = machineService;
-      const { batchId, error } = state.context;
+      const { batchId, sheetIdToReview, error } = state.context;
       // We use state.matches as recommended by the XState docs. This allows
       // us to add new substates to a state without breaking these checks.
       if (state.matches('disconnected')) {
@@ -614,7 +614,11 @@ export function createBatchScannerStateMachine({
         return { state: 'scanning', batchId: assertDefined(batchId) };
       }
       if (state.matches('sheetNeedsReview')) {
-        return { state: 'needsReview', batchId: assertDefined(batchId) };
+        return {
+          state: 'needsReview',
+          batchId: assertDefined(batchId),
+          sheetId: assertDefined(sheetIdToReview),
+        };
       }
       // @coverage-exclude
       throw new Error(`Unexpected state: ${JSON.stringify(state.value)}`);

--- a/apps/central-scan/backend/src/scripts/copy_batch.ts
+++ b/apps/central-scan/backend/src/scripts/copy_batch.ts
@@ -7,7 +7,7 @@ import {
   assertDefined,
   extractErrorMessage,
 } from '@votingworks/basics';
-import { Election, Id, safeParseInt } from '@votingworks/types';
+import { Id, safeParseInt } from '@votingworks/types';
 
 import { BaseLogger, LogSource } from '@votingworks/logging';
 import { getScanWorkspace } from '../globals.js';
@@ -40,12 +40,7 @@ function parseCommandLineArgs(args: readonly string[]): CopyBatchInput {
   return { batchName, numCopies };
 }
 
-function copySheet(
-  store: Store,
-  election: Election,
-  sheet: AcceptedSheet,
-  newBatchId: Id
-): void {
+function copySheet(store: Store, sheet: AcceptedSheet, newBatchId: Id): void {
   const newSheetId = uuid();
   const newSheet: AcceptedSheet = {
     ...sheet,
@@ -64,7 +59,7 @@ function copySheet(
   fs.copyFileSync(sheet.frontImagePath, newSheet.frontImagePath);
   fs.copyFileSync(sheet.backImagePath, newSheet.backImagePath);
 
-  store.addSheet(election, newSheetId, newSheet.batchId, [
+  store.addSheet(newSheetId, newSheet.batchId, [
     {
       imagePath: newSheet.frontImagePath,
       interpretation: newSheet.interpretation[0],
@@ -102,17 +97,12 @@ function copyBatch({ batchName, numCopies }: CopyBatchInput): void {
     new BaseLogger(LogSource.VxDevelopmentScript)
   );
 
-  const { election } = assertDefined(
-    store.getElectionRecord(),
-    'Store must be configured with an election'
-  ).electionDefinition;
-
   const sheets = getAcceptedSheetsInBatch(store, batchName);
 
   for (let i = 0; i < numCopies; i += 1) {
     const newBatchId = store.addBatch();
     for (const sheet of sheets) {
-      copySheet(store, election, sheet, newBatchId);
+      copySheet(store, sheet, newBatchId);
     }
     store.finishBatch({ batchId: newBatchId });
   }

--- a/apps/central-scan/backend/src/server.test.ts
+++ b/apps/central-scan/backend/src/server.test.ts
@@ -75,7 +75,7 @@ test('logs when sheet counts are present at startup', () => {
   expect(workspace.store.getBallotsCounted()).toEqual(0);
   // Create a batch and add a sheet to it
   const batchId = workspace.store.addBatch();
-  workspace.store.addSheet(electionDefinition.election, uuid(), batchId, [
+  workspace.store.addSheet(uuid(), batchId, [
     {
       imagePath: '/tmp/front-page.png',
       interpretation: {

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -5,14 +5,12 @@ import {
   anyPollingPlace,
   BallotMetadata,
   BallotType,
-  CandidateContest,
   DEFAULT_SYSTEM_SETTINGS,
   InterpretedHmpbPage,
   mapSheet,
   PageInterpretationWithFiles,
   SheetOf,
   TEST_JURISDICTION,
-  YesNoContest,
 } from '@votingworks/types';
 import { sleep } from '@votingworks/basics';
 import { AcceptedSheet, RejectedSheet } from '@votingworks/backend';
@@ -445,114 +443,6 @@ test('canUnconfigure not in test mode', async () => {
   expect(store.getCanUnconfigure()).toEqual(true);
 });
 
-test('adjudication', () => {
-  const candidateContests = election.contests.filter(
-    (contest): contest is CandidateContest => contest.type === 'candidate'
-  );
-  const yesnoContests = election.contests.filter(
-    (contest): contest is YesNoContest => contest.type === 'yesno'
-  );
-
-  const store = Store.memoryStore();
-  store.setElectionAndJurisdiction({
-    electionData,
-    jurisdiction,
-    electionPackageHash,
-  });
-  store.setPollingPlaceId(anyPollingPlace(election).id);
-  function mockPage(i: 0 | 1): PageInterpretationWithFiles {
-    const metadata: BallotMetadata = {
-      ballotHash,
-      ballotStyleId: '12',
-      precinctId: '23',
-      isTestMode: false,
-      ballotType: BallotType.Precinct,
-    };
-    return {
-      imagePath: i === 0 ? '/front.png' : '/back.png',
-      interpretation: {
-        type: 'InterpretedHmpbPage',
-        votes: {},
-        markInfo: {
-          ballotSize: { width: 800, height: 1000 },
-          marks: [
-            {
-              type: 'candidate',
-              contestId: candidateContests[i].id,
-              optionId: candidateContests[i].candidates[0].id,
-              score: 0.06, // marginal
-              scoredOffset: { x: 0, y: 0 },
-              bounds: zeroRect,
-              target: {
-                bounds: zeroRect,
-                inner: zeroRect,
-              },
-            },
-            ...(yesnoContests[i]
-              ? ([
-                  {
-                    type: 'yesno',
-                    contestId: yesnoContests[i].id,
-                    optionId: yesnoContests[i].options[0].id,
-                    score: 1, // definite
-                    scoredOffset: { x: 0, y: 0 },
-                    bounds: zeroRect,
-                    target: {
-                      bounds: zeroRect,
-                      inner: zeroRect,
-                    },
-                  },
-                ] as const)
-              : []),
-          ],
-        },
-        metadata: {
-          ...metadata,
-          pageNumber: 1,
-        },
-        adjudicationInfo: {
-          requiresAdjudication: true,
-          enabledReasons: [AdjudicationReason.MarginalMark],
-          enabledReasonInfos: [
-            {
-              type: AdjudicationReason.MarginalMark,
-              contestId: candidateContests[i].id,
-              optionId: candidateContests[i].candidates[0].id,
-            },
-            {
-              type: AdjudicationReason.Undervote,
-              contestId: candidateContests[i].id,
-              expected: 1,
-              optionIds: [],
-            },
-          ],
-          ignoredReasonInfos: [],
-        },
-        layout: {
-          pageSize: { width: 0, height: 0 },
-          metadata: {
-            ...metadata,
-            pageNumber: 1,
-          },
-          contests: [],
-        },
-      },
-    };
-  }
-  const batchId = store.addBatch();
-  const ballotId = uuid();
-  store.addSheet(ballotId, batchId, [mockPage(0), mockPage(1)]);
-  expect(store.getSheetInterpretation(ballotId)).toEqual([
-    mockPage(0).interpretation,
-    mockPage(1).interpretation,
-  ]);
-
-  store.finishBatch({ batchId });
-
-  // cleaning up batches now should have no impact
-  store.cleanupIncompleteBatches();
-});
-
 const metadata: BallotMetadata = {
   ballotHash,
   ballotStyleId: '12',
@@ -666,6 +556,9 @@ test('iterating over sheets', () => {
   };
   expect(Array.from(store.forEachAcceptedSheet())).toEqual([expectedSheet1]);
   expect(Array.from(store.forEachSheet())).toEqual([expectedSheet1]);
+  expect(store.getSheetInterpretation(sheet1Id)).toEqual(
+    expectedSheet1.interpretation
+  );
 
   // Add and retrieve a rejected sheet
   const sheet2Id = uuid();

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -543,9 +543,10 @@ test('adjudication', () => {
   const ballotId = uuid();
   store.addSheet(election, ballotId, batchId, [mockPage(0), mockPage(1)]);
 
-  // check the review paths
-  const reviewSheet = store.getNextAdjudicationSheet();
-  expect(reviewSheet?.id).toEqual(ballotId);
+  expect(store.getSheetInterpretation(ballotId)).toEqual([
+    mockPage(0).interpretation,
+    mockPage(1).interpretation,
+  ]);
 
   store.finishBatch({ batchId });
 

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -232,7 +232,7 @@ test('getBatches', () => {
   // Create a batch and add a sheet to it
   const batchId = store.addBatch();
   const sheetId = uuid();
-  store.addSheet(election, sheetId, batchId, [
+  store.addSheet(sheetId, batchId, [
     {
       imagePath: '/tmp/front-page.png',
       interpretation: {
@@ -249,7 +249,7 @@ test('getBatches', () => {
 
   // Add a second sheet
   const sheetId2 = uuid();
-  store.addSheet(election, sheetId2, batchId, [
+  store.addSheet(sheetId2, batchId, [
     {
       imagePath: '/tmp/front-page2.png',
       interpretation: {
@@ -359,7 +359,7 @@ test('canUnconfigure not in test mode', async () => {
 
   // Cannot unconfigure after new sheet added
   const sheetId = uuid();
-  store.addSheet(election, sheetId, batchId, [
+  store.addSheet(sheetId, batchId, [
     {
       imagePath: '/tmp/front-page.png',
       interpretation: {
@@ -380,7 +380,7 @@ test('canUnconfigure not in test mode', async () => {
   // Setup second batch with second sheet
   await sleep(1000);
   const batchId2 = store.addBatch();
-  store.addSheet(election, uuid(), batchId2, [
+  store.addSheet(uuid(), batchId2, [
     {
       imagePath: '/tmp/front-page2.png',
       interpretation: {
@@ -402,7 +402,7 @@ test('canUnconfigure not in test mode', async () => {
   await sleep(1000);
   const batchId3 = store.addBatch();
   const sheetId3 = uuid();
-  store.addSheet(election, sheetId3, batchId3, [
+  store.addSheet(sheetId3, batchId3, [
     {
       imagePath: '/tmp/front-page3.png',
       interpretation: {
@@ -541,8 +541,7 @@ test('adjudication', () => {
   }
   const batchId = store.addBatch();
   const ballotId = uuid();
-  store.addSheet(election, ballotId, batchId, [mockPage(0), mockPage(1)]);
-
+  store.addSheet(ballotId, batchId, [mockPage(0), mockPage(1)]);
   expect(store.getSheetInterpretation(ballotId)).toEqual([
     mockPage(0).interpretation,
     mockPage(1).interpretation,
@@ -651,7 +650,7 @@ test('iterating over sheets', () => {
   // Add and retrieve an accepted sheet
   const batchId = store.addBatch();
   const sheet1Id = uuid();
-  store.addSheet(election, sheet1Id, batchId, [
+  store.addSheet(sheet1Id, batchId, [
     { ...sheetWithFiles[0], imagePath: '1-front.jpg' },
     { ...sheetWithFiles[1], imagePath: '1-back.jpg' },
   ]);
@@ -671,7 +670,6 @@ test('iterating over sheets', () => {
   // Add and retrieve a rejected sheet
   const sheet2Id = uuid();
   store.addSheet(
-    election,
     sheet2Id,
     batchId,
     [
@@ -705,7 +703,7 @@ test('iterating over sheets', () => {
       ignoredReasonInfos: [],
     },
   };
-  store.addSheet(election, sheet3Id, batchId, [
+  store.addSheet(sheet3Id, batchId, [
     {
       ...sheetWithFiles[0],
       imagePath: '3-front.jpg',
@@ -713,7 +711,6 @@ test('iterating over sheets', () => {
     },
     { ...sheetWithFiles[1], imagePath: '3-back.jpg' },
   ]);
-  store.adjudicateSheet(sheet3Id);
   const expectedSheet3: AcceptedSheet = {
     type: 'accepted',
     id: sheet3Id,
@@ -768,23 +765,23 @@ test('iterating over each accepted sheet includes correct batch sequence id', ()
 
   const batch1Id = store.addBatch();
   const batch1Sheet1Id = uuid();
-  store.addSheet(election, batch1Sheet1Id, batch1Id, generateSheet());
+  store.addSheet(batch1Sheet1Id, batch1Id, generateSheet());
   const batch1Sheet2Id = uuid();
-  store.addSheet(election, batch1Sheet2Id, batch1Id, generateSheet());
+  store.addSheet(batch1Sheet2Id, batch1Id, generateSheet());
   const batch1Sheet3Id = uuid();
-  store.addSheet(election, batch1Sheet3Id, batch1Id, generateSheet());
+  store.addSheet(batch1Sheet3Id, batch1Id, generateSheet());
   store.finishBatch({ batchId: batch1Id });
 
   const batch2Id = store.addBatch();
   const batch2Sheet1Id = uuid();
-  store.addSheet(election, batch2Sheet1Id, batch2Id, generateSheet());
+  store.addSheet(batch2Sheet1Id, batch2Id, generateSheet());
   store.finishBatch({ batchId: batch2Id });
 
   const batch3Id = store.addBatch();
   const batch3Sheet1Id = uuid();
-  store.addSheet(election, batch3Sheet1Id, batch3Id, generateSheet());
+  store.addSheet(batch3Sheet1Id, batch3Id, generateSheet());
   const batch3Sheet2Id = uuid();
-  store.addSheet(election, batch3Sheet2Id, batch3Id, generateSheet());
+  store.addSheet(batch3Sheet2Id, batch3Id, generateSheet());
   store.finishBatch({ batchId: batch3Id });
 
   const acceptedSheets = Array.from(store.forEachAcceptedSheet());
@@ -868,7 +865,7 @@ test('getBallotsCounted', () => {
 
   // Create a batch and add a sheet to it
   const batchId = store.addBatch();
-  store.addSheet(election, uuid(), batchId, [
+  store.addSheet(uuid(), batchId, [
     {
       imagePath: '/tmp/front-page.png',
       interpretation: {
@@ -889,7 +886,7 @@ test('getBallotsCounted', () => {
 
   // Create a second batch and add a second and third sheet
   const batch2Id = store.addBatch();
-  store.addSheet(election, uuid(), batch2Id, [
+  store.addSheet(uuid(), batch2Id, [
     {
       imagePath: '/tmp/front-page2.png',
       interpretation: {
@@ -907,7 +904,7 @@ test('getBallotsCounted', () => {
   expect(store.getBallotsCounted()).toEqual(2);
 
   const sheetId3 = uuid();
-  store.addSheet(election, sheetId3, batch2Id, [
+  store.addSheet(sheetId3, batch2Id, [
     {
       imagePath: '/tmp/front-page3.png',
       interpretation: {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -971,21 +971,6 @@ export class Store {
   }
 
   /**
-   * Counts sheets awaiting adjudication.
-   */
-  adjudicationsRemaining(): number {
-    const { remaining } = this.client.one(`
-        select count(*) as remaining
-        from sheets
-        where
-          requires_adjudication = 1
-          and deleted_at is null
-          and finished_adjudication_at is null
-      `) as { remaining: number };
-    return remaining;
-  }
-
-  /**
    * Yields all scanned sheets that were accepted and should be tabulated
    */
   *forEachAcceptedSheet(): Generator<AcceptedSheet> {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -25,7 +25,6 @@ import {
   DiagnosticType,
   ElectionKey,
   constructElectionKey,
-  Election,
 } from '@votingworks/types';
 import {
   assert,
@@ -34,7 +33,6 @@ import {
   find,
   Optional,
 } from '@votingworks/basics';
-import makeDebug from 'debug';
 import { DateTime } from 'luxon';
 import { dirname, join } from 'node:path';
 import { randomUUID as uuid } from 'node:crypto';
@@ -52,11 +50,8 @@ import {
   updateCastVoteRecordHashes,
 } from '@votingworks/auth';
 import { BaseLogger } from '@votingworks/logging';
-import { combinePageInterpretationsForSheet } from '@votingworks/ballot-interpreter';
 import { normalizeAndJoin } from './util/path.js';
 import { NetworkConnectionInfo } from './types.js';
-
-const debug = makeDebug('scan:store');
 
 const SchemaPath = join(import.meta.dirname, '../schema.sql');
 
@@ -69,8 +64,6 @@ const getSheetsBaseQuery = `
     back_interpretation_json as backInterpretationJson,
     front_image_path as frontImagePath,
     back_image_path as backImagePath,
-    requires_adjudication as requiresAdjudication,
-    finished_adjudication_at as finishedAdjudicationAt,
     sheets.deleted_at as deletedAt,
     row_number() over (partition by batches.id order by sheets.created_at) indexInBatch
   from sheets left join batches on
@@ -85,8 +78,6 @@ interface SheetRow {
   backInterpretationJson: string;
   frontImagePath: string;
   backImagePath: string;
-  requiresAdjudication: 0 | 1;
-  finishedAdjudicationAt: Iso8601Timestamp | null;
   deletedAt: Iso8601Timestamp | null;
   indexInBatch: number;
 }
@@ -120,15 +111,6 @@ function sheetRowToRejectedSheet(row: SheetRow): RejectedSheet {
 }
 
 function sheetRowToSheet(row: SheetRow): Sheet {
-  // The central scanner UX guarantees this condition. Sheets requiring review have to be accepted
-  // or rejected before a batch is considered complete. And if someone shuts the machine down
-  // mid-adjudication, on boot, incomplete batches are cleaned up.
-  assert(
-    row.requiresAdjudication === 0 ||
-      row.finishedAdjudicationAt !== null ||
-      row.deletedAt !== null,
-    'Every sheet requiring review should have been either accepted or rejected'
-  );
   return row.deletedAt === null
     ? sheetRowToAcceptedSheet(row)
     : sheetRowToRejectedSheet(row);
@@ -630,18 +612,11 @@ export class Store {
    * Adds a sheet to an existing batch.
    */
   addSheet(
-    election: Election,
     sheetId: string,
     batchId: string,
     [front, back]: SheetOf<PageInterpretationWithFiles>,
     ballotAuditId?: string
   ): void {
-    const requiresAdjudication =
-      combinePageInterpretationsForSheet(
-        [front.interpretation, back.interpretation],
-        election
-      ).type !== 'ValidSheet';
-
     this.client.run(
       `insert into sheets (
           id,
@@ -650,11 +625,9 @@ export class Store {
           front_image_path,
           front_interpretation_json,
           back_image_path,
-          back_interpretation_json,
-          requires_adjudication,
-          finished_adjudication_at
+          back_interpretation_json
         ) values (
-          ?, ?, ?, ?, ?, ?, ?, ?, ?
+          ?, ?, ?, ?, ?, ?, ?
         )`,
       sheetId,
       batchId,
@@ -662,9 +635,7 @@ export class Store {
       front.imagePath,
       JSON.stringify(front.interpretation),
       back.imagePath,
-      JSON.stringify(back.interpretation),
-      requiresAdjudication ? 1 : 0,
-      requiresAdjudication ? null : DateTime.now().toISOTime()
+      JSON.stringify(back.interpretation)
     );
   }
 
@@ -737,24 +708,6 @@ export class Store {
       JSON.parse(row.frontInterpretationJson),
       JSON.parse(row.backInterpretationJson),
     ];
-  }
-
-  adjudicateSheet(sheetId: string): boolean {
-    debug('finishing adjudication for sheet %s', sheetId);
-
-    this.client.run(
-      `
-      update
-        sheets
-      set
-        finished_adjudication_at = ?
-      where id = ?
-    `,
-      new Date().toISOString(),
-      sheetId
-    );
-
-    return true;
   }
 
   /**
@@ -962,8 +915,7 @@ export class Store {
     const sql = `${getSheetsBaseQuery}
       where
         batches.deleted_at is null and
-        sheets.deleted_at is null and
-        (requires_adjudication = 0 or finished_adjudication_at is not null)
+        sheets.deleted_at is null
       order by sheets.created_at
     `;
     for (const row of this.client.each(sql) as Iterable<SheetRow>) {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -478,18 +478,6 @@ export class Store {
   }
 
   /**
-   * Returns the id of the an unfinished batch if there is one
-   */
-  // @coverage-defer
-  getOngoingBatchId(): Optional<string> {
-    const ongoingBatchRow = this.client.one(
-      'select id from batches where ended_at is null'
-    ) as { id: string } | undefined;
-
-    return ongoingBatchRow?.id;
-  }
-
-  /**
    * Records that batches have been backed up.
    */
   setScannerBackedUp(backedUp = true): void {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -716,42 +716,27 @@ export class Store {
     return normalizeAndJoin(dirname(this.getDbPath()), row.imagePath);
   }
 
-  getNextAdjudicationSheet():
-    | { id: string; pages: SheetOf<PageInterpretation> }
-    | undefined {
-    const row = this.client.one(
-      `
-      select
-        id,
-        front_interpretation_json as frontInterpretationJson,
-        back_interpretation_json as backInterpretationJson
-      from sheets
-      where
-        requires_adjudication = 1 and
-        finished_adjudication_at is null and
-        deleted_at is null
-      order by created_at asc
-      limit 1
-      `
-    ) as
-      | {
-          id: string;
-          frontInterpretationJson: string;
-          backInterpretationJson: string;
-        }
-      | undefined;
+  getSheetInterpretation(sheetId: string): SheetOf<PageInterpretation> {
+    const row = assertDefined(
+      this.client.one(
+        `
+        select
+          front_interpretation_json as frontInterpretationJson,
+          back_interpretation_json as backInterpretationJson
+        from sheets
+        where id = ?
+        `,
+        sheetId
+      )
+    ) as {
+      frontInterpretationJson: string;
+      backInterpretationJson: string;
+    };
 
-    if (row) {
-      debug('got next review sheet requiring adjudication (id=%s)', row.id);
-      return {
-        id: row.id,
-        pages: [
-          JSON.parse(row.frontInterpretationJson),
-          JSON.parse(row.backInterpretationJson),
-        ],
-      };
-    }
-    debug('no review sheets requiring adjudication');
+    return [
+      JSON.parse(row.frontInterpretationJson),
+      JSON.parse(row.backInterpretationJson),
+    ];
   }
 
   adjudicateSheet(sheetId: string): boolean {

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -9,7 +9,7 @@ export type BatchScannerMachineStatus =
   | { state: 'idle'; error?: string }
   | { state: 'disconnected' }
   | { state: 'scanning'; batchId: Id }
-  | { state: 'needsReview'; batchId: Id };
+  | { state: 'needsReview'; batchId: Id; sheetId: Id };
 
 export type ScanStatus = BatchScannerMachineStatus & {
   batches: BatchInfo[];

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -12,7 +12,6 @@ export type BatchScannerMachineStatus =
   | { state: 'needsReview'; batchId: Id };
 
 export type ScanStatus = BatchScannerMachineStatus & {
-  adjudicationsRemaining: number;
   batches: BatchInfo[];
   canUnconfigure: boolean;
 };

--- a/apps/central-scan/backend/src/types.ts
+++ b/apps/central-scan/backend/src/types.ts
@@ -12,7 +12,6 @@ export type BatchScannerMachineStatus =
   | { state: 'needsReview'; batchId: Id };
 
 export type ScanStatus = BatchScannerMachineStatus & {
-  isScannerAttached: boolean;
   adjudicationsRemaining: number;
   batches: BatchInfo[];
   canUnconfigure: boolean;

--- a/apps/central-scan/backend/test/helpers/setup_app.ts
+++ b/apps/central-scan/backend/test/helpers/setup_app.ts
@@ -110,13 +110,15 @@ export async function withApp(
   }
 }
 
-export async function waitForStatus(
+export function waitForStatus<State extends ScanStatus['state']>(
   apiClient: grout.Client<Api>,
-  status: Pick<ScanStatus, 'state'> & Partial<ScanStatus>
-): Promise<void> {
-  await vi.waitFor(
+  status: { state: State } & Partial<ScanStatus>
+): Promise<Extract<ScanStatus, { state: State }>> {
+  return vi.waitFor(
     async () => {
-      expect(await apiClient.getStatus()).toMatchObject(status);
+      const currentStatus = await apiClient.getStatus();
+      expect(currentStatus).toMatchObject(status);
+      return currentStatus as Extract<ScanStatus, { state: State }>;
     },
     { timeout: 10_000 }
   );

--- a/apps/central-scan/frontend/README.md
+++ b/apps/central-scan/frontend/README.md
@@ -38,12 +38,3 @@ This enables a "Batch Scanner" control in the dev dock where you can load ballot
 PDFs or images (JPG/PNG). Loaded ballots persist across scans — click "Clear" in
 the dev dock to reset. Each click of "Scan New Batch" in the main UI will scan
 all loaded ballots.
-
-### Testing Adjudication
-
-To force `requires_adjudication` of ballots, run this in
-`apps/central-scan/backend`:
-
-```
-sqlite3 dev-workspace/ballots.db 'update sheets set requires_adjudication = 1;'
-```

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -16,6 +16,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import * as grout from '@votingworks/grout';
+import { Id } from '@votingworks/types';
 
 export type ApiClient = grout.Client<Api>;
 
@@ -204,20 +205,16 @@ export const getMostRecentUpsDiagnostic = {
   },
 } as const;
 
-export const getNextReviewSheet = {
-  queryKey(): QueryKey {
-    return ['getNextReviewSheet'];
+export const getSheetForReview = {
+  queryKey(sheetId: Id): QueryKey {
+    return ['getSheetForReview', sheetId];
   },
 
-  useQuery() {
+  useQuery(sheetId: Id) {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getNextReviewSheet(), {
-      // Always refetch - using cached data could result in flashes of old data or even blank
-      // screens, as getNextReviewSheet intentionally returns null when there are no sheets left to
-      // review
-      cacheTime: 0,
-      staleTime: 0,
-    });
+    return useQuery(this.queryKey(sheetId), () =>
+      apiClient.getSheetForReview({ sheetId })
+    );
   },
 } as const;
 
@@ -312,7 +309,6 @@ export const continueScanning = {
     return useMutation(apiClient.continueScanning, {
       async onSuccess() {
         await queryClient.invalidateQueries(getStatus.queryKey());
-        await queryClient.invalidateQueries(getNextReviewSheet.queryKey());
       },
     });
   },

--- a/apps/central-scan/frontend/src/api.ts
+++ b/apps/central-scan/frontend/src/api.ts
@@ -302,11 +302,23 @@ export const scanBatch = {
   },
 } as const;
 
-export const continueScanning = {
+export const acceptSheet = {
   useMutation() {
     const apiClient = useApiClient();
     const queryClient = useQueryClient();
-    return useMutation(apiClient.continueScanning, {
+    return useMutation(apiClient.acceptSheet, {
+      async onSuccess() {
+        await queryClient.invalidateQueries(getStatus.queryKey());
+      },
+    });
+  },
+} as const;
+
+export const rejectSheet = {
+  useMutation() {
+    const apiClient = useApiClient();
+    const queryClient = useQueryClient();
+    return useMutation(apiClient.rejectSheet, {
       async onSuccess() {
         await queryClient.invalidateQueries(getStatus.queryKey());
       },

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -167,7 +167,7 @@ test('shows the ballot eject screen while a sheet needs review', async () => {
   });
   await screen.findByRole('heading', { name: 'Blank Ballot' });
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getButton('Confirm Ballot Removed'));
   apiMock.setStatus(mockStatus());
   await screen.findByText('Scan New Batch');

--- a/apps/central-scan/frontend/src/app.test.tsx
+++ b/apps/central-scan/frontend/src/app.test.tsx
@@ -9,6 +9,7 @@ import {
   mockVendorUser,
 } from '@votingworks/test-utils';
 import {
+  AdjudicationReason,
   DEFAULT_SYSTEM_SETTINGS,
   constructElectionKey,
   ElectionDefinition,
@@ -118,6 +119,58 @@ test('clicking Scan Batch will scan a batch', async () => {
   apiMock.expectScanBatch();
   userEvent.click(screen.getButton('Scan New Batch'));
   await screen.findByText('Scan New Batch'); // wait for button to reset
+});
+
+test('shows the ballot eject screen while a sheet needs review', async () => {
+  const images = [
+    {
+      imageUrl: 'mock-front-image',
+      ballotBounds: { x: 0, y: 0, width: 1700, height: 2200 },
+    },
+    {
+      imageUrl: 'mock-back-image',
+      ballotBounds: { x: 0, y: 0, width: 1700, height: 2200 },
+    },
+  ] as const;
+  apiMock.expectGetTestMode(true);
+  apiMock.expectGetElectionRecord(electionDefinition);
+  apiMock.setStatus(
+    mockStatus(
+      {},
+      { state: 'needsReview', batchId: 'batch-id', sheetId: 'sheet-id' }
+    )
+  );
+  apiMock.expectGetSheetForReview('sheet-id', {
+    sheetInterpretation: { type: 'InvalidSheet', reason: { type: 'unknown' } },
+    images: [...images],
+  });
+
+  render(<App apiClient={apiMock.apiClient} />);
+  await authenticateAsElectionManager(
+    electionDefinition,
+    'VxCentralScan Locked',
+    'Unreadable'
+  );
+
+  apiMock.setStatus(
+    mockStatus(
+      {},
+      { state: 'needsReview', batchId: 'batch-id', sheetId: 'sheet-id-2' }
+    )
+  );
+  apiMock.expectGetSheetForReview('sheet-id-2', {
+    sheetInterpretation: {
+      type: 'NeedsReviewSheet',
+      reasons: [{ type: AdjudicationReason.BlankBallot }],
+    },
+    images: [...images],
+  });
+  await screen.findByRole('heading', { name: 'Blank Ballot' });
+
+  apiMock.expectContinueScanning({ forceAccept: false });
+  userEvent.click(screen.getButton('Confirm Ballot Removed'));
+  apiMock.setStatus(mockStatus());
+  await screen.findByText('Scan New Batch');
 });
 
 test('clicking "Save CVRs" shows modal and makes a request to export', async () => {

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -196,7 +196,7 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
   if (status.state === 'needsReview') {
     return (
       <AppContext.Provider value={currentContext}>
-        <BallotEjectScreen isTestMode={isTestMode} />
+        <BallotEjectScreen isTestMode={isTestMode} sheetId={status.sheetId} />
       </AppContext.Provider>
     );
   }

--- a/apps/central-scan/frontend/src/app_root.tsx
+++ b/apps/central-scan/frontend/src/app_root.tsx
@@ -193,8 +193,7 @@ export function AppRoot({ logger }: AppRootProps): JSX.Element | null {
   // A polling place must be selected before scanning.
   const isPollingPlaceUnconfigured = !pollingPlaceIdQuery.data;
 
-  // @coverage-defer
-  if (status.adjudicationsRemaining > 0) {
+  if (status.state === 'needsReview') {
     return (
       <AppContext.Provider value={currentContext}>
         <BallotEjectScreen isTestMode={isTestMode} />

--- a/apps/central-scan/frontend/src/components/test_scan_button.test.tsx
+++ b/apps/central-scan/frontend/src/components/test_scan_button.test.tsx
@@ -20,19 +20,20 @@ afterEach(() => {
 });
 
 test('disabled behavior', async () => {
-  apiMock.setStatus(mockStatus({ isScannerAttached: true }));
+  apiMock.setStatus(mockStatus({}, { state: 'idle' }));
   renderInAppContext(<TestScanButton />, { apiMock });
-  const button = await screen.findButton('Perform Test Scan');
-  expect(button).toBeEnabled();
+  const button = screen.getButton('Perform Test Scan');
+  expect(button).toBeDisabled();
+  await vi.waitFor(() => {
+    expect(button).toBeEnabled();
+  });
 
-  apiMock.setStatus(
-    mockStatus({ isScannerAttached: false }, { state: 'disconnected' })
-  );
+  apiMock.setStatus(mockStatus({}, { state: 'disconnected' }));
   await vi.waitFor(() => {
     expect(button).toBeDisabled();
   });
 
-  apiMock.setStatus(mockStatus({ isScannerAttached: true }));
+  apiMock.setStatus(mockStatus({}, { state: 'idle' }));
   await vi.waitFor(() => {
     expect(button).toBeEnabled();
   });
@@ -40,9 +41,7 @@ test('disabled behavior', async () => {
   userEvent.click(button);
   await screen.findButton('Scan');
 
-  apiMock.setStatus(
-    mockStatus({ isScannerAttached: false }, { state: 'disconnected' })
-  );
+  apiMock.setStatus(mockStatus({}, { state: 'disconnected' }));
   await vi.waitFor(() => {
     expect(screen.queryButton('Scan')).not.toBeInTheDocument();
   });
@@ -50,7 +49,7 @@ test('disabled behavior', async () => {
 });
 
 test('happy path', async () => {
-  apiMock.setStatus(mockStatus({ isScannerAttached: true }));
+  apiMock.setStatus(mockStatus({}, { state: 'idle' }));
   renderInAppContext(<TestScanButton />, { apiMock });
   const button = await screen.findButton('Perform Test Scan');
   userEvent.click(button);
@@ -66,7 +65,7 @@ test('happy path', async () => {
 });
 
 test('fail because no paper', async () => {
-  apiMock.setStatus(mockStatus({ isScannerAttached: true }));
+  apiMock.setStatus(mockStatus({}, { state: 'idle' }));
   renderInAppContext(<TestScanButton />, { apiMock });
   const button = await screen.findButton('Perform Test Scan');
   userEvent.click(button);
@@ -77,7 +76,7 @@ test('fail because no paper', async () => {
 });
 
 test('fail because no bad image', async () => {
-  apiMock.setStatus(mockStatus({ isScannerAttached: true }));
+  apiMock.setStatus(mockStatus({}, { state: 'idle' }));
   renderInAppContext(<TestScanButton />, { apiMock });
   const button = await screen.findButton('Perform Test Scan');
   userEvent.click(button);

--- a/apps/central-scan/frontend/src/components/test_scan_button.tsx
+++ b/apps/central-scan/frontend/src/components/test_scan_button.tsx
@@ -4,10 +4,10 @@ import { assert, throwIllegalValue } from '@votingworks/basics';
 import { getStatus, performScanDiagnostic } from '../api.js';
 
 function TestScanModal({
-  isScannerAttached,
+  isScannerIdle,
   onClose,
 }: {
-  isScannerAttached: boolean;
+  isScannerIdle: boolean;
   onClose: VoidFunction;
 }): JSX.Element {
   const performDiagnosticMutation = performScanDiagnostic.useMutation();
@@ -16,7 +16,7 @@ function TestScanModal({
   assert(status !== 'error');
   switch (status) {
     case 'idle':
-      if (!isScannerAttached) {
+      if (!isScannerIdle) {
         return (
           <Modal
             title="Test Scan Diagnostic"
@@ -124,19 +124,17 @@ function TestScanModal({
 
 export function TestScanButton(): JSX.Element {
   const statusQuery = getStatus.usePollingQuery();
-  const isScannerAttached = statusQuery.data?.isScannerAttached ?? false;
+  const isScannerIdle =
+    statusQuery.isSuccess && statusQuery.data.state === 'idle';
   const [isModalOpen, setIsModalOpen] = React.useState(false);
   return (
     <React.Fragment>
-      <Button
-        disabled={!isScannerAttached}
-        onPress={() => setIsModalOpen(true)}
-      >
+      <Button disabled={!isScannerIdle} onPress={() => setIsModalOpen(true)}>
         Perform Test Scan
       </Button>
       {isModalOpen && (
         <TestScanModal
-          isScannerAttached={isScannerAttached}
+          isScannerIdle={isScannerIdle}
           onClose={() => setIsModalOpen(false)}
         />
       )}

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -18,8 +18,10 @@ import { createApiMock, ApiMock } from '../../test/api.js';
 
 let apiMock: ApiMock;
 
-type NextReviewSheet = Awaited<
-  ReturnType<(typeof apiMock.apiClient)['getNextReviewSheet']>
+const SHEET_ID = 'sheet-id';
+
+type SheetForReview = Awaited<
+  ReturnType<(typeof apiMock.apiClient)['getSheetForReview']>
 >;
 
 function buildHmpMetadataWithPage(pageNumber: number): BallotPageMetadata {
@@ -33,10 +35,10 @@ function buildHmpMetadataWithPage(pageNumber: number): BallotPageMetadata {
   };
 }
 
-function buildNextReviewSheet(
+function buildSheetForReview(
   sheetInterpretation: SheetInterpretation,
   contestIdsBySide: SheetOf<readonly string[]> = [[], []]
-): NextReviewSheet {
+): SheetForReview {
   function buildImage(pageNumber: number, contestIds: readonly string[]) {
     return {
       imageUrl: `mock-${pageNumber === 1 ? 'front' : 'back'}-image`,
@@ -81,14 +83,17 @@ afterEach(() => {
 });
 
 test('says the sheet is unreadable if it is', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: { type: 'unknown' },
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Unreadable');
   screen.getByText(
@@ -106,8 +111,9 @@ test('says the sheet is unreadable if it is', async () => {
 });
 
 test('says the ballot sheet is overvoted if it is', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'NeedsReviewSheet',
       reasons: [
         {
@@ -120,7 +126,9 @@ test('says the ballot sheet is overvoted if it is', async () => {
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Overvote');
   screen.getByText(
@@ -138,8 +146,9 @@ test('says the ballot sheet is overvoted if it is', async () => {
 });
 
 test('renders both ballot images with highlights on overvoted contests', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet(
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview(
       {
         type: 'NeedsReviewSheet',
         reasons: [
@@ -155,7 +164,9 @@ test('renders both ballot images with highlights on overvoted contests', async (
     )
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Overvote');
 
@@ -180,8 +191,9 @@ test('renders both ballot images with highlights on overvoted contests', async (
 });
 
 test('says the ballot sheet is undervoted if it is', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet(
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview(
       {
         type: 'NeedsReviewSheet',
         reasons: [
@@ -197,7 +209,9 @@ test('says the ballot sheet is undervoted if it is', async () => {
     )
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Undervote');
   screen.getByText(
@@ -219,8 +233,9 @@ test('says the ballot sheet is undervoted if it is', async () => {
 });
 
 test('says the ballot sheet is blank if it is', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet(
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview(
       {
         type: 'NeedsReviewSheet',
         reasons: [
@@ -237,7 +252,9 @@ test('says the ballot sheet is blank if it is', async () => {
     )
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Blank Ballot');
   screen.getByText(
@@ -260,14 +277,17 @@ test('says the ballot sheet is blank if it is', async () => {
 });
 
 test('says the ballot sheet has crossover voting if it does', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'NeedsReviewSheet',
       reasons: [{ type: AdjudicationReason.CrossoverVoting }],
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Crossover Voting');
   screen.getByText(
@@ -285,14 +305,17 @@ test('says the ballot sheet has crossover voting if it does', async () => {
 });
 
 test('calls out official ballot sheets in test mode', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: { type: 'invalid_test_mode' },
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Official Ballot');
   screen.getByText(
@@ -308,14 +331,18 @@ test('calls out official ballot sheets in test mode', async () => {
 });
 
 test('calls out test ballot sheets in live mode', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: { type: 'invalid_test_mode' },
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode={false} />, { apiMock });
+  renderInAppContext(
+    <BallotEjectScreen isTestMode={false} sheetId={SHEET_ID} />,
+    { apiMock }
+  );
 
   await screen.findByText('Test Ballot');
   screen.getByText(
@@ -331,8 +358,9 @@ test('calls out test ballot sheets in live mode', async () => {
 });
 
 test('shows invalid election screen when appropriate', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: {
         type: 'invalid_ballot_hash',
@@ -341,7 +369,10 @@ test('shows invalid election screen when appropriate', async () => {
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode={false} />, { apiMock });
+  renderInAppContext(
+    <BallotEjectScreen isTestMode={false} sheetId={SHEET_ID} />,
+    { apiMock }
+  );
 
   await screen.findByText('Wrong Election');
   screen.getByText('Ballot Election ID');
@@ -364,8 +395,9 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
     ...DEFAULT_SYSTEM_SETTINGS,
     disallowCastingOvervotes: true,
   });
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'NeedsReviewSheet',
       reasons: [
         {
@@ -378,7 +410,9 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Overvote');
   screen.getByText(
@@ -392,14 +426,17 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
 });
 
 test('says the scanner needs cleaning if a streak is detected', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: { type: 'vertical_streaks_detected' },
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Streak Detected');
   screen.getByText(
@@ -415,14 +452,17 @@ test('says the scanner needs cleaning if a streak is detected', async () => {
 });
 
 test('falls through to "Unreadable" for an UnreadablePage with an unrecognized reason', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: { type: 'unreadable' },
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Unreadable');
   screen.getByText(
@@ -437,14 +477,17 @@ test('falls through to "Unreadable" for an UnreadablePage with an unrecognized r
 });
 
 test('ballot with invalid scale', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: { type: 'invalid_scale' },
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Invalid Scale');
   screen.getByText('The last scanned ballot was printed at an invalid scale.');
@@ -458,14 +501,17 @@ test('ballot with invalid scale', async () => {
 });
 
 test('ballot from a precinct not in the selected polling place', async () => {
-  apiMock.expectGetNextReviewSheet(
-    buildNextReviewSheet({
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
       type: 'InvalidSheet',
       reason: { type: 'invalid_precinct' },
     })
   );
 
-  renderInAppContext(<BallotEjectScreen isTestMode />, { apiMock });
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
 
   await screen.findByText('Wrong Precinct');
   screen.getByText(

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -106,7 +106,7 @@ test('says the sheet is unreadable if it is', async () => {
     'Confirm Ballot Removed'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -138,10 +138,10 @@ test('says the ballot sheet is overvoted if it is', async () => {
     'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 
-  apiMock.expectContinueScanning({ forceAccept: true });
+  apiMock.expectAcceptSheet();
   userEvent.click(screen.getByText('Tabulate Ballot'));
 });
 
@@ -186,7 +186,7 @@ test('renders both ballot images with highlights on overvoted contests', async (
   // Back image has no highlights
   expect(ballotImages[1].querySelector('div')).not.toBeInTheDocument();
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -225,10 +225,10 @@ test('says the ballot sheet is undervoted if it is', async () => {
   const ballotImages = screen.getAllByRole('img', { name: /ballot/i });
   expect(ballotImages[0].querySelectorAll('div')).toHaveLength(1);
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 
-  apiMock.expectContinueScanning({ forceAccept: true });
+  apiMock.expectAcceptSheet();
   userEvent.click(screen.getByText('Tabulate Ballot'));
 });
 
@@ -269,10 +269,10 @@ test('says the ballot sheet is blank if it is', async () => {
   const ballotImages = screen.getAllByRole('img', { name: /ballot/i });
   expect(ballotImages[0].querySelector('div')).not.toBeInTheDocument();
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 
-  apiMock.expectContinueScanning({ forceAccept: true });
+  apiMock.expectAcceptSheet();
   userEvent.click(screen.getByText('Tabulate Ballot'));
 });
 
@@ -297,10 +297,10 @@ test('says the ballot sheet has crossover voting if it does', async () => {
     'Remove the ballot for manual adjudication or choose to tabulate it anyway.'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 
-  apiMock.expectContinueScanning({ forceAccept: true });
+  apiMock.expectAcceptSheet();
   userEvent.click(screen.getByText('Tabulate Ballot'));
 });
 
@@ -326,7 +326,7 @@ test('calls out official ballot sheets in test mode', async () => {
     'Confirm Ballot Removed'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -353,7 +353,7 @@ test('calls out test ballot sheets in live mode', async () => {
     'Confirm Ballot Removed'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -384,7 +384,7 @@ test('shows invalid election screen when appropriate', async () => {
 
   expect(screen.queryAllByText('Tabulate Ballot').length).toEqual(0);
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -421,7 +421,7 @@ test('does not allow tabulating the overvote if disallowCastingOvervotes is set'
 
   expect(screen.queryByText('Tabulate Ballot')).not.toBeInTheDocument();
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -447,7 +447,7 @@ test('says the scanner needs cleaning if a streak is detected', async () => {
     'Confirm Ballot Removed'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -472,7 +472,7 @@ test('falls through to "Unreadable" for an UnreadablePage with an unrecognized r
     'Confirm Ballot Removed'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -496,7 +496,7 @@ test('ballot with invalid scale', async () => {
     'Confirm Ballot Removed'
   );
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });
 
@@ -519,6 +519,6 @@ test('ballot from a precinct not in the selected polling place', async () => {
   );
   expect(screen.queryAllByText('Tabulate Ballot').length).toEqual(0);
 
-  apiMock.expectContinueScanning({ forceAccept: false });
+  apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
 });

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.test.tsx
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, expect, test } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { deferred } from '@votingworks/basics';
 import {
   AdjudicationReason,
   BallotPageMetadata,
@@ -521,4 +522,40 @@ test('ballot from a precinct not in the selected polling place', async () => {
 
   apiMock.expectRejectSheet();
   userEvent.click(screen.getByText('Confirm Ballot Removed'));
+});
+
+test('disables the buttons while a sheet action is in progress', async () => {
+  apiMock.expectGetSheetForReview(
+    SHEET_ID,
+    buildSheetForReview({
+      type: 'NeedsReviewSheet',
+      reasons: [{ type: AdjudicationReason.BlankBallot }],
+    })
+  );
+
+  renderInAppContext(<BallotEjectScreen isTestMode sheetId={SHEET_ID} />, {
+    apiMock,
+  });
+
+  await screen.findByText('Blank Ballot');
+  const rejectButton = screen.getButton('Confirm Ballot Removed');
+  const acceptButton = screen.getButton('Tabulate Ballot');
+  expect(rejectButton).toBeEnabled();
+  expect(acceptButton).toBeEnabled();
+
+  const rejectSheetResult = deferred<void>();
+  apiMock.apiClient.rejectSheet
+    .expectCallWith()
+    .returns(rejectSheetResult.promise);
+  userEvent.click(rejectButton);
+  await vi.waitFor(() => {
+    expect(rejectButton).toBeDisabled();
+  });
+  expect(acceptButton).toBeDisabled();
+
+  rejectSheetResult.resolve();
+  await vi.waitFor(() => {
+    expect(rejectButton).toBeEnabled();
+  });
+  expect(acceptButton).toBeEnabled();
 });

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -2,6 +2,7 @@ import {
   AdjudicationReason,
   ContestId,
   formatBallotHash,
+  Id,
   mapSheet,
 } from '@votingworks/types';
 import { assert, throwIllegalValue } from '@votingworks/basics';
@@ -24,7 +25,7 @@ import { AppContext } from '../contexts/app_context.js';
 import { Header } from '../navigation_screen.js';
 import {
   continueScanning,
-  getNextReviewSheet,
+  getSheetForReview,
   getSystemSettings,
 } from '../api.js';
 
@@ -54,6 +55,7 @@ const BallotImagesContainer = styled.div`
 
 interface Props {
   isTestMode: boolean;
+  sheetId: Id;
 }
 
 interface EjectInformation {
@@ -63,13 +65,16 @@ interface EjectInformation {
   highlightedContestIds?: Set<ContestId>;
 }
 
-export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
+export function BallotEjectScreen({
+  isTestMode,
+  sheetId,
+}: Props): JSX.Element | null {
   const { auth, electionDefinition } = useContext(AppContext);
   assert(electionDefinition);
   assert(isElectionManagerAuth(auth));
 
   const systemSettingsQuery = getSystemSettings.useQuery();
-  const getNextReviewSheetQuery = getNextReviewSheet.useQuery();
+  const getSheetForReviewQuery = getSheetForReview.useQuery(sheetId);
   const continueScanningMutation = continueScanning.useMutation();
 
   function removeBallotAndContinueScanning() {
@@ -80,14 +85,12 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
     continueScanningMutation.mutate({ forceAccept: true });
   }
 
-  const reviewInfo = getNextReviewSheetQuery.data;
-
-  if (!reviewInfo || !systemSettingsQuery.isSuccess) {
+  if (!getSheetForReviewQuery.isSuccess || !systemSettingsQuery.isSuccess) {
     return null;
   }
 
   const { disallowCastingOvervotes } = systemSettingsQuery.data;
-  const { sheetInterpretation } = reviewInfo;
+  const { sheetInterpretation, images } = getSheetForReviewQuery.data;
 
   const unreadableEjectInfo: EjectInformation = {
     header: 'Unreadable',
@@ -332,7 +335,7 @@ export function BallotEjectScreen({ isTestMode }: Props): JSX.Element | null {
           )}
         </AdjudicationExplanation>
         <BallotImagesContainer>
-          {mapSheet(reviewInfo.images, (pageImage, side) => {
+          {mapSheet(images, (pageImage, side) => {
             const highlights = pageImage.layout?.contests
               .filter(
                 (contestLayout) =>

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -78,6 +78,8 @@ export function BallotEjectScreen({
   const getSheetForReviewQuery = getSheetForReview.useQuery(sheetId);
   const acceptSheetMutation = acceptSheet.useMutation();
   const rejectSheetMutation = rejectSheet.useMutation();
+  const isSheetActionInProgress =
+    acceptSheetMutation.isLoading || rejectSheetMutation.isLoading;
 
   if (!getSheetForReviewQuery.isSuccess || !systemSettingsQuery.isSuccess) {
     return null;
@@ -303,6 +305,7 @@ export function BallotEjectScreen({
                 <Button
                   variant="primary"
                   onPress={() => rejectSheetMutation.mutate()}
+                  disabled={isSheetActionInProgress}
                   style={{ width: '100%', marginTop: '0.5rem' }}
                 >
                   Confirm Ballot Removed
@@ -312,6 +315,7 @@ export function BallotEjectScreen({
                 <Button
                   variant="primary"
                   onPress={() => acceptSheetMutation.mutate()}
+                  disabled={isSheetActionInProgress}
                   style={{ width: '100%' }}
                 >
                   Tabulate Ballot
@@ -322,6 +326,7 @@ export function BallotEjectScreen({
             <Button
               variant="primary"
               onPress={() => rejectSheetMutation.mutate()}
+              disabled={isSheetActionInProgress}
               style={{ marginTop: '0.5rem', width: '100%' }}
             >
               Confirm Ballot Removed

--- a/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/ballot_eject_screen.tsx
@@ -24,9 +24,10 @@ import styled from 'styled-components';
 import { AppContext } from '../contexts/app_context.js';
 import { Header } from '../navigation_screen.js';
 import {
-  continueScanning,
+  acceptSheet,
   getSheetForReview,
   getSystemSettings,
+  rejectSheet,
 } from '../api.js';
 
 const AdjudicationHeader = styled(Header)`
@@ -75,15 +76,8 @@ export function BallotEjectScreen({
 
   const systemSettingsQuery = getSystemSettings.useQuery();
   const getSheetForReviewQuery = getSheetForReview.useQuery(sheetId);
-  const continueScanningMutation = continueScanning.useMutation();
-
-  function removeBallotAndContinueScanning() {
-    continueScanningMutation.mutate({ forceAccept: false });
-  }
-
-  function acceptBallotAndContinueScanning() {
-    continueScanningMutation.mutate({ forceAccept: true });
-  }
+  const acceptSheetMutation = acceptSheet.useMutation();
+  const rejectSheetMutation = rejectSheet.useMutation();
 
   if (!getSheetForReviewQuery.isSuccess || !systemSettingsQuery.isSuccess) {
     return null;
@@ -308,7 +302,7 @@ export function BallotEjectScreen({
               <P>
                 <Button
                   variant="primary"
-                  onPress={removeBallotAndContinueScanning}
+                  onPress={() => rejectSheetMutation.mutate()}
                   style={{ width: '100%', marginTop: '0.5rem' }}
                 >
                   Confirm Ballot Removed
@@ -317,7 +311,7 @@ export function BallotEjectScreen({
               <P>
                 <Button
                   variant="primary"
-                  onPress={acceptBallotAndContinueScanning}
+                  onPress={() => acceptSheetMutation.mutate()}
                   style={{ width: '100%' }}
                 >
                   Tabulate Ballot
@@ -327,7 +321,7 @@ export function BallotEjectScreen({
           ) : (
             <Button
               variant="primary"
-              onPress={removeBallotAndContinueScanning}
+              onPress={() => rejectSheetMutation.mutate()}
               style={{ marginTop: '0.5rem', width: '100%' }}
             >
               Confirm Ballot Removed

--- a/apps/central-scan/frontend/src/screens/diagnostics_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/diagnostics_screen.tsx
@@ -57,7 +57,7 @@ export function DiagnosticsScreen(): JSX.Element {
     return <NavigationScreen title="Diagnostics">{null}</NavigationScreen>;
   }
 
-  const { isScannerAttached } = statusQuery.data;
+  const { state } = statusQuery.data;
   const { electionDefinition, electionPackageHash } =
     electionRecordQuery.data ?? {};
   const batteryInfo = batteryInfoQuery.data;
@@ -76,7 +76,7 @@ export function DiagnosticsScreen(): JSX.Element {
             // @coverage-defer
             batteryInfo={batteryInfo ?? undefined}
             diskSpaceSummary={diskSpaceSummary}
-            isScannerAttached={isScannerAttached}
+            isScannerAttached={state !== 'disconnected'}
             mostRecentScannerDiagnostic={scannerDiagnosticRecord}
             mostRecentUpsDiagnostic={upsDiagnosticRecord}
             upsSectionAdditionalContents={

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.test.tsx
@@ -283,10 +283,7 @@ test('Delete All Batches button', async () => {
 describe('Scan Ballots Button', () => {
   test('disabled when no scanner is attached', () => {
     renderScreen({
-      status: mockStatus(
-        { isScannerAttached: false },
-        { state: 'disconnected' }
-      ),
+      status: mockStatus({}, { state: 'disconnected' }),
     });
     expect(screen.getButton('No Scanner')).toBeDisabled();
   });

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -279,7 +279,7 @@ export function ScanBallotsScreen({
               disabled={
                 isScanning || statusIsStale || isPollingPlaceUnconfigured
               }
-              isScannerAttached={status.isScannerAttached}
+              isScannerAttached={status.state !== 'disconnected'}
             />
           </TopBarActions>
         </TopBar>

--- a/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
+++ b/apps/central-scan/frontend/src/screens/scan_ballots_screen.tsx
@@ -223,16 +223,6 @@ export function ScanBallotsScreen({
     });
   }
 
-  let exportButtonTitle;
-  // @coverage-defer
-  if (status.adjudicationsRemaining > 0) {
-    exportButtonTitle =
-      'You cannot save results until all sheets have been adjudicated.';
-  } else if (status.batches.length === 0) {
-    exportButtonTitle =
-      'You cannot save results until you have scanned at least one sheet.';
-  }
-
   return (
     <NavigationScreen title="Scan Ballots">
       <Content>
@@ -265,10 +255,7 @@ export function ScanBallotsScreen({
           <TopBarActions>
             <Button
               onPress={() => setIsExportingCvrs(true)}
-              disabled={
-                status.adjudicationsRemaining > 0 || status.batches.length === 0
-              }
-              nonAccessibleTitle={exportButtonTitle}
+              disabled={status.batches.length === 0}
               icon="Export"
               color="primary"
             >

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -174,8 +174,12 @@ export function createApiMock(
         .resolves(sheetForReview);
     },
 
-    expectContinueScanning(input: { forceAccept: boolean }) {
-      apiClient.continueScanning.expectCallWith(input).resolves();
+    expectAcceptSheet() {
+      apiClient.acceptSheet.expectCallWith().resolves();
+    },
+
+    expectRejectSheet() {
+      apiClient.rejectSheet.expectCallWith().resolves();
     },
 
     expectExportCastVoteRecords() {

--- a/apps/central-scan/frontend/test/api.tsx
+++ b/apps/central-scan/frontend/test/api.tsx
@@ -13,6 +13,7 @@ import {
   DiagnosticRecord,
   DippedSmartCardAuth,
   ElectionDefinition,
+  Id,
   SystemSettings,
 } from '@votingworks/types';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -162,14 +163,15 @@ export function createApiMock(
       apiClient.scanBatch.expectCallWith().resolves();
     },
 
-    expectGetNextReviewSheet(
-      reviewSheetInfo?: Awaited<
-        ReturnType<(typeof apiClient)['getNextReviewSheet']>
+    expectGetSheetForReview(
+      sheetId: Id,
+      sheetForReview: Awaited<
+        ReturnType<(typeof apiClient)['getSheetForReview']>
       >
     ) {
-      apiClient.getNextReviewSheet
-        .expectRepeatedCallsWith()
-        .resolves(reviewSheetInfo ?? null);
+      apiClient.getSheetForReview
+        .expectRepeatedCallsWith({ sheetId })
+        .resolves(sheetForReview);
     },
 
     expectContinueScanning(input: { forceAccept: boolean }) {

--- a/apps/central-scan/frontend/test/fixtures.ts
+++ b/apps/central-scan/frontend/test/fixtures.ts
@@ -6,7 +6,6 @@ import { BatchInfo } from '@votingworks/types';
 
 export const DEFAULT_STATUS: ScanStatus = {
   state: 'idle',
-  isScannerAttached: true,
   adjudicationsRemaining: 0,
   canUnconfigure: true,
   batches: [],

--- a/apps/central-scan/frontend/test/fixtures.ts
+++ b/apps/central-scan/frontend/test/fixtures.ts
@@ -6,7 +6,6 @@ import { BatchInfo } from '@votingworks/types';
 
 export const DEFAULT_STATUS: ScanStatus = {
   state: 'idle',
-  adjudicationsRemaining: 0,
   canUnconfigure: true,
   batches: [],
 };


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->

Assorted refactors/cleanup unlocked by https://github.com/votingworks/vxsuite/pull/9324. See commit log for details.

## Demo Video or Screenshot

N/A

## Testing Plan

Automated tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
