### PR TITLE
VxCentralScan: Clean up unused code in store

### DIFF
--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -5,7 +5,6 @@ create table election (
   election_package_hash text not null,
   jurisdiction text not null,
   is_test_mode integer not null default true,
-  polls_state text not null default 'polls_closed_initial',
   polling_place_id text,
   scanner_backed_up_at text,
   created_at text not null default current_timestamp

--- a/apps/central-scan/backend/schema.sql
+++ b/apps/central-scan/backend/schema.sql
@@ -6,7 +6,6 @@ create table election (
   jurisdiction text not null,
   is_test_mode integer not null default true,
   polls_state text not null default 'polls_closed_initial',
-  is_sound_muted integer not null default false,
   polling_place_id text,
   scanner_backed_up_at text,
   created_at text not null default current_timestamp

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -121,24 +121,6 @@ test('get/set test mode', () => {
   expect(store.getTestMode()).toEqual(true);
 });
 
-test('get/set polls state', () => {
-  const store = Store.memoryStore();
-
-  // Before setting an election
-  expect(store.getPollsState()).toEqual('polls_closed_initial');
-  expect(() => store.setPollsState('polls_open')).toThrowError();
-
-  store.setElectionAndJurisdiction({
-    electionData,
-    jurisdiction,
-    electionPackageHash,
-  });
-
-  // After setting an election
-  store.setPollsState('polls_open');
-  expect(store.getPollsState()).toEqual('polls_open');
-});
-
 test('get/set scanner as backed up', () => {
   const store = Store.memoryStore();
   store.setElectionAndJurisdiction({
@@ -820,8 +802,6 @@ test('resetElectionSession', () => {
   });
   store.setPollingPlaceId(anyPollingPlace(election).id);
 
-  store.setPollsState('polls_open');
-
   store.addBatch();
   store.addBatch();
   expect(
@@ -836,7 +816,6 @@ test('resetElectionSession', () => {
   store.resetElectionSession();
 
   // resetElectionSession should reset election session state
-  expect(store.getPollsState()).toEqual('polls_closed_initial');
   expect(store.getScannerBackupTimestamp()).toBeFalsy();
 
   // resetElectionSession should clear all batches

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -121,29 +121,6 @@ test('get/set test mode', () => {
   expect(store.getTestMode()).toEqual(true);
 });
 
-test('get/set is sounds muted mode', () => {
-  const store = Store.memoryStore();
-
-  // Before setting an election
-  expect(store.getIsSoundMuted()).toEqual(false);
-  expect(() => store.setIsSoundMuted(true)).toThrowError();
-
-  store.setElectionAndJurisdiction({
-    electionData,
-    jurisdiction,
-    electionPackageHash,
-  });
-
-  // After setting an election
-  expect(store.getIsSoundMuted()).toEqual(false);
-
-  store.setIsSoundMuted(true);
-  expect(store.getIsSoundMuted()).toEqual(true);
-
-  store.setIsSoundMuted(false);
-  expect(store.getIsSoundMuted()).toEqual(false);
-});
-
 test('get/set polls state', () => {
   const store = Store.memoryStore();
 

--- a/apps/central-scan/backend/src/store.test.ts
+++ b/apps/central-scan/backend/src/store.test.ts
@@ -911,14 +911,13 @@ test('getBallotsCounted', () => {
   expect(store.getBallotsCounted()).toEqual(1);
 });
 
-test('systemSettings can set/get/delete', () => {
+test('systemSettings can set/get', () => {
   const store = Store.memoryStore();
+  expect(store.getSystemSettings()).toBeUndefined();
   const systemSettings = DEFAULT_SYSTEM_SETTINGS;
   store.setSystemSettings(systemSettings);
   const systemSettingsInStore = store.getSystemSettings();
   expect(systemSettingsInStore).toEqual(DEFAULT_SYSTEM_SETTINGS);
-  store.deleteSystemSettings();
-  expect(store.getSystemSettings()).toBeUndefined();
 });
 
 test('getCastVoteRecordRootHash, updateCastVoteRecordHashes, and clearCastVoteRecordHashes', () => {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -322,13 +322,6 @@ export class Store {
   }
 
   /**
-   * Deletes system settings
-   */
-  deleteSystemSettings(): void {
-    this.client.run('delete from system_settings');
-  }
-
-  /**
    * Stores the system settings.
    */
   setSystemSettings(systemSettings: SystemSettings): void {

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -11,9 +11,6 @@ import {
   PageInterpretation,
   PageInterpretationSchema,
   PageInterpretationWithFiles,
-  PollsState as PollsStateType,
-  PollsStateSchema,
-  safeParse,
   safeParseElectionDefinition,
   safeParseJson,
   SheetOf,
@@ -398,43 +395,6 @@ export class Store {
   }
 
   /**
-   * Gets the current polls state (open, paused, closed initial, or closed final)
-   */
-  getPollsState(): PollsStateType {
-    const electionRow = this.client.one(
-      'select polls_state as rawPollsState from election'
-    ) as { rawPollsState: string } | undefined;
-
-    if (!electionRow) {
-      // we will not skip the check by default once an election is defined
-      return 'polls_closed_initial';
-    }
-
-    const pollsStateParseResult = safeParse(
-      PollsStateSchema,
-      electionRow.rawPollsState
-    );
-
-    // @coverage-defer
-    if (pollsStateParseResult.isErr()) {
-      throw new Error('Unable to parse stored polls state.');
-    }
-
-    return pollsStateParseResult.ok();
-  }
-
-  /**
-   * Sets the current polls state
-   */
-  setPollsState(pollsState: PollsStateType): void {
-    if (!this.hasElection()) {
-      throw new Error('Cannot set polls state without an election.');
-    }
-
-    this.client.run('update election set polls_state = ?', pollsState);
-  }
-
-  /**
    * Adds a batch and returns its id.
    */
   addBatch(): string {
@@ -667,8 +627,6 @@ export class Store {
     // @coverage-defer
     if (this.hasElection()) {
       this.client.transaction(() => {
-        this.setPollsState('polls_closed_initial');
-
         // Delete batches, which will cascade delete sheets
         this.client.run('delete from batches');
         // Reset auto-incrementing key on "batches" table

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -383,36 +383,6 @@ export class Store {
     this.client.run('update election set is_test_mode = ?', testMode ? 1 : 0);
   }
 
-  /**
-   * Gets whether sound is muted.
-   */
-  getIsSoundMuted(): boolean {
-    const electionRow = this.client.one(
-      'select is_sound_muted as isSoundMuted from election'
-    ) as { isSoundMuted: number } | undefined;
-
-    if (!electionRow) {
-      // we will not mute sounds by default once an election is defined
-      return false;
-    }
-
-    return Boolean(electionRow.isSoundMuted);
-  }
-
-  /**
-   * Sets whether sound is muted.
-   */
-  setIsSoundMuted(isSoundMuted: boolean): void {
-    if (!this.hasElection()) {
-      throw new Error('Cannot set sounds to muted without an election.');
-    }
-
-    this.client.run(
-      'update election set is_sound_muted = ?',
-      isSoundMuted ? 1 : 0
-    );
-  }
-
   getBallotPaperSizeForElection(): HmpbBallotPaperSize {
     const electionRecord = this.getElectionRecord();
     return (

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -615,17 +615,6 @@ export class Store {
     return scannerBackedUpAt >= DateTime.max(...cvrsLastUpdatedDates);
   }
 
-  // @coverage-defer
-  addBallotCard(batchId: string): string {
-    const id = uuid();
-    this.client.run(
-      'insert into ballot_cards (id, batch_id) values (?, ?)',
-      id,
-      batchId
-    );
-    return id;
-  }
-
   /**
    * Adds a sheet to an existing batch.
    */

--- a/apps/central-scan/backend/src/store.ts
+++ b/apps/central-scan/backend/src/store.ts
@@ -474,10 +474,9 @@ export class Store {
         sheets.deleted_at is null
       where
         batches.deleted_at is null
-    `) as { ballotsCounted: number } | undefined;
+    `) as { ballotsCounted: number };
 
-    // @coverage-defer
-    return row?.ballotsCounted ?? 0;
+    return row.ballotsCounted;
   }
 
   /**


### PR DESCRIPTION
🤖 Generated with Claude Code

## Overview

<!-- Add a link to a GitHub issue here -->

Clean up a bunch of unused code from the VxCentralScan store discovered while working on the state machine refactor.

## Demo Video or Screenshot

N/A

## Testing Plan

Existing tests

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
