### PR TITLE
[VxAdmin] Screenshot suite: capture CVR location details panel

### DIFF
--- a/apps/admin/integration-testing/e2e/screenshots.spec.ts
+++ b/apps/admin/integration-testing/e2e/screenshots.spec.ts
@@ -596,6 +596,15 @@ test('results', async ({ page }, testInfo) => {
   await page.getByText('Cvrs17').waitFor();
   await screenshot('tally-screen-with-cvrs');
 
+  await page.getByRole('button', { name: /North Lincoln/ }).click();
+  await page.getByRole('button', { name: 'Close Panel' }).waitFor();
+  await screenshot('tally-screen-location-cvrs-panel');
+  await screenshotWithLocatorHighlight(
+    page.getByRole('button', { name: /^Remove CVR File From/ }),
+    'tally-screen-location-cvrs-panel-remove-highlighted'
+  );
+  await page.getByRole('button', { name: 'Close Panel' }).click();
+
   // Full election tally report
   await page.getByText('Reports').click();
   await page.getByText('Unofficial Tally Reports').waitFor();


### PR DESCRIPTION
## Overview

Adds two screenshots to the VxAdmin screenshot suite (`results` test in
`apps/admin/integration-testing/e2e/screenshots.spec.ts`) showing the CVR
import details for a single polling place on the Tally page's Cast Vote Records
tab:

- `tally-screen-location-cvrs-panel` — the North Lincoln location card selected
  and its details panel open, listing the loaded import (export time, source,
  scanner, CVR count).
- `tally-screen-location-cvrs-panel-remove-highlighted` — the same view with
  the per-import remove (trash) button highlighted.

The panel is closed again afterwards so the rest of the test is unchanged.
Because screenshot filenames carry a per-test sequence number, every later
screenshot in the `results` test shifts up by two.

## Demo Video or Screenshot

Captured by the `test-apps-admin-integration-testing` CI job for this branch
(job 1370521):

**`tally-screen-location-cvrs-panel`**

![North Lincoln details panel open](https://output.circle-artifacts.com/output/job/04aae942-ebd8-4117-b4c7-38263ddec187/artifacts/0/apps/admin/integration-testing/test-results/screenshots/results-004-tally-screen-location-cvrs-panel.png)

**`tally-screen-location-cvrs-panel-remove-highlighted`**

![Per-import remove button highlighted](https://output.circle-artifacts.com/output/job/04aae942-ebd8-4117-b4c7-38263ddec187/artifacts/0/apps/admin/integration-testing/test-results/screenshots/results-005-tally-screen-location-cvrs-panel-remove-highlighted.png)

## Testing Plan

Ran the `results` screenshot test locally against the built app and inspected
the two new PNGs: the panel is fully rendered (no fade-in artifact) and the
highlight ring frames the trash button.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [x] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [x] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
