### PR TITLE
ui: Add ScrollTable component

### DIFF
--- a/apps/design/frontend/src/ballot_audio/tts_text_editor.tsx
+++ b/apps/design/frontend/src/ballot_audio/tts_text_editor.tsx
@@ -3,10 +3,16 @@ import styled from 'styled-components';
 
 import { assertDefined } from '@votingworks/basics';
 import { TtsEdit } from '@votingworks/types';
-import { Icons, Button, DesktopPalette, Caption, Font } from '@votingworks/ui';
+import {
+  Icons,
+  Button,
+  cssThemedScrollbars,
+  DesktopPalette,
+  Caption,
+  Font,
+} from '@votingworks/ui';
 
 import * as api from '../api.js';
-import { cssThemedScrollbars } from '../scrollbars.js';
 
 const Container = styled.div`
   display: grid;

--- a/apps/design/frontend/src/ballot_audio/ui_string_preview.tsx
+++ b/apps/design/frontend/src/ballot_audio/ui_string_preview.tsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 
 import { ElectionStringKey } from '@votingworks/types';
-import { DesktopPalette, richTextStyles } from '@votingworks/ui';
-
-import { cssThemedScrollbars } from '../scrollbars.js';
+import {
+  cssThemedScrollbars,
+  DesktopPalette,
+  richTextStyles,
+} from '@votingworks/ui';
 
 const Container = styled.div`
   display: flex;

--- a/apps/design/frontend/src/entity_list.tsx
+++ b/apps/design/frontend/src/entity_list.tsx
@@ -6,9 +6,8 @@ import {
   DesktopPalette,
   Font,
   H2,
+  cssThemedScrollbars,
 } from '@votingworks/ui';
-
-import { cssThemedScrollbars } from './scrollbars.js';
 
 const Box = styled.ul.attrs({ role: 'listbox' })`
   --entity-list-border: ${(p) => p.theme.sizes.bordersRem.hairline}rem solid

--- a/apps/design/frontend/src/form_fixed.tsx
+++ b/apps/design/frontend/src/form_fixed.tsx
@@ -1,6 +1,5 @@
-import { DesktopPalette, H2 } from '@votingworks/ui';
+import { cssThemedScrollbars, DesktopPalette, H2 } from '@votingworks/ui';
 import styled, { css } from 'styled-components';
-import { cssThemedScrollbars } from './scrollbars.js';
 import { StyledRichTextEditor } from './rich_text_editor.js';
 
 export const FormBody = styled.div`

--- a/libs/ui/.storybook/preview.tsx
+++ b/libs/ui/.storybook/preview.tsx
@@ -168,6 +168,7 @@ export const decorators: DecoratorFunction[] = [
           defaultColorMode={globals.colorMode}
           defaultSizeMode={globals.sizeMode}
           screenType={globals.screenType}
+          showScrollBars={context.parameters['showScrollBars'] === true}
         >
           <StoryWrapper context={context}>
             <Story />

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -85,6 +85,7 @@ export * from './set_clock.js';
 export * from './smart_cards_screen.js';
 export * from './tabbed_section/index.js';
 export * from './table.js';
+export * from './scroll_table.js';
 export * from './scrollbars.js';
 export * from './test_mode.js';
 export * from './themes/make_theme.js';

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -85,6 +85,7 @@ export * from './set_clock.js';
 export * from './smart_cards_screen.js';
 export * from './tabbed_section/index.js';
 export * from './table.js';
+export * from './scrollbars.js';
 export * from './test_mode.js';
 export * from './themes/make_theme.js';
 export * from './themes/render_with_themes.js';

--- a/libs/ui/src/scroll_table.stories.tsx
+++ b/libs/ui/src/scroll_table.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta } from '@storybook/react-vite' with {
+  'resolution-mode': 'import',
+};
+
+import { range } from '@votingworks/basics';
+import { ScrollTable as Component } from './scroll_table.js';
+
+const ROW_COUNT = 20;
+
+const meta: Meta<typeof Component> = {
+  title: 'libs-ui/ScrollTable',
+  component: Component,
+  parameters: { showScrollBars: true },
+};
+
+export default meta;
+
+export function ScrollTable(): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '24rem' }}>
+      <Component style={{ flex: 1 }}>
+        <Component.Header>
+          <Component.Column width="max-content">Sync</Component.Column>
+          <Component.Column width="1fr">Batch</Component.Column>
+          <Component.Column width="1fr">Sheets</Component.Column>
+          <Component.Column width="20rem">Scanned At</Component.Column>
+        </Component.Header>
+        <Component.Body>
+          {range(1, ROW_COUNT + 1).map((n) => (
+            <Component.Row key={n}>
+              <Component.Cell>
+                {n % 3 === 0 ? 'Not sent' : 'Sent'}
+              </Component.Cell>
+              <Component.Cell>Batch {n}</Component.Cell>
+              <Component.Cell>{((n * 7) % 40) + 1}</Component.Cell>
+              <Component.Cell>
+                9/10/2026, 10:{String(n).padStart(2, '0')} AM
+              </Component.Cell>
+            </Component.Row>
+          ))}
+        </Component.Body>
+      </Component>
+    </div>
+  );
+}

