### PR TITLE
fix(lint): correct some false positives in `vx/gts-jsdoc`

### DIFF
--- a/libs/eslint-plugin-vx/src/rules/gts_jsdoc.ts
+++ b/libs/eslint-plugin-vx/src/rules/gts_jsdoc.ts
@@ -87,6 +87,10 @@ const rule: TSESLint.RuleModule<
         // @coverage-defer
         if (variable) {
           for (const def of variable.defs) {
+            if (def.type === TSESLint.Scope.DefinitionType.ImportBinding) {
+              continue;
+            }
+
             checkHasJsDoc(def.node);
           }
         }
@@ -110,7 +114,7 @@ const rule: TSESLint.RuleModule<
           }
         } else if (node.declaration) {
           checkHasJsDoc(node.declaration);
-        } else {
+        } else if (!node.source) {
           for (const specifier of node.specifiers) {
             checkHasJsDoc(specifier.local);
           }

--- a/libs/eslint-plugin-vx/tests/rules/gts_jsdoc.test.ts
+++ b/libs/eslint-plugin-vx/tests/rules/gts_jsdoc.test.ts
@@ -62,6 +62,18 @@ ruleTester.run('gts-jsdoc', rule, {
       const two = 2;
       export { one as ONE, two as TWO };
     `,
+    `
+      import { UsbPortAction } from './usb_port_status.js';
+      export type { UsbPortAction } from './usb_port_status.js';
+    `,
+    `
+      import { UsbPortAction } from './usb_port_status.js';
+      export { UsbPortAction };
+    `,
+    `
+      const one = 1;
+      export { one } from './usb_port_status.js';
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
It was flagging an import specifier that was then later exported. If the module doesn't declare the binding it should not be responsible for documenting it.

<img width="738" height="263" alt="image" src="https://github.com/user-attachments/assets/66c64bc3-8658-4a8f-aa3c-1b1e75938c89" />
