### PR TITLE
VxDesign: Fix TTS audio base64 encoding to use explicit length

### DIFF
--- a/libs/backend/src/language_and_audio/speech_synthesizer.ts
+++ b/libs/backend/src/language_and_audio/speech_synthesizer.ts
@@ -106,6 +106,10 @@ export class GoogleCloudSpeechSynthesizer implements SpeechSynthesizer {
 
     assert(response.audioContent instanceof Uint8Array);
 
-    return Buffer.from(response.audioContent.buffer).toString('base64');
+    return Buffer.from(
+      response.audioContent.buffer,
+      response.audioContent.byteOffset,
+      response.audioContent.byteLength
+    ).toString('base64');
   }
 }

--- a/libs/backend/src/language_and_audio/test_utils.ts
+++ b/libs/backend/src/language_and_audio/test_utils.ts
@@ -51,11 +51,19 @@ const mockGoogleCloudTextToSpeechClient: MinimalGoogleCloudTextToSpeechClient =
     synthesizeSpeech(input: {
       input: { text: string };
     }): Promise<[{ audioContent: string | Uint8Array }, undefined, undefined]> {
+      const encodedContent = new TextEncoder().encode(
+        mockCloudSynthesizedSpeech(input.input.text)
+      );
+
+      // Pad the backing buffer to make sure downstream consumers are only using
+      // the specified Uint8Array range.
+      const buffer = new ArrayBuffer(encodedContent.byteLength + 20);
+      const view = new Uint8Array(buffer, 10, encodedContent.byteLength);
+      view.set(encodedContent);
+
       return Promise.resolve([
         {
-          audioContent: new TextEncoder().encode(
-            mockCloudSynthesizedSpeech(input.input.text)
-          ),
+          audioContent: view,
         },
         undefined,
         undefined,


### PR DESCRIPTION
## Overview

Ran into an edge case in local testing where TTS audio doesn't play back and tracked it down to this bug - made an [edit](https://github.com/votingworks/vxsuite/pull/7361) here a while ago and somehow missed the range params in the data conversion.

## Demo Video or Screenshot
N/A

## Testing Plan
- Added a failing repro by padding the test speech synthesizer output - fixed by the patch.

## Checklist

- [x] I have prefixed my PR title with "VxDesign: ", "VxPollBook: ", or "HWTA: " if my change is specific to one of those products.