--- a/libs/ui/src/scroll_table.test.tsx
+++ b/libs/ui/src/scroll_table.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import { expect, test } from 'vitest';
+import { range } from '@votingworks/basics';
+import { suppressingConsoleOutput } from '@votingworks/test-utils';
+import { render, screen, within } from '../test/react_testing_library.js';
+import { ScrollTable } from './scroll_table.js';
+import { styled } from './styled.js';
+
+test('renders header and rows with table semantics and derives column sizes', () => {
+  render(
+    <ScrollTable className="grow" style={{ marginTop: '1rem' }}>
+      <ScrollTable.Header>
+        <ScrollTable.Column width="max-content">Name</ScrollTable.Column>
+        <ScrollTable.Column>Count</ScrollTable.Column>
+        <ScrollTable.Column width="1fr" />
+      </ScrollTable.Header>
+      <ScrollTable.Body>
+        <ScrollTable.Row>
+          <ScrollTable.Cell>Batch 1</ScrollTable.Cell>
+          <ScrollTable.Cell>3</ScrollTable.Cell>
+          <ScrollTable.Cell />
+        </ScrollTable.Row>
+        <ScrollTable.Row>
+          <ScrollTable.Cell>Batch 2</ScrollTable.Cell>
+          <ScrollTable.Cell>5</ScrollTable.Cell>
+          <ScrollTable.Cell />
+        </ScrollTable.Row>
+      </ScrollTable.Body>
+    </ScrollTable>
+  );
+
+  const table = screen.getByRole('table');
+  expect(table).toHaveClass('grow');
+  expect(table).toHaveStyle({ marginTop: '1rem' });
+  expect(table).toHaveStyleRule(
+    'grid-template-columns',
+    'max-content auto 1fr 0.45rem'
+  );
+  screen.getByRole('columnheader', { name: 'Name' });
+  screen.getByRole('columnheader', { name: 'Count' });
+  expect(screen.getAllByRole('row')).toHaveLength(3);
+  screen.getByRole('cell', { name: 'Batch 2' });
+  screen.getByRole('cell', { name: '5' });
+});
+
+const NumericCell = styled(ScrollTable.Cell)`
+  justify-content: end;
+`;
+
+const NumericColumn = styled(ScrollTable.Column)`
+  text-align: end;
+`;
+
+function LabelCell({ children }: { children: React.ReactNode }): JSX.Element {
+  return <ScrollTable.Cell>{children}</ScrollTable.Cell>;
+}
+
+test('accepts rows from arrays, conditional children, fragments, styled parts, and wrappers', () => {
+  render(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>Name</ScrollTable.Column>
+        {false}
+        <NumericColumn width="6rem">Count</NumericColumn>
+      </ScrollTable.Header>
+      <ScrollTable.Body>
+        {range(1, 3).map((n) => (
+          <ScrollTable.Row key={n}>
+            <LabelCell>Batch {n}</LabelCell>
+            {null}
+            <NumericCell>{n * 10}</NumericCell>
+          </ScrollTable.Row>
+        ))}
+        <React.Fragment>
+          {range(3, 6).map((n) => (
+            <ScrollTable.Row key={n}>
+              <LabelCell>Batch {n}</LabelCell>
+              <NumericCell>{n * 10}</NumericCell>
+            </ScrollTable.Row>
+          ))}
+        </React.Fragment>
+      </ScrollTable.Body>
+    </ScrollTable>
+  );
+
+  expect(screen.getByRole('table')).toHaveStyleRule(
+    'grid-template-columns',
+    'auto 6rem 0.45rem'
+  );
+  const body = screen.getByRole('rowgroup');
+  expect(within(body).getAllByRole('row')).toHaveLength(5);
+  expect(within(body).getAllByRole('cell')).toHaveLength(10);
+  within(body).getByRole('cell', { name: '50' });
+});
+
+test('renders a header without a body', () => {
+  render(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>Name</ScrollTable.Column>
+      </ScrollTable.Header>
+    </ScrollTable>
+  );
+
+  screen.getByRole('columnheader', { name: 'Name' });
+  expect(screen.queryByRole('rowgroup')).not.toBeInTheDocument();
+});
+
+function expectRenderToThrow(element: JSX.Element, message: string): void {
+  function ignoreReportedError(event: ErrorEvent) {
+    event.preventDefault();
+  }
+  window.addEventListener('error', ignoreReportedError);
+  try {
+    suppressingConsoleOutput(() => {
+      expect(() => render(element)).toThrow(message);
+    });
+  } finally {
+    window.removeEventListener('error', ignoreReportedError);
+  }
+}
+
+const SHAPE_MESSAGE =
+  'ScrollTable children must be a ScrollTable.Header followed by an optional ScrollTable.Body';
+
+test('requires a header followed by an optional body', () => {
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Body>
+        <ScrollTable.Row>
+          <ScrollTable.Cell>Only row</ScrollTable.Cell>
+        </ScrollTable.Row>
+      </ScrollTable.Body>
+    </ScrollTable>,
+    SHAPE_MESSAGE
+  );
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>A</ScrollTable.Column>
+      </ScrollTable.Header>
+      <ScrollTable.Header>
+        <ScrollTable.Column>B</ScrollTable.Column>
+      </ScrollTable.Header>
+    </ScrollTable>,
+    SHAPE_MESSAGE
+  );
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Body />
+      <ScrollTable.Header>
+        <ScrollTable.Column>A</ScrollTable.Column>
+      </ScrollTable.Header>
+    </ScrollTable>,
+    SHAPE_MESSAGE
+  );
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>A</ScrollTable.Column>
+      </ScrollTable.Header>
+      <ScrollTable.Body />
+      <ScrollTable.Body />
+    </ScrollTable>,
+    SHAPE_MESSAGE
+  );
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>A</ScrollTable.Column>
+      </ScrollTable.Header>
+      <div>stray</div>
+    </ScrollTable>,
+    SHAPE_MESSAGE
+  );
+});
+
+test('requires columns, rows, and cells to be elements', () => {
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Header>not a column</ScrollTable.Header>
+    </ScrollTable>,
+    'ScrollTable.Header children must be column elements'
+  );
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>A</ScrollTable.Column>
+      </ScrollTable.Header>
+      <ScrollTable.Body>not a row</ScrollTable.Body>
+    </ScrollTable>,
+    'ScrollTable.Body children must be row elements'
+  );
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>A</ScrollTable.Column>
+      </ScrollTable.Header>
+      <ScrollTable.Body>
+        <ScrollTable.Row>not a cell</ScrollTable.Row>
+      </ScrollTable.Body>
+    </ScrollTable>,
+    'ScrollTable.Row children must be cell elements'
+  );
+});
+
+test('requires every row to have one cell per column', () => {
+  expectRenderToThrow(
+    <ScrollTable>
+      <ScrollTable.Header>
+        <ScrollTable.Column>A</ScrollTable.Column>
+        <ScrollTable.Column>B</ScrollTable.Column>
+      </ScrollTable.Header>
+      <ScrollTable.Body>
+        <ScrollTable.Row>
+          <ScrollTable.Cell>only one</ScrollTable.Cell>
+        </ScrollTable.Row>
+      </ScrollTable.Body>
+    </ScrollTable>,
+    'ScrollTable.Row has 1 cells but the header has 2 columns'
+  );
+});

--- a/libs/ui/src/scroll_table.tsx
+++ b/libs/ui/src/scroll_table.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { assert } from '@votingworks/basics';
+import { cssThemedScrollbars, SCROLLBAR_THICKNESS_REM } from './scrollbars.js';
+import { styled } from './styled.js';
+
+const Grid = styled.div.attrs({ role: 'table' })<{ columnTemplate: string }>`
+  display: grid;
+
+  /* Add an extra column for the scrollbar gutter */
+  grid-template-columns: ${(p) => p.columnTemplate} ${SCROLLBAR_THICKNESS_REM}rem;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: min-content;
+  border: ${(p) =>
+    `${p.theme.sizes.bordersRem.thin}rem solid ${p.theme.colors.outline}`};
+  border-radius: ${(p) => p.theme.sizes.borderRadiusRem}rem;
+  overflow: hidden;
+`;
+
+const Header = styled.div.attrs({ role: 'row' })`
+  display: grid;
+
+  /* Inherit the column template from Grid */
+  grid-template-columns: subgrid;
+
+  /* Span all columns */
+  grid-column: 1 / -1;
+  background-color: ${(p) => p.theme.colors.container};
+  border-bottom: ${(p) =>
+    `${p.theme.sizes.bordersRem.thin}rem solid ${p.theme.colors.outline}`};
+`;
+
+interface ColumnProps {
+  /**
+   * The grid width for the column (e.g. "1fr", "max-content").
+   * Defaults to "auto".
+   */
+  width?: string;
+}
+
+const Column = styled.div
+  .withConfig<ColumnProps>({
+    shouldForwardProp: (prop, defaultValidatorFn) =>
+      prop !== 'width' && defaultValidatorFn(prop),
+  })
+  .attrs({ role: 'columnheader' })`
+  padding: 0.5rem 1rem;
+  font-weight: ${(p) => p.theme.sizes.fontWeight.semiBold};
+`;
+
+const Body = styled.div.attrs({ role: 'rowgroup' })`
+  display: grid;
+
+  /* Inherit the column template from Grid */
+  grid-template-columns: subgrid;
+
+  /* Span all columns */
+  grid-column: 1 / -1;
+
+  /* Fill the remaining vertical space */
+  grid-auto-rows: max-content;
+  align-content: start;
+  overflow: hidden auto;
+
+  ${cssThemedScrollbars}
+`;
+
+const Row = styled.div.attrs({ role: 'row' })`
+  display: grid;
+
+  /* Inherit the column template from Body */
+  grid-template-columns: subgrid;
+
+  /* Span all columns */
+  grid-column: 1 / -1;
+
+  &:nth-child(even) {
+    background-color: ${(p) => p.theme.colors.containerLow};
+  }
+
+  &:last-child {
+    border-bottom: ${(p) =>
+      `${p.theme.sizes.bordersRem.hairline}rem solid ${p.theme.colors.outline}`};
+  }
+`;
+
+const Cell = styled.div.attrs({ role: 'cell' })`
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+`;
+
+type ElementWithChildren = React.ReactElement<{ children?: React.ReactNode }>;
+
+function flattenChildren(children: React.ReactNode): React.ReactNode[] {
+  return React.Children.toArray(children).flatMap((child) =>
+    React.isValidElement<{ children?: React.ReactNode }>(child) &&
+    child.type === React.Fragment
+      ? flattenChildren(child.props.children)
+      : [child]
+  );
+}
+
+function elementChildren(
+  children: React.ReactNode,
+  message: string
+): ElementWithChildren[] {
+  return flattenChildren(children).map((child) => {
+    assert(
+      React.isValidElement<{ children?: React.ReactNode }>(child),
+      message
+    );
+    return child;
+  });
+}
+
+function columnTemplateFromHeader(children: React.ReactNode): string {
+  const [header, body, ...rest] = flattenChildren(children);
+  assert(
+    React.isValidElement<{ children?: React.ReactNode }>(header) &&
+      header.type === Header &&
+      (body === undefined ||
+        (React.isValidElement<{ children?: React.ReactNode }>(body) &&
+          body.type === Body)) &&
+      rest.length === 0,
+    'ScrollTable children must be a ScrollTable.Header followed by an optional ScrollTable.Body'
+  );
+  const columns = elementChildren(
+    header.props.children,
+    'ScrollTable.Header children must be column elements'
+  ) as Array<React.ReactElement<ColumnProps>>;
+
+  if (body !== undefined) {
+    const rows = elementChildren(
+      body.props.children,
+      'ScrollTable.Body children must be row elements'
+    );
+    for (const row of rows) {
+      const cells = elementChildren(
+        row.props.children,
+        'ScrollTable.Row children must be cell elements'
+      );
+      assert(
+        cells.length === columns.length,
+        `ScrollTable.Row has ${cells.length} cells but the header has ${columns.length} columns`
+      );
+    }
+  }
+
+  return columns.map((column) => column.props.width ?? 'auto').join(' ');
+}
+
+export interface ScrollTableProps {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * A table component with a sticky header and scrollable body. Implemented using
+ * a grid layout under the hood rather than a table element. You can specify
+ * column widths using the `width` prop on `ScrollTable.Column` elements -
+ * it takes grid layout CSS size specifiers.
+ *
+ * Usage example:
+ *
+ * ```tsx
+ * <ScrollTable>
+ *   <ScrollTable.Header>
+ *     <ScrollTable.Column width="1fr">
+ *       Header 1
+ *     </ScrollTable.Column>
+ *     <ScrollTable.Column width="min-content">
+ *       Header 2
+ *     </ScrollTable.Column>
+ *   </ScrollTable.Header>
+ *   <ScrollTable.Body>
+ *     <ScrollTable.Row>
+ *       <ScrollTable.Cell>Data 1</ScrollTable.Cell>
+ *       <ScrollTable.Cell>Data 2</ScrollTable.Cell>
+ *     </ScrollTable.Row>
+ *   </ScrollTable.Body>
+ * </ScrollTable>
+ * ```
+ *
+ */
+export function ScrollTable({
+  children,
+  className,
+  style,
+}: ScrollTableProps): JSX.Element {
+  return (
+    <Grid
+      className={className}
+      style={style}
+      columnTemplate={columnTemplateFromHeader(children)}
+    >
+      {children}
+    </Grid>
+  );
+}
+
+ScrollTable.Header = Header;
+ScrollTable.Column = Column;
+ScrollTable.Body = Body;
+ScrollTable.Row = Row;
+ScrollTable.Cell = Cell;

--- a/libs/ui/src/scrollbars.ts
+++ b/libs/ui/src/scrollbars.ts
@@ -1,20 +1,20 @@
-import { DesktopPalette } from '@votingworks/ui';
 import { css } from 'styled-components';
+import { DesktopPalette } from './themes/make_theme.js';
 
 const colorBg = 'transparent';
 const colorThumb = DesktopPalette.Gray10;
 const colorThumbHover = DesktopPalette.Gray40;
-const thicknessRem = 0.45;
+export const SCROLLBAR_THICKNESS_REM = 0.45;
 
 export const cssThemedScrollbars = css`
   scrollbar-track-color: ${colorBg};
   scrollbar-color: ${colorThumb};
-  scrollbar-width: ${thicknessRem}rem;
+  scrollbar-width: ${SCROLLBAR_THICKNESS_REM}rem;
   scroll-behavior: smooth;
 
   ::-webkit-scrollbar {
-    height: ${thicknessRem}rem;
-    width: ${thicknessRem}rem;
+    height: ${SCROLLBAR_THICKNESS_REM}rem;
+    width: ${SCROLLBAR_THICKNESS_REM}rem;
   }
 
   ::-webkit-scrollbar-track {


### PR DESCRIPTION
🤖 Co-authored with Claude Code

## Overview

Adds a new ScrollTable component to libs/ui. I'm hoping this can eventually be swapped in to replace the Table component. This table has a sticky header and a scrollable body. It also has light row striping and is styled more like a card (with rounded corners and a border).

Under the hood, it uses a grid layout rather than table elements, as this allows us to put the scrollbar inside the body (rather than having it overlap the header as well). We still get dynamic column widths (using modern grid layout logic rather than table logic). I also included the ability to specify column widths using grid template syntax, which is quite expressive.

<!-- Add a link to a GitHub issue here -->

## Demo Video or Screenshot


https://github.com/user-attachments/assets/c5399b72-47e8-4200-b86a-48546509e708



## Testing Plan

Added automated tests and a Storybook story

## Checklist

- [ ] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate for any new user actions.
- [ ] I have added the "user-facing-change" label to this PR, if relevant, to automate an announcement in #machine-product-updates.
